### PR TITLE
feat(#168): parse History through the Finding pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ The Case Directory contains:
 - `manifest_header.json`: the Selection Policy, counts, and both digests
 - `working-copy/`: the selected content for later analysis
 
-The compiled CLI also runs the integrity check that occurs before analysis.
-Artifact parsing starts in issue #168.
+The compiled CLI checks the Working Copy before each analysis.
+It parses History from all Profiles and writes Findings to the Case.
+
+Committed and recovery content use separate passes.
+Recovered rows keep the `wal_resident` or `journal_resident` Commit State.
 
 ## Requirements
 
@@ -53,16 +56,49 @@ node cli/dist/cli.js ingest "/path/to/User Data" \
 Tier 2 content is off by default.
 Add `--include-tier-2` to copy the Tier 2 paths from Selection Policy `chrome-userdata/1`.
 
-## Check the Working Copy
+## Analyze History
 
-Run the analysis preflight after ingest:
+Run the analysis after ingest:
 
 ```sh
-node cli/dist/cli.js analyse --case "/path/to/CASE-001" --json
+node cli/dist/cli.js analyse \
+  --case "/path/to/CASE-001" \
+  --timezone "America/New_York" \
+  --origin-os macos \
+  --json
 ```
 
+The Declared Timezone defaults to `UTC`.
+Use `--origin-os` only for History version 16 or earlier.
+The accepted values are `windows`, `macos`, and `linux`.
+
 The command refuses a missing, moved, changed, or extended Working Copy.
-The refusal is a JSON diagnostic with code `WORKING_COPY_INTEGRITY_REFUSAL`.
+The refusal has the JSON code `WORKING_COPY_INTEGRITY_REFUSAL`.
+
+## Query History Findings
+
+Each query returns 50 rows by default.
+Set `--limit` from 1 through 100.
+Use `nextCursor` as the next `--after` value.
+
+```sh
+node cli/dist/cli.js history \
+  --case "/path/to/CASE-001" \
+  --view visits \
+  --profile Default \
+  --search "example.com" \
+  --commit-state committed \
+  --sort visit-time \
+  --direction desc \
+  --limit 50 \
+  --json
+```
+
+The views are `visits`, `activity`, `most-visited`, and `durations`.
+You can repeat `--profile` to query at most 100 Profiles.
+Use `--commit-state` to keep committed and recovered rows separate.
+The `--from`, `--to`, and `--transition` filters apply only to `visits`.
+Timestamp bounds must include `Z` or a numeric offset.
 
 ## Verify the implementation
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -4,28 +4,61 @@ import {
   ForensixError,
   MINIMUM_NODE_VERSION,
   TOOL_VERSION,
+  analyseCase,
   ingestUserDataDir,
-  preflightAnalysis,
+  queryHistory,
+  type CommitState,
+  type DeclaredOriginOs,
+  type HistoryDirection,
+  type HistorySort,
+  type HistoryView,
   type IngestProgress,
   type IngestResult,
 } from "@forensix/core";
 
 const USAGE = `Usage:
   forensix ingest <user-data-dir> --case <case-directory> [--include-tier-2] [--json]
-  forensix analyse --case <case-directory> [--json]
+  forensix analyse --case <case-directory> [--timezone <iana-zone>] [--origin-os <windows|macos|linux>] [--json]
+  forensix history --case <case-directory> [--view <visits|activity|most-visited|durations>]
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--transition <name>] [--from <instant>] [--to <instant>]
+                   [--sort <field>] [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
   forensix --version
 `;
+
+type OptionValue = string | true;
 
 interface ParsedArguments {
   readonly command: string | undefined;
   readonly positionals: readonly string[];
-  readonly options: ReadonlyMap<string, string | true>;
+  readonly options: ReadonlyMap<string, readonly OptionValue[]>;
 }
+
+const FLAG_OPTIONS = new Set(["--json", "--include-tier-2"]);
+const VALUE_OPTIONS = new Set([
+  "--case",
+  "--timezone",
+  "--origin-os",
+  "--view",
+  "--profile",
+  "--search",
+  "--commit-state",
+  "--transition",
+  "--from",
+  "--to",
+  "--sort",
+  "--direction",
+  "--limit",
+  "--after",
+]);
+const REPEATABLE_OPTIONS = new Set(["--profile"]);
 
 function parseArguments(arguments_: readonly string[]): ParsedArguments {
   const [command, ...remaining] = arguments_;
   const positionals: string[] = [];
-  const options = new Map<string, string | true>();
+  const options = new Map<string, OptionValue[]>();
 
   for (let index = 0; index < remaining.length; index += 1) {
     const argument = remaining[index];
@@ -36,32 +69,52 @@ function parseArguments(arguments_: readonly string[]): ParsedArguments {
       positionals.push(argument);
       continue;
     }
-    if (options.has(argument)) {
+    if (!FLAG_OPTIONS.has(argument) && !VALUE_OPTIONS.has(argument)) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        `Unknown option: ${argument}`,
+      );
+    }
+    const existing = options.get(argument);
+    if (existing !== undefined && !REPEATABLE_OPTIONS.has(argument)) {
       throw new ForensixError(
         "INVALID_ARGUMENT",
         `Option is repeated: ${argument}`,
       );
     }
-    if (argument === "--json" || argument === "--include-tier-2") {
-      options.set(argument, true);
+    if (FLAG_OPTIONS.has(argument)) {
+      options.set(argument, [true]);
       continue;
     }
-    if (argument === "--case") {
-      const value = remaining[index + 1];
-      if (value === undefined || value.startsWith("--")) {
-        throw new ForensixError(
-          "INVALID_ARGUMENT",
-          "Option --case needs a path.",
-        );
-      }
-      options.set(argument, value);
-      index += 1;
-      continue;
+    const value = remaining[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        `Option ${argument} needs a value.`,
+      );
     }
-    throw new ForensixError("INVALID_ARGUMENT", `Unknown option: ${argument}`);
+    options.set(argument, [...(existing ?? []), value]);
+    index += 1;
   }
 
   return { command, positionals, options };
+}
+
+function hasOption(arguments_: ParsedArguments, option: string): boolean {
+  return arguments_.options.has(option);
+}
+
+function optionValues(arguments_: ParsedArguments, option: string): string[] {
+  return (arguments_.options.get(option) ?? []).filter(
+    (value): value is string => typeof value === "string",
+  );
+}
+
+function optionValue(
+  arguments_: ParsedArguments,
+  option: string,
+): string | undefined {
+  return optionValues(arguments_, option)[0];
 }
 
 function nodeVersionIsSupported(version: string): boolean {
@@ -78,11 +131,64 @@ function nodeVersionIsSupported(version: string): boolean {
 }
 
 function requiredCasePath(arguments_: ParsedArguments): string {
-  const casePath = arguments_.options.get("--case");
-  if (typeof casePath !== "string") {
+  const casePath = optionValue(arguments_, "--case");
+  if (casePath === undefined) {
     throw new ForensixError("INVALID_ARGUMENT", "Option --case is required.");
   }
   return casePath;
+}
+
+function assertAllowedOptions(
+  arguments_: ParsedArguments,
+  allowed: ReadonlySet<string>,
+): void {
+  const invalid = [...arguments_.options.keys()].filter(
+    (option) => !allowed.has(option),
+  );
+  if (invalid.length > 0) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `The ${arguments_.command ?? "unknown"} command has invalid options.`,
+      { invalid_options: invalid },
+    );
+  }
+}
+
+function enumOption<const Values extends readonly string[]>(
+  arguments_: ParsedArguments,
+  option: string,
+  values: Values,
+): Values[number] | undefined {
+  const value = optionValue(arguments_, option);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!values.includes(value)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Option ${option} has an unsupported value: ${value}`,
+      { option, value, allowed: values },
+    );
+  }
+  return value as Values[number];
+}
+
+function integerOption(
+  arguments_: ParsedArguments,
+  option: string,
+): number | undefined {
+  const value = optionValue(arguments_, option);
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(value)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Option ${option} must be an integer.`,
+      { option, value },
+    );
+  }
+  return Number(value);
 }
 
 async function consumeIngest(
@@ -118,27 +224,18 @@ async function run(arguments_: readonly string[]): Promise<number> {
   }
 
   const parsed = parseArguments(arguments_);
-  const jsonOutput = parsed.options.has("--json");
+  const jsonOutput = hasOption(parsed, "--json");
   if (parsed.command === "ingest") {
+    assertAllowedOptions(
+      parsed,
+      new Set(["--case", "--json", "--include-tier-2"]),
+    );
     if (parsed.positionals.length !== 1) {
       throw new ForensixError(
         "INVALID_ARGUMENT",
         "The ingest command needs one User Data Dir path.",
       );
     }
-    const unknownIngestOptions = [...parsed.options.keys()].filter(
-      (option) =>
-        option !== "--case" &&
-        option !== "--json" &&
-        option !== "--include-tier-2",
-    );
-    if (unknownIngestOptions.length > 0) {
-      throw new ForensixError(
-        "INVALID_ARGUMENT",
-        "The ingest command has an invalid option.",
-      );
-    }
-
     const sourcePath = parsed.positionals[0];
     if (sourcePath === undefined) {
       throw new ForensixError(
@@ -150,7 +247,7 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ingestUserDataDir({
         sourcePath,
         caseDirectory: requiredCasePath(parsed),
-        includeTier2: parsed.options.has("--include-tier-2"),
+        includeTier2: hasOption(parsed, "--include-tier-2"),
       }),
       !jsonOutput,
     );
@@ -159,16 +256,87 @@ async function run(arguments_: readonly string[]): Promise<number> {
   }
 
   if (parsed.command === "analyse") {
-    if (
-      parsed.positionals.length !== 0 ||
-      parsed.options.has("--include-tier-2")
-    ) {
+    assertAllowedOptions(
+      parsed,
+      new Set(["--case", "--json", "--timezone", "--origin-os"]),
+    );
+    if (parsed.positionals.length !== 0) {
       throw new ForensixError(
         "INVALID_ARGUMENT",
-        "The analyse command accepts only --case and --json.",
+        "The analyse command accepts no positional values.",
       );
     }
-    const result = await preflightAnalysis(requiredCasePath(parsed));
+    const result = await analyseCase({
+      caseDirectory: requiredCasePath(parsed),
+      declaredTimezone: optionValue(parsed, "--timezone"),
+      declaredOriginOs: enumOption(parsed, "--origin-os", [
+        "windows",
+        "macos",
+        "linux",
+      ] as const) as DeclaredOriginOs | undefined,
+      invocation: arguments_,
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "history") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--view",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--transition",
+        "--from",
+        "--to",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The history command accepts no positional values.",
+      );
+    }
+    const result = queryHistory({
+      caseDirectory: requiredCasePath(parsed),
+      view: enumOption(parsed, "--view", [
+        "visits",
+        "activity",
+        "most-visited",
+        "durations",
+      ] as const) as HistoryView | undefined,
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      transition: optionValue(parsed, "--transition"),
+      from: optionValue(parsed, "--from"),
+      to: optionValue(parsed, "--to"),
+      sort: enumOption(parsed, "--sort", [
+        "visit-time",
+        "local-time",
+        "url",
+        "duration",
+        "visit-count",
+        "profile",
+      ] as const) as HistorySort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | HistoryDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return 0;
   }
@@ -186,12 +354,10 @@ try {
     error instanceof ForensixError
       ? error.toDiagnostic()
       : new ForensixError(
-          "INGEST_FAILED",
+          process.argv[2] === "ingest" ? "INGEST_FAILED" : "ANALYSIS_FAILED",
           "ForensiX stopped before completion.",
           {},
-          {
-            cause: error,
-          },
+          { cause: error },
         ).toDiagnostic();
   process.stderr.write(`${JSON.stringify(diagnostic)}\n`);
   process.exitCode = 1;

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -1,0 +1,328 @@
+import { randomUUID } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { CASE_FILENAME, TOOL_VERSION } from "./case.js";
+import type { Candidate, Finding } from "./forensic-model.js";
+
+export type DeclaredOriginOs = "windows" | "macos" | "linux";
+
+export interface PersistedFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortTime: string | null;
+  readonly sortUrl: string | null;
+  readonly sortDuration: bigint | null;
+  readonly sortCount: bigint | null;
+  readonly transitionCore: string | null;
+}
+
+export interface PersistedCandidate {
+  readonly candidate: Candidate;
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly searchText: string;
+}
+
+export interface HistoryArtifactWrite {
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedFinding[];
+  readonly candidates?: readonly PersistedCandidate[];
+  readonly committedVisitCount: number;
+  readonly recoveredVisitCount: number;
+}
+
+export interface StoreHistoryAnalysisOptions {
+  readonly caseDirectory: string;
+  readonly sourceId: string;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+  readonly invocation: readonly string[];
+  readonly startedAt: string;
+  readonly artifacts: readonly HistoryArtifactWrite[];
+}
+
+export interface StoredHistoryAnalysis {
+  readonly runId: string;
+  readonly finishedAt: string;
+  readonly runStatus: "complete" | "partial";
+}
+
+export function initializeFindingSchema(database: DatabaseSync): void {
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+
+    CREATE TABLE IF NOT EXISTS analysis_runs (
+      run_id TEXT PRIMARY KEY,
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      artifact TEXT NOT NULL CHECK (artifact = 'History'),
+      started_at TEXT NOT NULL,
+      finished_at TEXT,
+      tool_version TEXT NOT NULL,
+      invocation_json TEXT NOT NULL,
+      declared_timezone TEXT NOT NULL,
+      declared_origin_os TEXT CHECK (
+        declared_origin_os IS NULL OR
+        declared_origin_os IN ('windows', 'macos', 'linux')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('running', 'complete', 'partial'))
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS history_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'History'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS history_one_active_result
+      ON history_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS forensic_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES history_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_time TEXT,
+      sort_url TEXT,
+      sort_duration INTEGER,
+      sort_count INTEGER,
+      transition_core TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS forensic_findings_active_query
+      ON forensic_findings(finding_kind, profile_path, commit_state, finding_id);
+    CREATE INDEX IF NOT EXISTS forensic_findings_profile_query
+      ON forensic_findings(finding_kind, profile_path, finding_id);
+    CREATE INDEX IF NOT EXISTS forensic_findings_time_query
+      ON forensic_findings(finding_kind, COALESCE(sort_time, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS forensic_findings_url_query
+      ON forensic_findings(finding_kind, COALESCE(sort_url, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS forensic_findings_duration_query
+      ON forensic_findings(finding_kind, COALESCE(sort_duration, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS forensic_findings_count_query
+      ON forensic_findings(finding_kind, COALESCE(sort_count, -1), finding_id);
+
+    CREATE TABLE IF NOT EXISTS forensic_candidates (
+      candidate_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES history_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      record_type TEXT NOT NULL CHECK (record_type = 'candidate'),
+      candidate_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      rank INTEGER NOT NULL CHECK (rank > 0),
+      supporting_count INTEGER NOT NULL CHECK (supporting_count > 0),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL
+    ) STRICT;
+  `);
+}
+
+function insertFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortTime,
+    row.sortUrl,
+    row.sortDuration,
+    row.sortCount,
+    row.transitionCore,
+  );
+}
+
+function insertCandidate(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedCandidate,
+): void {
+  const candidate = row.candidate;
+  statement.run(
+    artifactResultId,
+    runId,
+    candidate.recordType,
+    candidate.candidateKind,
+    row.profile,
+    row.commitState,
+    candidate.rank,
+    candidate.count,
+    JSON.stringify(candidate.provenance),
+    JSON.stringify(candidate.fields),
+    row.searchText,
+  );
+}
+
+export function storeHistoryAnalysis(
+  options: StoreHistoryAnalysisOptions,
+): StoredHistoryAnalysis {
+  const runId = randomUUID();
+  const database = new DatabaseSync(
+    join(resolve(options.caseDirectory), CASE_FILENAME),
+    { readBigInts: true },
+  );
+  try {
+    initializeFindingSchema(database);
+    database.exec("BEGIN IMMEDIATE;");
+    try {
+      database
+        .prepare(
+          `INSERT INTO analysis_runs
+             (run_id, source_id, artifact, started_at, tool_version,
+              invocation_json, declared_timezone, declared_origin_os, status)
+           VALUES (?, ?, 'History', ?, ?, ?, ?, ?, 'running')`,
+        )
+        .run(
+          runId,
+          options.sourceId,
+          options.startedAt,
+          TOOL_VERSION,
+          JSON.stringify(options.invocation),
+          options.declaredTimezone,
+          options.declaredOriginOs,
+        );
+
+      const insertArtifact = database.prepare(
+        `INSERT INTO history_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'History', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertFindingStatement = database.prepare(
+        `INSERT INTO forensic_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_time, sort_url,
+            sort_duration, sort_count, transition_core)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const insertCandidateStatement = database.prepare(
+        `INSERT INTO forensic_candidates
+           (artifact_result_id, run_id, record_type, candidate_kind,
+            profile_path, commit_state, rank, supporting_count,
+            provenance_json, fields_json, search_text)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePrevious = database.prepare(
+        `UPDATE history_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'History'
+            AND active = 1`,
+      );
+      const activateCurrent = database.prepare(
+        "UPDATE history_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
+
+      for (const artifact of options.artifacts) {
+        const insertion = insertArtifact.run(
+          runId,
+          options.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertFinding(
+            insertFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        for (const candidate of artifact.candidates ?? []) {
+          insertCandidate(
+            insertCandidateStatement,
+            artifactResultId,
+            runId,
+            candidate,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePrevious.run(options.sourceId, artifact.profile);
+          activateCurrent.run(artifactResultId);
+        }
+      }
+
+      const runStatus = options.artifacts.some(
+        (artifact) => artifact.status === "unavailable",
+      )
+        ? "partial"
+        : "complete";
+      const finishedAt = new Date().toISOString();
+      database
+        .prepare(
+          "UPDATE analysis_runs SET finished_at = ?, status = ? WHERE run_id = ?",
+        )
+        .run(finishedAt, runStatus, runId);
+      database.exec("COMMIT;");
+      database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
+      return { runId, finishedAt, runStatus };
+    } catch (error) {
+      database.exec("ROLLBACK;");
+      throw error;
+    }
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/case.ts
+++ b/core/src/case.ts
@@ -42,6 +42,7 @@ export interface CaseSourceRecord {
   readonly entryCount: number;
   readonly copiedEntryCount: number;
   readonly profileCount: number;
+  readonly profiles: readonly string[];
   readonly unavailableCount: number;
   readonly unclassifiedCount: number;
   readonly entries: readonly ManifestEntry[];
@@ -310,6 +311,17 @@ export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
       );
     }
 
+    const profileRows = database
+      .prepare("SELECT path FROM profiles WHERE source_id = ? ORDER BY path")
+      .all(source.source_id) as unknown as { readonly path: string }[];
+    if (profileRows.length !== source.profile_count) {
+      throw new ForensixError(
+        "CASE_INVALID",
+        "Case Profile count does not match.",
+        { expected: source.profile_count, actual: profileRows.length },
+      );
+    }
+
     const rows = database
       .prepare(
         `SELECT path, state, unavailable_reason, node_type, file_kind,
@@ -374,6 +386,7 @@ export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
       entryCount: source.entry_count,
       copiedEntryCount: source.copied_entry_count,
       profileCount: source.profile_count,
+      profiles: profileRows.map((row) => row.path),
       unavailableCount: source.unavailable_count,
       unclassifiedCount: source.unclassified_count,
       entries,

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -8,6 +8,9 @@ export type ForensixErrorCode =
   | "INGEST_FAILED"
   | "CASE_NOT_FOUND"
   | "CASE_INVALID"
+  | "ANALYSIS_FAILED"
+  | "ANALYSIS_NOT_FOUND"
+  | "INVALID_CURSOR"
   | "WORKING_COPY_INTEGRITY_REFUSAL";
 
 export interface ErrorDiagnostic {

--- a/core/src/forensic-model.ts
+++ b/core/src/forensic-model.ts
@@ -1,0 +1,194 @@
+const findingBrand: unique symbol = Symbol("forensix.finding");
+const candidateBrand: unique symbol = Symbol("forensix.candidate");
+
+export type FieldUnavailableReason =
+  | "missing_column"
+  | "null_value"
+  | "related_row_missing"
+  | "epoch_requires_declared_origin_os"
+  | "timestamp_out_of_range"
+  | "unsupported_value";
+
+export interface ValueField<T> {
+  readonly state: "value";
+  readonly value: T;
+  readonly synthetic?: boolean;
+}
+
+export interface AbsentField {
+  readonly state: "absent";
+}
+
+export interface UnavailableField {
+  readonly state: "unavailable";
+  readonly reason: FieldUnavailableReason;
+}
+
+export type FieldState<T> = ValueField<T> | AbsentField | UnavailableField;
+export type ForensicFields = Readonly<Record<string, FieldState<unknown>>>;
+
+export interface SourceRowProvenance {
+  readonly manifestEntryId: string;
+  readonly sourceId: string;
+  readonly manifestEntryOrdinal: number;
+  readonly manifestPath: string;
+  readonly database: string;
+  readonly table: string;
+  readonly rowId: string;
+}
+
+export interface Provenance extends SourceRowProvenance {
+  readonly supportingRows?: readonly SourceRowProvenance[];
+}
+
+export type CommitState = "committed" | "wal_resident" | "journal_resident";
+
+export interface Finding<
+  Kind extends string = string,
+  Fields extends ForensicFields = ForensicFields,
+> {
+  readonly recordType: "finding";
+  readonly findingKind: Kind;
+  readonly profile: string;
+  readonly commitState: CommitState;
+  readonly provenance: Provenance;
+  readonly fields: Fields;
+  readonly [findingBrand]: true;
+}
+
+export interface Candidate<
+  Kind extends string = string,
+  Fields extends ForensicFields = ForensicFields,
+> {
+  readonly recordType: "candidate";
+  readonly candidateKind: Kind;
+  readonly rank: number;
+  readonly count: number;
+  readonly provenance: Provenance;
+  readonly fields: Fields;
+  readonly [candidateBrand]: true;
+}
+
+export function valueField<T>(
+  value: T,
+  options: { readonly synthetic?: boolean } = {},
+): ValueField<T> {
+  return options.synthetic === undefined
+    ? { state: "value", value }
+    : { state: "value", value, synthetic: options.synthetic };
+}
+
+export function absentField(): AbsentField {
+  return { state: "absent" };
+}
+
+export function unavailableField(
+  reason: FieldUnavailableReason,
+): UnavailableField {
+  return { state: "unavailable", reason };
+}
+
+function assertFields(fields: ForensicFields): void {
+  for (const [name, field] of Object.entries(fields)) {
+    if (field.state === "value") {
+      if (!("value" in field)) {
+        throw new TypeError(`Finding field ${name} has no value.`);
+      }
+      continue;
+    }
+    if (field.state === "absent") {
+      if (Object.keys(field).length !== 1) {
+        throw new TypeError(`Absent Finding field ${name} has extra data.`);
+      }
+      continue;
+    }
+    if (field.state === "unavailable" && field.reason.length > 0) {
+      continue;
+    }
+    throw new TypeError(`Finding field ${name} has no Field State.`);
+  }
+}
+
+function assertSourceRowProvenance(provenance: SourceRowProvenance): void {
+  if (
+    provenance.sourceId.length === 0 ||
+    provenance.manifestEntryOrdinal < 0 ||
+    provenance.manifestPath.length === 0 ||
+    provenance.database.length === 0 ||
+    provenance.table.length === 0 ||
+    provenance.rowId.length === 0 ||
+    provenance.manifestEntryId !==
+      `${provenance.sourceId}:${provenance.manifestEntryOrdinal}`
+  ) {
+    throw new TypeError("Finding Provenance is not resolvable.");
+  }
+}
+
+function assertProvenance(provenance: Provenance): void {
+  assertSourceRowProvenance(provenance);
+  for (const supportingRow of provenance.supportingRows ?? []) {
+    assertSourceRowProvenance(supportingRow);
+  }
+}
+
+export function createFinding<
+  Kind extends string,
+  Fields extends ForensicFields,
+>(input: {
+  readonly findingKind: Kind;
+  readonly profile: string;
+  readonly commitState: CommitState;
+  readonly provenance: Provenance;
+  readonly fields: Fields;
+}): Finding<Kind, Fields> {
+  assertProvenance(input.provenance);
+  assertFields(input.fields);
+  return {
+    recordType: "finding",
+    ...input,
+    [findingBrand]: true,
+  };
+}
+
+export function createCandidate<
+  Kind extends string,
+  Fields extends ForensicFields,
+>(input: {
+  readonly candidateKind: Kind;
+  readonly rank: number;
+  readonly count: number;
+  readonly provenance: Provenance;
+  readonly fields: Fields;
+}): Candidate<Kind, Fields> {
+  if (!Number.isSafeInteger(input.rank) || input.rank < 1) {
+    throw new TypeError("Candidate rank must be a positive integer.");
+  }
+  if (!Number.isSafeInteger(input.count) || input.count < 1) {
+    throw new TypeError("Candidate count must be a positive integer.");
+  }
+  assertProvenance(input.provenance);
+  assertFields(input.fields);
+  return {
+    recordType: "candidate",
+    ...input,
+    [candidateBrand]: true,
+  };
+}
+
+export class FindingCollection<
+  Row extends Finding = Finding,
+> implements Iterable<Row> {
+  readonly #rows: Row[] = [];
+
+  public add(row: Row): void {
+    this.#rows.push(row);
+  }
+
+  public get size(): number {
+    return this.#rows.length;
+  }
+
+  public [Symbol.iterator](): Iterator<Row> {
+    return this.#rows[Symbol.iterator]();
+  }
+}

--- a/core/src/history-query.ts
+++ b/core/src/history-query.ts
@@ -1,0 +1,505 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type HistoryView = "visits" | "activity" | "most-visited" | "durations";
+export type HistoryDirection = "asc" | "desc";
+export type HistorySort =
+  | "visit-time"
+  | "local-time"
+  | "url"
+  | "duration"
+  | "visit-count"
+  | "profile";
+
+export interface HistoryQuery {
+  readonly caseDirectory: string;
+  readonly view?: HistoryView;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly transition?: string;
+  readonly from?: string;
+  readonly to?: string;
+  readonly sort?: HistorySort;
+  readonly direction?: HistoryDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface HistoryPage {
+  readonly status: "ok";
+  readonly command: "history";
+  readonly view: HistoryView;
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+const HISTORY_VIEWS = [
+  "visits",
+  "activity",
+  "most-visited",
+  "durations",
+] as const;
+const HISTORY_DIRECTIONS = ["asc", "desc"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const VIEW_KINDS: Readonly<Record<HistoryView, string>> = {
+  visits: "history_visit",
+  activity: "history_activity_summary",
+  "most-visited": "history_most_visited_summary",
+  durations: "history_duration_summary",
+};
+
+const SORTS: Readonly<Record<HistorySort, SortDefinition>> = {
+  "visit-time": { expression: "COALESCE(f.sort_time, '')", kind: "text" },
+  "local-time": { expression: "COALESCE(f.sort_time, '')", kind: "text" },
+  url: { expression: "COALESCE(f.sort_url, '')", kind: "text" },
+  duration: { expression: "COALESCE(f.sort_duration, -1)", kind: "integer" },
+  "visit-count": {
+    expression: "COALESCE(f.sort_count, -1)",
+    kind: "integer",
+  },
+  profile: { expression: "f.profile_path", kind: "text" },
+};
+
+const VIEW_SORTS: Readonly<Record<HistoryView, readonly HistorySort[]>> = {
+  visits: ["visit-time", "url", "duration", "profile"],
+  activity: ["local-time", "visit-count", "duration", "profile"],
+  "most-visited": ["visit-count", "url", "profile"],
+  durations: ["duration", "visit-count", "url", "profile"],
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+const DEFAULT_SORT: Readonly<Record<HistoryView, HistorySort>> = {
+  visits: "visit-time",
+  activity: "local-time",
+  "most-visited": "visit-count",
+  durations: "duration",
+};
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly view: HistoryView;
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly transition: string | null;
+  readonly from: string | null;
+  readonly to: string | null;
+  readonly sort: HistorySort;
+  readonly direction: HistoryDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "History cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "History cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "History --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function normalizeInstant(
+  value: string | undefined,
+  option: string,
+): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  const match =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,6}))?(Z|[+-]\d{2}:\d{2})$/.exec(
+      value,
+    );
+  const date = new Date(value);
+  const year = Number(match?.[1]);
+  const month = Number(match?.[2]);
+  const day = Number(match?.[3]);
+  const hour = Number(match?.[4]);
+  const minute = Number(match?.[5]);
+  const second = Number(match?.[6]);
+  const daysInMonth = new Date(Date.UTC(year, month, 0)).getUTCDate();
+  if (
+    match === null ||
+    Number.isNaN(date.getTime()) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > daysInMonth ||
+    hour > 23 ||
+    minute > 59 ||
+    second > 59
+  ) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `History ${option} must be an ISO 8601 instant with an offset.`,
+      { value },
+    );
+  }
+  const fraction = (match[7] ?? "").padEnd(6, "0");
+  const milliseconds = date.toISOString();
+  return `${milliseconds.slice(0, -5)}.${milliseconds.slice(-4, -1)}${fraction.slice(3)}Z`;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `History ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM history_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function findingSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'forensic_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryHistory(input: HistoryQuery): HistoryPage {
+  const view = enumValue(input.view, "visits", HISTORY_VIEWS, "--view");
+  const direction = enumValue(
+    input.direction,
+    "desc",
+    HISTORY_DIRECTIONS,
+    "--direction",
+  );
+  const sort = input.sort ?? DEFAULT_SORT[view];
+  if (!(sort in SORTS) || !VIEW_SORTS[view].includes(sort)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `History sort ${sort} is not available for ${view}.`,
+      { view, sort, allowed: VIEW_SORTS[view] },
+    );
+  }
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortDefinition = SORTS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "History queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+  const transition = input.transition?.toLocaleLowerCase("en-US") ?? null;
+  const from = normalizeInstant(input.from, "--from");
+  const to = normalizeInstant(input.to, "--to");
+  if (view !== "visits" && (from !== null || to !== null)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "History time bounds apply only to the visits view.",
+      { view },
+    );
+  }
+  if (view !== "visits" && transition !== null) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "History transition filters apply only to the visits view.",
+      { view },
+    );
+  }
+  if (from !== null && to !== null && from > to) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "History --from must not be later than --to.",
+    );
+  }
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!findingSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no History analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      view,
+      profiles,
+      search,
+      commitState,
+      transition,
+      from,
+      to,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [VIEW_KINDS[view]];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (transition !== null) {
+      conditions.push("f.transition_core = ?");
+      parameters.push(transition);
+    }
+    if (from !== null) {
+      conditions.push("f.sort_time >= ?");
+      parameters.push(from);
+    }
+    if (to !== null) {
+      conditions.push("f.sort_time <= ?");
+      parameters.push(to);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortDefinition.expression} ${operator} ? OR ` +
+          `(${sortDefinition.expression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        findingId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "History cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortDefinition.expression} AS cursor_key
+           FROM forensic_findings f
+           JOIN history_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortDefinition.expression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "history",
+      view,
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/history-sqlite.ts
+++ b/core/src/history-sqlite.ts
@@ -1,0 +1,592 @@
+import { lstat, mkdtemp, open, rm } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import type { CommitState } from "./forensic-model.js";
+import { readStableRegularFile } from "./stable-file.js";
+
+export type RawHistoryValue = null | string | bigint | Uint8Array;
+export type HistorySourceTable = "visits" | "urls" | "visit_source";
+
+export interface SidecarSourceRow {
+  readonly table: HistorySourceTable;
+  readonly rowId: string;
+}
+
+export interface RawHistoryVisit {
+  readonly visitId: RawHistoryValue;
+  readonly urlId: RawHistoryValue;
+  readonly visitTime: RawHistoryValue;
+  readonly fromVisit: RawHistoryValue;
+  readonly externalReferrerUrl: RawHistoryValue;
+  readonly transition: RawHistoryValue;
+  readonly segmentId: RawHistoryValue;
+  readonly visitDuration: RawHistoryValue;
+  readonly incrementedOmniboxTypedScore: RawHistoryValue;
+  readonly openerVisit: RawHistoryValue;
+  readonly originatorCacheGuid: RawHistoryValue;
+  readonly originatorVisitId: RawHistoryValue;
+  readonly originatorFromVisit: RawHistoryValue;
+  readonly originatorOpenerVisit: RawHistoryValue;
+  readonly isKnownToSync: RawHistoryValue;
+  readonly considerForNtpMostVisited: RawHistoryValue;
+  readonly visitedLinkId: RawHistoryValue;
+  readonly appId: RawHistoryValue;
+  readonly urlRecordId: RawHistoryValue;
+  readonly url: RawHistoryValue;
+  readonly title: RawHistoryValue;
+  readonly urlVisitCount: RawHistoryValue;
+  readonly typedCount: RawHistoryValue;
+  readonly lastVisitTime: RawHistoryValue;
+  readonly hidden: RawHistoryValue;
+  readonly visitSource: RawHistoryValue;
+  readonly sidecarTables: readonly HistorySourceTable[];
+  readonly sidecarRows: readonly SidecarSourceRow[];
+}
+
+export interface HistorySchema {
+  readonly version: number;
+  readonly visitColumns: ReadonlySet<string>;
+  readonly urlColumns: ReadonlySet<string>;
+  readonly hasVisitSource: boolean;
+}
+
+export interface HistoryPass {
+  readonly schema: HistorySchema;
+  readonly rows: readonly RawHistoryVisit[];
+  readonly integrity: string;
+}
+
+export interface RecoveredHistoryPass extends HistoryPass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface HistoryPasses {
+  readonly committed: HistoryPass;
+  readonly recovered: RecoveredHistoryPass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+export interface VerifiedHistoryFile {
+  readonly path: string;
+  readonly manifestPath: string;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+const REQUIRED_VISIT_COLUMNS = [
+  "id",
+  "url",
+  "visit_time",
+  "from_visit",
+  "transition",
+] as const;
+const CURRENT_VISIT_COLUMNS = [
+  ...REQUIRED_VISIT_COLUMNS,
+  "external_referrer_url",
+  "segment_id",
+  "visit_duration",
+  "incremented_omnibox_typed_score",
+  "opener_visit",
+  "originator_cache_guid",
+  "originator_visit_id",
+  "originator_from_visit",
+  "originator_opener_visit",
+  "is_known_to_sync",
+  "consider_for_ntp_most_visited",
+  "visited_link_id",
+  "app_id",
+] as const;
+const POST_VERSION_16_VISIT_COLUMNS = [
+  "external_referrer_url",
+  "opener_visit",
+  "originator_cache_guid",
+  "originator_visit_id",
+  "originator_from_visit",
+  "originator_opener_visit",
+  "is_known_to_sync",
+  "consider_for_ntp_most_visited",
+  "visited_link_id",
+  "app_id",
+] as const;
+const REQUIRED_URL_COLUMNS = [
+  "id",
+  "url",
+  "title",
+  "visit_count",
+  "typed_count",
+  "last_visit_time",
+  "hidden",
+] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function requireColumns(
+  actual: ReadonlySet<string>,
+  expected: readonly string[],
+  table: string,
+  version: number,
+): void {
+  const missing = expected.filter((column) => !actual.has(column));
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `History schema version ${version} is missing required ${table} columns.`,
+      { table, version, missing_columns: missing },
+    );
+  }
+}
+
+function readSchema(database: DatabaseSync): HistorySchema {
+  for (const table of ["meta", "urls", "visits"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `History database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 15) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "History meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const visitColumns = tableColumns(database, "visits");
+  const urlColumns = tableColumns(database, "urls");
+  requireColumns(visitColumns, REQUIRED_VISIT_COLUMNS, "visits", version);
+  requireColumns(urlColumns, REQUIRED_URL_COLUMNS, "urls", version);
+  if (version >= 70) {
+    requireColumns(visitColumns, CURRENT_VISIT_COLUMNS, "visits", version);
+  }
+  const hasVisitSource = tableExists(database, "visit_source");
+  if (
+    version <= 16 &&
+    (hasVisitSource ||
+      POST_VERSION_16_VISIT_COLUMNS.some((column) => visitColumns.has(column)))
+  ) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "History meta.version does not agree with the visits schema.",
+      { recorded_version: version },
+    );
+  }
+
+  return {
+    version,
+    visitColumns,
+    urlColumns,
+    hasVisitSource,
+  };
+}
+
+function optionalColumn(
+  columns: ReadonlySet<string>,
+  tableAlias: string,
+  column: string,
+  alias: string,
+): string {
+  return columns.has(column)
+    ? `${tableAlias}."${column}" AS "${alias}"`
+    : `NULL AS "${alias}"`;
+}
+
+function normalizeValue(value: unknown): RawHistoryValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "History contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): HistoryPass {
+  const schema = readSchema(database);
+  const visit = (column: string, alias: string): string =>
+    optionalColumn(schema.visitColumns, "v", column, alias);
+  const url = (column: string, alias: string): string =>
+    optionalColumn(schema.urlColumns, "u", column, alias);
+  const visitSourceSelect = schema.hasVisitSource
+    ? "vs.source AS visitSource"
+    : "NULL AS visitSource";
+  const visitSourceJoin = schema.hasVisitSource
+    ? "LEFT JOIN visit_source vs ON vs.id = v.id"
+    : "";
+  const statement = database.prepare(`
+    SELECT
+      ${visit("id", "visitId")},
+      ${visit("url", "urlId")},
+      ${visit("visit_time", "visitTime")},
+      ${visit("from_visit", "fromVisit")},
+      ${visit("external_referrer_url", "externalReferrerUrl")},
+      ${visit("transition", "transition")},
+      ${visit("segment_id", "segmentId")},
+      ${visit("visit_duration", "visitDuration")},
+      ${visit("incremented_omnibox_typed_score", "incrementedOmniboxTypedScore")},
+      ${visit("opener_visit", "openerVisit")},
+      ${visit("originator_cache_guid", "originatorCacheGuid")},
+      ${visit("originator_visit_id", "originatorVisitId")},
+      ${visit("originator_from_visit", "originatorFromVisit")},
+      ${visit("originator_opener_visit", "originatorOpenerVisit")},
+      ${visit("is_known_to_sync", "isKnownToSync")},
+      ${visit("consider_for_ntp_most_visited", "considerForNtpMostVisited")},
+      ${visit("visited_link_id", "visitedLinkId")},
+      ${visit("app_id", "appId")},
+      ${url("id", "urlRecordId")},
+      ${url("url", "url")},
+      ${url("title", "title")},
+      ${url("visit_count", "urlVisitCount")},
+      ${url("typed_count", "typedCount")},
+      ${url("last_visit_time", "lastVisitTime")},
+      ${url("hidden", "hidden")},
+      ${visitSourceSelect}
+    FROM visits v
+    LEFT JOIN urls u ON u.id = v.url
+    ${visitSourceJoin}
+    ORDER BY v.id
+  `);
+  const rows: RawHistoryVisit[] = [];
+  for (const row of statement.iterate()) {
+    rows.push({
+      visitId: normalizeValue(row.visitId),
+      urlId: normalizeValue(row.urlId),
+      visitTime: normalizeValue(row.visitTime),
+      fromVisit: normalizeValue(row.fromVisit),
+      externalReferrerUrl: normalizeValue(row.externalReferrerUrl),
+      transition: normalizeValue(row.transition),
+      segmentId: normalizeValue(row.segmentId),
+      visitDuration: normalizeValue(row.visitDuration),
+      incrementedOmniboxTypedScore: normalizeValue(
+        row.incrementedOmniboxTypedScore,
+      ),
+      openerVisit: normalizeValue(row.openerVisit),
+      originatorCacheGuid: normalizeValue(row.originatorCacheGuid),
+      originatorVisitId: normalizeValue(row.originatorVisitId),
+      originatorFromVisit: normalizeValue(row.originatorFromVisit),
+      originatorOpenerVisit: normalizeValue(row.originatorOpenerVisit),
+      isKnownToSync: normalizeValue(row.isKnownToSync),
+      considerForNtpMostVisited: normalizeValue(row.considerForNtpMostVisited),
+      visitedLinkId: normalizeValue(row.visitedLinkId),
+      appId: normalizeValue(row.appId),
+      urlRecordId: normalizeValue(row.urlRecordId),
+      url: normalizeValue(row.url),
+      title: normalizeValue(row.title),
+      urlVisitCount: normalizeValue(row.urlVisitCount),
+      typedCount: normalizeValue(row.typedCount),
+      lastVisitTime: normalizeValue(row.lastVisitTime),
+      hidden: normalizeValue(row.hidden),
+      visitSource: normalizeValue(row.visitSource),
+      sidecarTables: [],
+      sidecarRows: [],
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function immutableDatabase(path: string): DatabaseSync {
+  const url = pathToFileURL(path);
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, {
+    readOnly: true,
+    readBigInts: true,
+  });
+}
+
+function fingerprint(values: readonly RawHistoryValue[]): string {
+  return JSON.stringify(values, (_key, value: unknown) =>
+    typeof value === "bigint" ? `${value.toString()}n` : value,
+  );
+}
+
+function tableFingerprint(
+  row: RawHistoryVisit,
+  table: HistorySourceTable,
+): string {
+  if (table === "visits") {
+    return fingerprint([
+      row.visitId,
+      row.urlId,
+      row.visitTime,
+      row.fromVisit,
+      row.externalReferrerUrl,
+      row.transition,
+      row.segmentId,
+      row.visitDuration,
+      row.incrementedOmniboxTypedScore,
+      row.openerVisit,
+      row.originatorCacheGuid,
+      row.originatorVisitId,
+      row.originatorFromVisit,
+      row.originatorOpenerVisit,
+      row.isKnownToSync,
+      row.considerForNtpMostVisited,
+      row.visitedLinkId,
+      row.appId,
+    ]);
+  }
+  if (table === "urls") {
+    return fingerprint([
+      row.urlRecordId,
+      row.url,
+      row.title,
+      row.urlVisitCount,
+      row.typedCount,
+      row.lastVisitTime,
+      row.hidden,
+    ]);
+  }
+  return fingerprint([row.visitId, row.visitSource]);
+}
+
+function rowId(row: RawHistoryVisit): string | null {
+  return typeof row.visitId === "bigint" ? row.visitId.toString() : null;
+}
+
+function presentTables(row: RawHistoryVisit): HistorySourceTable[] {
+  return [
+    "visits",
+    ...(row.urlRecordId === null ? [] : (["urls"] as const)),
+    ...(row.visitSource === null ? [] : (["visit_source"] as const)),
+  ];
+}
+
+function tableRowId(
+  row: RawHistoryVisit,
+  table: HistorySourceTable,
+): string | null {
+  const value = table === "urls" ? row.urlRecordId : row.visitId;
+  return typeof value === "bigint" ? value.toString() : null;
+}
+
+function recoveredOnlyRows(
+  committed: readonly RawHistoryVisit[],
+  recovered: readonly RawHistoryVisit[],
+): RawHistoryVisit[] {
+  const committedByVisitId = new Map(
+    committed.flatMap((row) => {
+      const id = rowId(row);
+      return id === null ? [] : [[id, row] as const];
+    }),
+  );
+  const rows: RawHistoryVisit[] = [];
+  for (const row of recovered) {
+    const id = rowId(row);
+    const committedRow = id === null ? undefined : committedByVisitId.get(id);
+    const tables = new Set<HistorySourceTable>([
+      ...presentTables(row),
+      ...(committedRow === undefined ? [] : presentTables(committedRow)),
+    ]);
+    const sidecarTables = [...tables].filter(
+      (table) =>
+        committedRow === undefined ||
+        tableFingerprint(row, table) !== tableFingerprint(committedRow, table),
+    );
+    if (sidecarTables.length > 0) {
+      const sidecarRows = sidecarTables.flatMap((table) => {
+        const sourceRowId =
+          tableRowId(row, table) ??
+          (committedRow === undefined ? null : tableRowId(committedRow, table));
+        return sourceRowId === null ? [] : [{ table, rowId: sourceRowId }];
+      });
+      rows.push({ ...row, sidecarTables, sidecarRows });
+    }
+  }
+  return rows;
+}
+
+async function writeAll(destination: FileHandle, chunk: Buffer): Promise<void> {
+  let written = 0;
+  while (written < chunk.length) {
+    const result = await destination.write(
+      chunk,
+      written,
+      chunk.length - written,
+    );
+    written += result.bytesWritten;
+  }
+}
+
+async function snapshotVerifiedFile(
+  source: VerifiedHistoryFile,
+  destinationPath: string,
+): Promise<void> {
+  let stats;
+  try {
+    stats = await lstat(source.path, { bigint: true });
+  } catch {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_missing" },
+    ]);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_not_regular_file" },
+    ]);
+  }
+
+  const destination = await open(destinationPath, "wx", 0o600);
+  let result;
+  try {
+    result = await readStableRegularFile(source.path, stats, async (chunk) =>
+      writeAll(destination, chunk),
+    );
+    await destination.sync();
+  } finally {
+    await destination.close();
+  }
+  if (result.status !== "stable") {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_unreadable" },
+    ]);
+  }
+  const issues = [];
+  if (result.size !== source.size) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_size_mismatch" as const,
+      expected: source.size,
+      actual: result.size,
+    });
+  }
+  if (result.sha256 !== source.sha256) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_hash_mismatch" as const,
+      expected: source.sha256,
+      actual: result.sha256,
+    });
+  }
+  if (issues.length > 0) {
+    throw new WorkingCopyIntegrityRefusal(issues);
+  }
+}
+
+export async function readHistoryPasses(options: {
+  readonly database: VerifiedHistoryFile;
+  readonly sidecars: readonly VerifiedHistoryFile[];
+}): Promise<HistoryPasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-history-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: HistoryPass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyRows(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -1,0 +1,1179 @@
+import { join, resolve } from "node:path";
+
+import {
+  storeHistoryAnalysis,
+  type DeclaredOriginOs,
+  type HistoryArtifactWrite,
+  type PersistedFinding,
+} from "./case-findings.js";
+import {
+  loadCaseSource,
+  workingCopyAbsolutePath,
+  type CaseSourceRecord,
+} from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type Provenance,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import {
+  readHistoryPasses,
+  type HistorySchema,
+  type HistorySourceTable,
+  type RawHistoryValue,
+  type RawHistoryVisit,
+  type VerifiedHistoryFile,
+} from "./history-sqlite.js";
+import { verifyWorkingCopy, type WorkingCopyVerification } from "./verify.js";
+
+export type EpochFamily =
+  | "1601-us"
+  | "1601-ms"
+  | "1601-seconds"
+  | "unix-seconds"
+  | "unix-us"
+  | "unix-ms-json-double"
+  | "omaha-days";
+
+export interface ForensicTimestamp {
+  readonly raw: string;
+  readonly epochFamily: EpochFamily;
+  readonly utc: string;
+  readonly declaredTimezone: string;
+  readonly resolution: string;
+}
+
+export interface AnalyseCaseOptions {
+  readonly caseDirectory: string;
+  readonly declaredTimezone?: string;
+  readonly declaredOriginOs?: DeclaredOriginOs;
+  readonly invocation?: readonly string[];
+}
+
+export interface HistoryAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly recoveryUnavailableProfileCount: number;
+  readonly committedVisitCount: number;
+  readonly recoveredVisitCount: number;
+  readonly findingCount: number;
+  readonly candidateCount: 0;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+  readonly declaredOriginOsConflict: boolean;
+}
+
+export interface AnalyseCaseResult extends WorkingCopyVerification {
+  readonly command: "analyse";
+  readonly analysisStatus: "ready";
+  readonly artifactCount: number;
+  readonly runId: string;
+  readonly history: HistoryAnalysisSummary;
+}
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface BuiltVisit {
+  readonly finding: Finding;
+  readonly persisted: PersistedFinding;
+  readonly visitId: string;
+  readonly urlId: string | null;
+  readonly url: FieldState<string>;
+  readonly title: FieldState<string>;
+  readonly visitTimeUtc: string | null;
+  readonly durationMicros: bigint | null;
+  readonly provenance: Provenance;
+}
+
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+const TRANSITION_CORES = new Map<number, string>([
+  [0, "link"],
+  [1, "typed"],
+  [2, "auto_bookmark"],
+  [3, "auto_subframe"],
+  [4, "manual_subframe"],
+  [5, "generated"],
+  [6, "auto_toplevel"],
+  [7, "form_submit"],
+  [8, "reload"],
+  [9, "keyword"],
+  [10, "keyword_generated"],
+]);
+const TRANSITION_QUALIFIERS = [
+  [0x00800000n, "blocked"],
+  [0x01000000n, "forward_back"],
+  [0x02000000n, "from_address_bar"],
+  [0x04000000n, "home_page"],
+  [0x08000000n, "from_api"],
+  [0x10000000n, "chain_start"],
+  [0x20000000n, "chain_end"],
+  [0x40000000n, "client_redirect"],
+  [0x80000000n, "server_redirect"],
+] as const;
+const VISIT_SOURCES = new Map<bigint, string>([
+  [0n, "synced"],
+  [1n, "browsed"],
+  [2n, "extension"],
+  [3n, "firefox_imported"],
+  [4n, "ie_imported"],
+  [5n, "safari_imported"],
+  [6n, "actor"],
+  [7n, "os_migration_imported"],
+]);
+
+function validateDeclaredTimezone(timezone: string): string {
+  try {
+    new Intl.DateTimeFormat("en-CA", { timeZone: timezone }).format(
+      new Date(0),
+    );
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Declared Timezone is not supported: ${timezone}`,
+      { declared_timezone: timezone },
+      { cause: error },
+    );
+  }
+  return timezone;
+}
+
+function bigintValue(value: RawHistoryValue): bigint | null {
+  return typeof value === "bigint" ? value : null;
+}
+
+function preservedInteger(
+  value: RawHistoryValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent) {
+    return absentField();
+  }
+  if (value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function preservedBoolean(
+  value: RawHistoryValue,
+  columnPresent: boolean,
+): FieldState<boolean> {
+  if (!columnPresent) {
+    return absentField();
+  }
+  if (value === null) {
+    return absentField();
+  }
+  if (value === 0n) {
+    return valueField(false);
+  }
+  if (value === 1n) {
+    return valueField(true);
+  }
+  return unavailableField("unsupported_value");
+}
+
+function preservedString(
+  value: RawHistoryValue,
+  columnPresent: boolean,
+  relatedRowPresent = true,
+): FieldState<string> {
+  if (!columnPresent) {
+    return absentField();
+  }
+  if (!relatedRowPresent) {
+    return unavailableField("related_row_missing");
+  }
+  if (value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+function resolveHistoryEpoch(
+  schemaVersion: number,
+  declaredOriginOs: DeclaredOriginOs | null,
+): {
+  readonly epochFamily: "1601-us" | "unix-us";
+  readonly resolution: string;
+} | null {
+  if (schemaVersion >= 17) {
+    return {
+      epochFamily: "1601-us",
+      resolution: `verified_schema_version_${schemaVersion}`,
+    };
+  }
+  if (declaredOriginOs === null) {
+    return null;
+  }
+  return {
+    epochFamily: declaredOriginOs === "windows" ? "1601-us" : "unix-us",
+    resolution: `verified_schema_version_${schemaVersion}_declared_origin_os_${declaredOriginOs}`,
+  };
+}
+
+function timestampField(
+  raw: RawHistoryValue,
+  columnPresent: boolean,
+  schemaVersion: number,
+  declaredOriginOs: DeclaredOriginOs | null,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (!columnPresent || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const resolution = resolveHistoryEpoch(schemaVersion, declaredOriginOs);
+  if (resolution === null) {
+    return unavailableField("epoch_requires_declared_origin_os");
+  }
+  const unixMicros =
+    resolution.epochFamily === "1601-us"
+      ? raw - WINDOWS_EPOCH_OFFSET_MICROS
+      : raw;
+  const utc = utcFromUnixMicros(unixMicros);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: resolution.epochFamily,
+      utc,
+      declaredTimezone,
+      resolution: resolution.resolution,
+    },
+    { synthetic: false },
+  );
+}
+
+function transitionDetails(raw: RawHistoryValue): {
+  readonly raw: FieldState<string>;
+  readonly core: FieldState<string>;
+  readonly qualifiers: FieldState<readonly string[]>;
+  readonly coreValue: string | null;
+  readonly qualifierValues: readonly string[];
+} {
+  if (typeof raw !== "bigint") {
+    const unavailable = unavailableField("unsupported_value");
+    return {
+      raw: unavailable,
+      core: unavailable,
+      qualifiers: unavailable,
+      coreValue: null,
+      qualifierValues: [],
+    };
+  }
+  const unsigned = BigInt.asUintN(32, raw);
+  const coreNumber = Number(unsigned & 0xffn);
+  const core = TRANSITION_CORES.get(coreNumber);
+  const qualifiers: string[] = TRANSITION_QUALIFIERS.filter(
+    ([mask]) => (unsigned & mask) !== 0n,
+  ).map(([, name]) => name);
+  const knownMask = TRANSITION_QUALIFIERS.reduce(
+    (mask, [qualifier]) => mask | qualifier,
+    0n,
+  );
+  const unknownMask = unsigned & 0xffffff00n & ~knownMask;
+  if (unknownMask !== 0n) {
+    qualifiers.push(`unknown_0x${unknownMask.toString(16).padStart(8, "0")}`);
+  }
+  return {
+    raw: valueField(raw.toString()),
+    core:
+      core === undefined
+        ? unavailableField("unsupported_value")
+        : valueField(core),
+    qualifiers: valueField(qualifiers),
+    coreValue: core ?? null,
+    qualifierValues: qualifiers,
+  };
+}
+
+function sourceRowProvenance(
+  manifest: ManifestIdentity,
+  table: string,
+  rowId: string,
+): SourceRowProvenance {
+  return {
+    manifestEntryId: `${manifest.sourceId}:${manifest.ordinal}`,
+    sourceId: manifest.sourceId,
+    manifestEntryOrdinal: manifest.ordinal,
+    manifestPath: manifest.path,
+    database: manifest.databasePath,
+    table,
+    rowId,
+  };
+}
+
+function urlField<T>(
+  field: FieldState<T>,
+  relatedRowPresent: boolean,
+): FieldState<T> {
+  return relatedRowPresent ? field : unavailableField("related_row_missing");
+}
+
+interface RedirectRelationships {
+  readonly childIds: readonly string[];
+  readonly supportingRows: readonly SourceRowProvenance[];
+}
+
+function redirectRelationshipsForRows(
+  rowSets: readonly {
+    readonly rows: readonly RawHistoryVisit[];
+    readonly manifest: ManifestIdentity;
+  }[],
+): ReadonlyMap<string, RedirectRelationships> {
+  const redirectChildren = new Map<string, Map<string, SourceRowProvenance>>();
+  for (const rowSet of rowSets) {
+    for (const row of rowSet.rows) {
+      const visitId = bigintValue(row.visitId)?.toString();
+      const fromVisit = bigintValue(row.fromVisit);
+      const transition = transitionDetails(row.transition);
+      if (
+        visitId !== undefined &&
+        fromVisit !== null &&
+        fromVisit !== 0n &&
+        transition.qualifierValues.some((value) => value.endsWith("_redirect"))
+      ) {
+        const key = fromVisit.toString();
+        const children =
+          redirectChildren.get(key) ?? new Map<string, SourceRowProvenance>();
+        children.set(
+          visitId,
+          sourceRowProvenance(rowSet.manifest, "visits", visitId),
+        );
+        redirectChildren.set(key, children);
+      }
+    }
+  }
+  return new Map(
+    [...redirectChildren].map(([parent, children]) => {
+      const sorted = [...children].sort(([left], [right]) =>
+        BigInt(left) < BigInt(right)
+          ? -1
+          : BigInt(left) > BigInt(right)
+            ? 1
+            : 0,
+      );
+      return [
+        parent,
+        {
+          childIds: sorted.map(([childId]) => childId),
+          supportingRows: sorted.map(([, provenance]) => provenance),
+        },
+      ];
+    }),
+  );
+}
+
+function buildVisits(options: {
+  readonly rows: readonly RawHistoryVisit[];
+  readonly schema: HistorySchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly committedManifest?: ManifestIdentity;
+  readonly redirectRelationships: ReadonlyMap<string, RedirectRelationships>;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}): BuiltVisit[] {
+  return options.rows.map((row) => {
+    const visitId = bigintValue(row.visitId)?.toString();
+    if (visitId === undefined) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "History visits.id is not an exact integer.",
+      );
+    }
+    const urlId = bigintValue(row.urlId)?.toString() ?? null;
+    const relatedUrlPresent = bigintValue(row.urlRecordId) !== null;
+    const transition = transitionDetails(row.transition);
+    const visitTime = timestampField(
+      row.visitTime,
+      options.schema.visitColumns.has("visit_time"),
+      options.schema.version,
+      options.declaredOriginOs,
+      options.declaredTimezone,
+    );
+    const lastVisitTime = urlField(
+      timestampField(
+        row.lastVisitTime,
+        options.schema.urlColumns.has("last_visit_time"),
+        options.schema.version,
+        options.declaredOriginOs,
+        options.declaredTimezone,
+      ),
+      relatedUrlPresent,
+    );
+    const fromVisit = bigintValue(row.fromVisit);
+    const isRedirect = transition.qualifierValues.some((value) =>
+      value.endsWith("_redirect"),
+    );
+    const visitSourceRaw =
+      row.visitSource === null && options.schema.hasVisitSource
+        ? 1n
+        : bigintValue(row.visitSource);
+    const visitSource =
+      visitSourceRaw === null
+        ? unavailableField("missing_column")
+        : VISIT_SOURCES.has(visitSourceRaw)
+          ? valueField(VISIT_SOURCES.get(visitSourceRaw) as string)
+          : unavailableField("unsupported_value");
+    const manifestForTable = (table: HistorySourceTable): ManifestIdentity =>
+      row.sidecarTables.includes(table)
+        ? options.manifest
+        : (options.committedManifest ?? options.manifest);
+    const provenance = sourceRowProvenance(
+      manifestForTable("visits"),
+      "visits",
+      visitId,
+    );
+    const supportingRows: SourceRowProvenance[] = [];
+    const urlRowId = bigintValue(row.urlRecordId)?.toString();
+    if (urlRowId !== undefined) {
+      supportingRows.push(
+        sourceRowProvenance(manifestForTable("urls"), "urls", urlRowId),
+      );
+    }
+    if (row.visitSource !== null && typeof row.visitSource === "bigint") {
+      supportingRows.push(
+        sourceRowProvenance(
+          manifestForTable("visit_source"),
+          "visit_source",
+          visitId,
+        ),
+      );
+    }
+    for (const sidecarRow of row.sidecarRows) {
+      if (
+        sidecarRow.table !== "visits" ||
+        provenance.manifestPath !== options.manifest.path
+      ) {
+        supportingRows.push(
+          sourceRowProvenance(
+            options.manifest,
+            sidecarRow.table,
+            sidecarRow.rowId,
+          ),
+        );
+      }
+    }
+    supportingRows.push(
+      ...(options.redirectRelationships.get(visitId)?.supportingRows ?? []),
+    );
+    const uniqueSupportingRows = [
+      ...new Map(
+        supportingRows.map((row) => [sourceRowKey(row), row]),
+      ).values(),
+    ];
+    const fullProvenance: Provenance =
+      uniqueSupportingRows.length === 0
+        ? provenance
+        : { ...provenance, supportingRows: uniqueSupportingRows };
+    const url = preservedString(
+      row.url,
+      options.schema.urlColumns.has("url"),
+      relatedUrlPresent,
+    );
+    const title = preservedString(
+      row.title,
+      options.schema.urlColumns.has("title"),
+      relatedUrlPresent,
+    );
+    const duration = bigintValue(row.visitDuration);
+    const fields = {
+      visitId: valueField(visitId),
+      urlId: preservedInteger(
+        row.urlId,
+        options.schema.visitColumns.has("url"),
+      ),
+      urlRecordId: urlField(
+        preservedInteger(row.urlRecordId, options.schema.urlColumns.has("id")),
+        relatedUrlPresent,
+      ),
+      url,
+      title,
+      urlVisitCount: urlField(
+        preservedInteger(
+          row.urlVisitCount,
+          options.schema.urlColumns.has("visit_count"),
+        ),
+        relatedUrlPresent,
+      ),
+      typedCount: urlField(
+        preservedInteger(
+          row.typedCount,
+          options.schema.urlColumns.has("typed_count"),
+        ),
+        relatedUrlPresent,
+      ),
+      lastVisitTime,
+      hidden: urlField(
+        preservedBoolean(row.hidden, options.schema.urlColumns.has("hidden")),
+        relatedUrlPresent,
+      ),
+      visitTime,
+      fromVisit: preservedInteger(
+        row.fromVisit,
+        options.schema.visitColumns.has("from_visit"),
+      ),
+      externalReferrerUrl: preservedString(
+        row.externalReferrerUrl,
+        options.schema.visitColumns.has("external_referrer_url"),
+      ),
+      transitionRaw: transition.raw,
+      transitionCore: transition.core,
+      transitionQualifiers: transition.qualifiers,
+      redirectFromVisitId:
+        isRedirect && fromVisit !== null && fromVisit !== 0n
+          ? valueField(fromVisit.toString())
+          : absentField(),
+      redirectToVisitIds: valueField(
+        options.redirectRelationships.get(visitId)?.childIds ?? [],
+      ),
+      segmentId: preservedInteger(
+        row.segmentId,
+        options.schema.visitColumns.has("segment_id"),
+      ),
+      visitDurationMicros: preservedInteger(
+        row.visitDuration,
+        options.schema.visitColumns.has("visit_duration"),
+      ),
+      incrementedOmniboxTypedScore: preservedBoolean(
+        row.incrementedOmniboxTypedScore,
+        options.schema.visitColumns.has("incremented_omnibox_typed_score"),
+      ),
+      openerVisit: preservedInteger(
+        row.openerVisit,
+        options.schema.visitColumns.has("opener_visit"),
+      ),
+      originatorCacheGuid: preservedString(
+        row.originatorCacheGuid,
+        options.schema.visitColumns.has("originator_cache_guid"),
+      ),
+      originatorVisitId: preservedInteger(
+        row.originatorVisitId,
+        options.schema.visitColumns.has("originator_visit_id"),
+      ),
+      originatorFromVisit: preservedInteger(
+        row.originatorFromVisit,
+        options.schema.visitColumns.has("originator_from_visit"),
+      ),
+      originatorOpenerVisit: preservedInteger(
+        row.originatorOpenerVisit,
+        options.schema.visitColumns.has("originator_opener_visit"),
+      ),
+      isKnownToSync: preservedBoolean(
+        row.isKnownToSync,
+        options.schema.visitColumns.has("is_known_to_sync"),
+      ),
+      considerForNtpMostVisited: preservedBoolean(
+        row.considerForNtpMostVisited,
+        options.schema.visitColumns.has("consider_for_ntp_most_visited"),
+      ),
+      visitedLinkId: preservedInteger(
+        row.visitedLinkId,
+        options.schema.visitColumns.has("visited_link_id"),
+      ),
+      appId: preservedString(
+        row.appId,
+        options.schema.visitColumns.has("app_id"),
+      ),
+      visitSourceRaw:
+        visitSourceRaw === null
+          ? unavailableField("missing_column")
+          : valueField(visitSourceRaw.toString()),
+      visitSource,
+    };
+    const finding = createFinding({
+      findingKind: "history_visit",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance: fullProvenance,
+      fields,
+    });
+    const visitTimeUtc =
+      visitTime.state === "value" ? visitTime.value.utc : null;
+    return {
+      finding,
+      persisted: {
+        finding,
+        searchText: [
+          options.profile,
+          url.state === "value" ? url.value : "",
+          title.state === "value" ? title.value : "",
+          transition.coreValue ?? "",
+          visitSource.state === "value" ? visitSource.value : "",
+        ]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortTime: visitTimeUtc,
+        sortUrl: url.state === "value" ? url.value : null,
+        sortDuration: duration,
+        sortCount: null,
+        transitionCore: transition.coreValue,
+      },
+      visitId,
+      urlId,
+      url,
+      title,
+      visitTimeUtc,
+      durationMicros: duration,
+      provenance: fullProvenance,
+    };
+  });
+}
+
+function localDateAndHour(
+  utc: string,
+  declaredTimezone: string,
+): { readonly date: string; readonly hour: string } {
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: declaredTimezone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    hourCycle: "h23",
+  }).formatToParts(new Date(utc));
+  const part = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find((candidate) => candidate.type === type)?.value ?? "";
+  return {
+    date: `${part("year")}-${part("month")}-${part("day")}`,
+    hour: part("hour"),
+  };
+}
+
+function sourceRowKey(provenance: SourceRowProvenance): string {
+  return [
+    provenance.manifestEntryId,
+    provenance.database,
+    provenance.table,
+    provenance.rowId,
+  ].join("\0");
+}
+
+function summaryProvenance(visits: readonly BuiltVisit[]): Provenance {
+  const first = visits[0];
+  if (first === undefined) {
+    throw new Error("A History summary needs supporting visits.");
+  }
+  const supportingRows = new Map<string, SourceRowProvenance>();
+  for (const visit of visits) {
+    for (const row of [
+      visit.provenance,
+      ...(visit.provenance.supportingRows ?? []),
+    ]) {
+      if (sourceRowKey(row) !== sourceRowKey(first.provenance)) {
+        supportingRows.set(sourceRowKey(row), row);
+      }
+    }
+  }
+  return supportingRows.size === 0
+    ? first.provenance
+    : { ...first.provenance, supportingRows: [...supportingRows.values()] };
+}
+
+function durationSummaryFields(visits: readonly BuiltVisit[]): {
+  readonly withDurationCount: number;
+  readonly withoutDurationCount: number;
+  readonly total: bigint;
+  readonly totalField: FieldState<string>;
+  readonly averageField: FieldState<string>;
+} {
+  const knownDurations = visits.flatMap((visit) =>
+    visit.durationMicros === null ? [] : [visit.durationMicros],
+  );
+  const total = knownDurations.reduce((sum, duration) => sum + duration, 0n);
+  const withDurationCount = knownDurations.length;
+  return {
+    withDurationCount,
+    withoutDurationCount: visits.length - withDurationCount,
+    total,
+    totalField:
+      withDurationCount === 0 ? absentField() : valueField(total.toString()),
+    averageField:
+      withDurationCount === 0
+        ? absentField()
+        : valueField((total / BigInt(withDurationCount)).toString()),
+  };
+}
+
+function boundedSortInteger(value: bigint): bigint | null {
+  return value >= SQLITE_MIN_INTEGER && value <= SQLITE_MAX_INTEGER
+    ? value
+    : null;
+}
+
+function buildSummaries(
+  visits: readonly BuiltVisit[],
+  declaredTimezone: string,
+): PersistedFinding[] {
+  const results: PersistedFinding[] = [];
+  const activityGroups = new Map<string, BuiltVisit[]>();
+  const urlGroups = new Map<string, BuiltVisit[]>();
+
+  for (const visit of visits) {
+    if (visit.visitTimeUtc !== null) {
+      const local = localDateAndHour(visit.visitTimeUtc, declaredTimezone);
+      const activityKey = `${visit.finding.profile}\0${visit.finding.commitState}\0${local.date}\0${local.hour}`;
+      const group = activityGroups.get(activityKey) ?? [];
+      group.push(visit);
+      activityGroups.set(activityKey, group);
+    }
+    const urlKey = `${visit.finding.profile}\0${visit.finding.commitState}\0${visit.urlId ?? (visit.url.state === "value" ? visit.url.value : visit.visitId)}`;
+    const urlGroup = urlGroups.get(urlKey) ?? [];
+    urlGroup.push(visit);
+    urlGroups.set(urlKey, urlGroup);
+  }
+
+  for (const group of activityGroups.values()) {
+    const first = group[0];
+    if (first === undefined || first.visitTimeUtc === null) {
+      continue;
+    }
+    const local = localDateAndHour(first.visitTimeUtc, declaredTimezone);
+    const duration = durationSummaryFields(group);
+    const finding = createFinding({
+      findingKind: "history_activity_summary",
+      profile: first.finding.profile,
+      commitState: first.finding.commitState,
+      provenance: summaryProvenance(group),
+      fields: {
+        localDate: valueField(local.date),
+        localHour: valueField(local.hour),
+        declaredTimezone: valueField(declaredTimezone),
+        supportingVisitCount: valueField(group.length.toString()),
+        visitsWithDurationCount: valueField(
+          duration.withDurationCount.toString(),
+        ),
+        visitsWithoutDurationCount: valueField(
+          duration.withoutDurationCount.toString(),
+        ),
+        totalDurationMicros: duration.totalField,
+      },
+    });
+    results.push({
+      finding,
+      searchText:
+        `${first.finding.profile}\n${local.date}\n${local.hour}`.toLocaleLowerCase(
+          "en-US",
+        ),
+      sortTime: `${local.date}T${local.hour}`,
+      sortUrl: null,
+      sortDuration:
+        duration.withDurationCount === 0
+          ? null
+          : boundedSortInteger(duration.total),
+      sortCount: BigInt(group.length),
+      transitionCore: null,
+    });
+  }
+
+  for (const group of urlGroups.values()) {
+    const first = group[0];
+    if (first === undefined) {
+      continue;
+    }
+    const duration = durationSummaryFields(group);
+    const commonFields = {
+      url: first.url,
+      title: first.title,
+      supportingVisitCount: valueField(group.length.toString()),
+    };
+    const mostVisited = createFinding({
+      findingKind: "history_most_visited_summary",
+      profile: first.finding.profile,
+      commitState: first.finding.commitState,
+      provenance: summaryProvenance(group),
+      fields: commonFields,
+    });
+    results.push({
+      finding: mostVisited,
+      searchText:
+        `${first.finding.profile}\n${first.url.state === "value" ? first.url.value : ""}\n${first.title.state === "value" ? first.title.value : ""}`.toLocaleLowerCase(
+          "en-US",
+        ),
+      sortTime: first.visitTimeUtc,
+      sortUrl: first.url.state === "value" ? first.url.value : null,
+      sortDuration: null,
+      sortCount: BigInt(group.length),
+      transitionCore: null,
+    });
+
+    const durationSummary = createFinding({
+      findingKind: "history_duration_summary",
+      profile: first.finding.profile,
+      commitState: first.finding.commitState,
+      provenance: summaryProvenance(group),
+      fields: {
+        ...commonFields,
+        visitsWithDurationCount: valueField(
+          duration.withDurationCount.toString(),
+        ),
+        visitsWithoutDurationCount: valueField(
+          duration.withoutDurationCount.toString(),
+        ),
+        totalDurationMicros: duration.totalField,
+        averageDurationMicros: duration.averageField,
+      },
+    });
+    results.push({
+      finding: durationSummary,
+      searchText:
+        `${first.finding.profile}\n${first.url.state === "value" ? first.url.value : ""}\n${first.title.state === "value" ? first.title.value : ""}`.toLocaleLowerCase(
+          "en-US",
+        ),
+      sortTime: first.visitTimeUtc,
+      sortUrl: first.url.state === "value" ? first.url.value : null,
+      sortDuration:
+        duration.withDurationCount === 0
+          ? null
+          : boundedSortInteger(duration.total),
+      sortCount: BigInt(group.length),
+      transitionCore: null,
+    });
+  }
+
+  return results;
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): HistoryArtifactWrite {
+  return {
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedVisitCount: 0,
+    recoveredVisitCount: 0,
+  };
+}
+
+async function analyseProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}): Promise<HistoryArtifactWrite> {
+  const databasePath = `${options.profile}/History`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      null,
+      "unavailable",
+      "history_manifest_entry_missing",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "history_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `history_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "history_not_in_working_copy",
+    );
+  }
+
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "history_manifest_representation_incomplete",
+    );
+  }
+  const verifiedDatabase: VerifiedHistoryFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedHistoryFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-shm` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readHistoryPasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const redirectRelationships = redirectRelationshipsForRows([
+      { rows: passes.committed.rows, manifest },
+      ...(passes.recovered === null
+        ? []
+        : [
+            {
+              rows: passes.recovered.rows,
+              manifest: recoveredManifest as ManifestIdentity,
+            },
+          ]),
+    ]);
+    const committed = buildVisits({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      redirectRelationships,
+      declaredTimezone: options.declaredTimezone,
+      declaredOriginOs: options.declaredOriginOs,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildVisits({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            committedManifest: manifest,
+            redirectRelationships,
+            declaredTimezone: options.declaredTimezone,
+            declaredOriginOs: options.declaredOriginOs,
+          });
+    const allVisits = [...committed, ...recovered];
+    return {
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [
+        ...allVisits.map((visit) => visit.persisted),
+        ...buildSummaries(allVisits, options.declaredTimezone),
+      ],
+      committedVisitCount: committed.length,
+      recoveredVisitCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `history_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}
+
+export async function analyseCase(
+  options: AnalyseCaseOptions,
+): Promise<AnalyseCaseResult> {
+  const caseDirectory = resolve(options.caseDirectory);
+  const declaredTimezone = validateDeclaredTimezone(
+    options.declaredTimezone ?? "UTC",
+  );
+  const declaredOriginOs = options.declaredOriginOs ?? null;
+  const startedAt = new Date().toISOString();
+  const verification = await verifyWorkingCopy(caseDirectory);
+  const source = loadCaseSource(caseDirectory);
+  const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
+  const artifacts: HistoryArtifactWrite[] = [];
+  for (const profile of source.profiles) {
+    artifacts.push(
+      await analyseProfile({
+        source,
+        profile,
+        workingCopyPath,
+        declaredTimezone,
+        declaredOriginOs,
+      }),
+    );
+  }
+
+  await verifyWorkingCopy(caseDirectory);
+  const stored = storeHistoryAnalysis({
+    caseDirectory,
+    sourceId: source.sourceId,
+    declaredTimezone,
+    declaredOriginOs,
+    invocation: options.invocation ?? ["analyse", "--case", caseDirectory],
+    startedAt,
+    artifacts,
+  });
+  const singletonLock = source.entries.find(
+    (entry) =>
+      entry.path === "SingletonLock" &&
+      entry.state === "value" &&
+      entry.node_type === "symlink",
+  );
+  const analysed = artifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const absent = artifacts.filter((artifact) => artifact.status === "absent");
+  const unavailable = artifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
+  return {
+    ...verification,
+    command: "analyse",
+    analysisStatus: "ready",
+    artifactCount: analysed.length,
+    runId: stored.runId,
+    history: {
+      status: unavailable.length === 0 ? "complete" : "partial",
+      profileCount: source.profiles.length,
+      analysedProfileCount: analysed.length,
+      absentProfileCount: absent.length,
+      unavailableProfileCount: unavailable.length,
+      recoveryUnavailableProfileCount: analysed.filter(
+        (artifact) => artifact.recoveryStatus === "unavailable",
+      ).length,
+      committedVisitCount: analysed.reduce(
+        (count, artifact) => count + artifact.committedVisitCount,
+        0,
+      ),
+      recoveredVisitCount: analysed.reduce(
+        (count, artifact) => count + artifact.recoveredVisitCount,
+        0,
+      ),
+      findingCount: analysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+      candidateCount: 0,
+      declaredTimezone,
+      declaredOriginOs,
+      declaredOriginOsConflict:
+        declaredOriginOs === "windows" && singletonLock !== undefined,
+    },
+  };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -54,5 +54,41 @@ export {
   type AnalysisPreflightResult,
   type WorkingCopyVerification,
 } from "./verify.js";
+export {
+  absentField,
+  createCandidate,
+  createFinding,
+  FindingCollection,
+  unavailableField,
+  valueField,
+  type AbsentField,
+  type Candidate,
+  type CommitState,
+  type FieldState,
+  type FieldUnavailableReason,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+  type SourceRowProvenance,
+  type UnavailableField,
+  type ValueField,
+} from "./forensic-model.js";
+export {
+  analyseCase,
+  type AnalyseCaseOptions,
+  type AnalyseCaseResult,
+  type EpochFamily,
+  type ForensicTimestamp,
+  type HistoryAnalysisSummary,
+} from "./history.js";
+export {
+  queryHistory,
+  type HistoryDirection,
+  type HistoryPage,
+  type HistoryQuery,
+  type HistorySort,
+  type HistoryView,
+} from "./history-query.js";
+export { type DeclaredOriginOs } from "./case-findings.js";
 
 export const MINIMUM_NODE_VERSION = "24.15.0" as const;

--- a/core/test/forensic-model.typecheck.ts
+++ b/core/test/forensic-model.typecheck.ts
@@ -1,0 +1,43 @@
+import {
+  FindingCollection,
+  createCandidate,
+  createFinding,
+  valueField,
+  type Finding,
+  type Provenance,
+} from "../src/index.js";
+
+const provenance: Provenance = {
+  manifestEntryId: "source-1:4",
+  sourceId: "source-1",
+  manifestEntryOrdinal: 4,
+  manifestPath: "Default/History",
+  database: "Default/History",
+  table: "visits",
+  rowId: "1",
+};
+
+const finding = createFinding({
+  findingKind: "history_visit",
+  profile: "Default",
+  commitState: "committed",
+  provenance,
+  fields: { url: valueField("https://example.test/") },
+});
+const candidate = createCandidate({
+  candidateKind: "browsing_topic",
+  rank: 1,
+  count: 1,
+  provenance,
+  fields: { topic: valueField("example") },
+});
+
+const findings = new FindingCollection<Finding>();
+findings.add(finding);
+
+// @ts-expect-error A Candidate can never enter a Finding collection.
+findings.add(candidate);
+
+// @ts-expect-error Finding and Candidate are distinct nominal types.
+const invalidFinding: Finding = candidate;
+void invalidFinding;

--- a/e2e/history-cli.test.ts
+++ b/e2e/history-cli.test.ts
@@ -1,0 +1,1315 @@
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { once } from "node:events";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface FieldValue<T> {
+  readonly state: "value";
+  readonly value: T;
+  readonly synthetic?: boolean;
+}
+
+interface TimestampValue {
+  readonly raw: string;
+  readonly epochFamily: "1601-us" | "unix-us";
+  readonly utc: string;
+  readonly declaredTimezone: string;
+  readonly resolution: string;
+}
+
+interface HistoryFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "history_visit";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly manifestEntryId: string;
+    readonly sourceId: string;
+    readonly manifestEntryOrdinal: number;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: {
+    readonly visitId: FieldValue<string>;
+    readonly url: FieldValue<string>;
+    readonly title: FieldValue<string>;
+    readonly visitTime: FieldValue<TimestampValue>;
+    readonly fromVisit: FieldValue<string>;
+    readonly externalReferrerUrl: FieldValue<string>;
+    readonly transitionRaw: FieldValue<string>;
+    readonly transitionCore: FieldValue<string>;
+    readonly transitionQualifiers: FieldValue<readonly string[]>;
+    readonly redirectFromVisitId:
+      | FieldValue<string>
+      | { readonly state: "absent" };
+    readonly redirectToVisitIds: FieldValue<readonly string[]>;
+    readonly visitSource: FieldValue<string>;
+    readonly visitDurationMicros: FieldValue<string>;
+    readonly originatorCacheGuid: FieldValue<string>;
+    readonly appId: FieldValue<string>;
+  };
+}
+
+interface HistoryPage {
+  readonly status: "ok";
+  readonly command: "history";
+  readonly view: "visits";
+  readonly items: readonly HistoryFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function createHistory(
+  path: string,
+  rows: readonly {
+    readonly id: bigint;
+    readonly urlId: bigint;
+    readonly url: string;
+    readonly title: string;
+    readonly visitTime: bigint;
+    readonly fromVisit: bigint;
+    readonly transition: bigint;
+    readonly duration: bigint;
+    readonly source?: bigint;
+  }[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR,
+        title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY,
+        segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL,
+        visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+
+    const insertUrl = database.prepare(
+      `INSERT INTO urls
+         (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertVisit = database.prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertSource = database.prepare(
+      "INSERT INTO visit_source (id, source) VALUES (?, ?)",
+    );
+
+    const counts = new Map<bigint, number>();
+    for (const row of rows) {
+      counts.set(row.urlId, (counts.get(row.urlId) ?? 0) + 1);
+    }
+    const urls = new Map(rows.map((row) => [row.urlId, row]));
+    for (const row of urls.values()) {
+      insertUrl.run(
+        row.urlId,
+        row.url,
+        row.title,
+        counts.get(row.urlId) ?? 0,
+        1,
+        row.visitTime,
+        0,
+      );
+    }
+    for (const row of rows) {
+      insertVisit.run(
+        row.id,
+        row.urlId,
+        row.visitTime,
+        row.fromVisit,
+        row.fromVisit === 0n ? "" : "https://external.example/referrer",
+        row.transition,
+        0,
+        row.duration,
+        1,
+        0,
+        "origin-cache-guid",
+        row.id + 1000n,
+        0,
+        0,
+        1,
+        1,
+        row.id + 2000n,
+        "com.example.browser",
+      );
+      if (row.source !== undefined) {
+        insertSource.run(row.id, row.source);
+      }
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"), [
+    {
+      id: 1n,
+      urlId: 10n,
+      url: "https://alpha.example/start",
+      title: "Alpha start",
+      visitTime: 13_348_638_245_123_456n,
+      fromVisit: 0n,
+      transition: 0x10000001n,
+      duration: 2_500_000n,
+    },
+    {
+      id: 2n,
+      urlId: 11n,
+      url: "https://alpha.example/redirected",
+      title: "Alpha redirected",
+      visitTime: 13_348_638_305_456_000n,
+      fromVisit: 1n,
+      transition: 0x60000000n,
+      duration: 5_000_000n,
+      source: 2n,
+    },
+  ]);
+  await createHistory(join(source, "Profile 1", "History"), [
+    {
+      id: 7n,
+      urlId: 70n,
+      url: "https://beta.example/",
+      title: "Beta",
+      visitTime: 13_361_718_600_000_000n,
+      fromVisit: 0n,
+      transition: 8n,
+      duration: 750_000n,
+    },
+  ]);
+  return source;
+}
+
+async function createWalSource(root: string): Promise<{
+  readonly source: string;
+  readonly writer: DatabaseSync;
+}> {
+  const source = join(root, "wal-source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  const historyPath = join(source, "Default", "History");
+  await createHistory(historyPath, [
+    {
+      id: 1n,
+      urlId: 10n,
+      url: "https://committed.example/",
+      title: "Committed",
+      visitTime: 13_348_638_245_123_456n,
+      fromVisit: 0n,
+      transition: 1n,
+      duration: 100n,
+    },
+    {
+      id: 3n,
+      urlId: 30n,
+      url: "https://visit-update.example/",
+      title: "Visit update",
+      visitTime: 13_348_638_250_000_000n,
+      fromVisit: 0n,
+      transition: 1n,
+      duration: 300n,
+    },
+    {
+      id: 4n,
+      urlId: 40n,
+      url: "https://url-deleted.example/",
+      title: "URL deleted",
+      visitTime: 13_348_638_251_000_000n,
+      fromVisit: 0n,
+      transition: 1n,
+      duration: 400n,
+      source: 2n,
+    },
+  ]);
+  const writer = new DatabaseSync(historyPath);
+  writer.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA wal_autocheckpoint = 0;
+    PRAGMA wal_checkpoint(TRUNCATE);
+  `);
+  writer
+    .prepare("UPDATE urls SET title = ? WHERE id = ?")
+    .run("URL changed in WAL", 10n);
+  writer
+    .prepare("UPDATE visits SET visit_duration = ? WHERE id = ?")
+    .run(333n, 3n);
+  writer.prepare("DELETE FROM urls WHERE id = ?").run(40n);
+  writer.prepare("DELETE FROM visit_source WHERE id = ?").run(4n);
+  writer
+    .prepare(
+      `INSERT INTO urls
+         (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      20n,
+      "https://wal.example/",
+      "WAL resident",
+      1,
+      0,
+      13_348_638_305_456_000n,
+      0,
+    );
+  writer
+    .prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      2n,
+      20n,
+      13_348_638_305_456_000n,
+      1n,
+      "",
+      0x60000000n,
+      0n,
+      200n,
+      0,
+      0n,
+      "",
+      0n,
+      0n,
+      0n,
+      0,
+      1,
+      0n,
+      null,
+    );
+  return { source, writer };
+}
+
+async function createHotJournalSource(root: string): Promise<{
+  readonly source: string;
+  readonly writer: ChildProcess;
+}> {
+  const source = join(root, "journal-source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  const rows = Array.from({ length: 300 }, (_, index) => {
+    const id = BigInt(index + 1);
+    return {
+      id,
+      urlId: id + 1000n,
+      url:
+        index === 0
+          ? "https://journal-target.example/"
+          : `https://filler-${index}.example/${"x".repeat(900)}`,
+      title: index === 0 ? "Journal target" : `Filler ${index}`,
+      visitTime: 13_348_638_245_123_456n + id,
+      fromVisit: 0n,
+      transition: 1n,
+      duration: id,
+    };
+  });
+  const historyPath = join(source, "Default", "History");
+  await createHistory(historyPath, rows);
+  const childCode = `
+    import { DatabaseSync } from "node:sqlite";
+    const database = new DatabaseSync(process.argv[1]);
+    database.exec("PRAGMA journal_mode=DELETE; PRAGMA cache_size=1; PRAGMA cache_spill=ON; PRAGMA synchronous=FULL; BEGIN IMMEDIATE;");
+    database.prepare("DELETE FROM visits WHERE id = 1").run();
+    database.prepare("DELETE FROM urls WHERE id = 1001").run();
+    const update = database.prepare("UPDATE visits SET app_id = ? WHERE id = ?");
+    for (let id = 2; id <= 300; id += 1) {
+      update.run("changed-" + "y".repeat(1000), id);
+    }
+    process.stdout.write("READY\\n");
+    setInterval(() => undefined, 1000);
+  `;
+  const writer = spawn(
+    process.execPath,
+    ["--input-type=module", "-e", childCode, historyPath],
+    { stdio: ["ignore", "pipe", "inherit"] },
+  );
+  if (writer.stdout === null) {
+    throw new Error("Hot-journal writer has no stdout.");
+  }
+  let output = "";
+  for await (const chunk of writer.stdout) {
+    output += String(chunk);
+    if (output.includes("READY")) {
+      break;
+    }
+  }
+  if (!output.includes("READY")) {
+    throw new Error(
+      "Hot-journal writer stopped before the transaction spilled.",
+    );
+  }
+  return { source, writer };
+}
+
+async function stopHotJournalWriter(writer: ChildProcess): Promise<void> {
+  if (writer.exitCode !== null || writer.signalCode !== null) {
+    return;
+  }
+  writer.kill("SIGKILL");
+  await once(writer, "exit");
+}
+
+async function createLegacyHistorySource(root: string): Promise<string> {
+  const source = join(root, "legacy-source");
+  await mkdir(join(source, "Default"), { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  const database = new DatabaseSync(join(source, "Default", "History"));
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '16'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY,
+        url LONGVARCHAR,
+        title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL
+      );
+      INSERT INTO urls VALUES (
+        1, 'https://legacy.example/', 'Legacy', 1, 0,
+        1704164645123456, 0
+      );
+      INSERT INTO visits VALUES (
+        1, 1, 1704164645123456, 0, 1, 0, 42, 0
+      );
+    `);
+  } finally {
+    database.close();
+  }
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI History Finding pipeline", () => {
+  it("analyses committed History across Profiles and returns bounded keyset pages", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-history-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const sourceHistoryBytes = await readFile(
+      join(source, "Default", "History"),
+    );
+    const caseDirectory = join(root, "CASE-HISTORY");
+
+    const ingest = runCli([
+      "ingest",
+      source,
+      "--case",
+      caseDirectory,
+      "--json",
+    ]);
+    expect(ingest.status).toBe(0);
+
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      status: "verified",
+      command: "analyse",
+      analysisStatus: "ready",
+      artifactCount: 2,
+      history: {
+        status: "complete",
+        profileCount: 2,
+        committedVisitCount: 3,
+        recoveredVisitCount: 0,
+      },
+    });
+
+    const firstCommand = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--view",
+      "visits",
+      "--sort",
+      "visit-time",
+      "--direction",
+      "asc",
+      "--limit",
+      "2",
+      "--json",
+    ]);
+    expect(firstCommand.status).toBe(0);
+    const first = parseJson<HistoryPage>(firstCommand.stdout);
+    expect(first).toMatchObject({
+      status: "ok",
+      command: "history",
+      view: "visits",
+      limit: 2,
+    });
+    expect(first.items).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+    expect(first.items.map((row) => row.profile)).toEqual([
+      "Default",
+      "Default",
+    ]);
+
+    const [start, redirected] = first.items;
+    expect(start).toBeDefined();
+    expect(start).toMatchObject({
+      recordType: "finding",
+      findingKind: "history_visit",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        sourceId: expect.any(String),
+        manifestEntryId: expect.any(String),
+        manifestEntryOrdinal: expect.any(Number),
+        manifestPath: "Default/History",
+        database: "Default/History",
+        table: "visits",
+        rowId: "1",
+      },
+      fields: {
+        visitId: { state: "value", value: "1" },
+        url: { state: "value", value: "https://alpha.example/start" },
+        title: { state: "value", value: "Alpha start" },
+        visitTime: {
+          state: "value",
+          value: {
+            raw: "13348638245123456",
+            epochFamily: "1601-us",
+            utc: "2024-01-02T03:04:05.123456Z",
+            declaredTimezone: "America/New_York",
+            resolution: "verified_schema_version_70",
+          },
+          synthetic: false,
+        },
+        fromVisit: { state: "value", value: "0" },
+        externalReferrerUrl: { state: "value", value: "" },
+        transitionRaw: { state: "value", value: "268435457" },
+        transitionCore: { state: "value", value: "typed" },
+        transitionQualifiers: {
+          state: "value",
+          value: ["chain_start"],
+        },
+        redirectToVisitIds: { state: "value", value: ["2"] },
+        visitSource: { state: "value", value: "browsed" },
+        visitDurationMicros: { state: "value", value: "2500000" },
+        originatorCacheGuid: {
+          state: "value",
+          value: "origin-cache-guid",
+        },
+        appId: { state: "value", value: "com.example.browser" },
+      },
+    });
+    expect(redirected?.fields).toMatchObject({
+      redirectFromVisitId: { state: "value", value: "1" },
+      transitionCore: { state: "value", value: "link" },
+      transitionQualifiers: {
+        state: "value",
+        value: ["chain_end", "client_redirect"],
+      },
+      visitSource: { state: "value", value: "extension" },
+    });
+
+    const secondCommand = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--view",
+      "visits",
+      "--sort",
+      "visit-time",
+      "--direction",
+      "asc",
+      "--limit",
+      "2",
+      "--after",
+      first.nextCursor as string,
+      "--json",
+    ]);
+    expect(secondCommand.status).toBe(0);
+    const second = parseJson<HistoryPage>(secondCommand.stdout);
+    expect(second.items.map((row) => row.profile)).toEqual(["Profile 1"]);
+    expect(second.nextCursor).toBeNull();
+    expect(
+      new Set(
+        [...first.items, ...second.items].map((row) => row.provenance.rowId),
+      ).size,
+    ).toBe(3);
+
+    const filtered = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--view",
+      "visits",
+      "--profile",
+      "Default",
+      "--profile",
+      "Profile 1",
+      "--commit-state",
+      "committed",
+      "--search",
+      "beta.example",
+      "--sort",
+      "url",
+      "--direction",
+      "asc",
+      "--limit",
+      "10",
+      "--json",
+    ]);
+    expect(filtered.status).toBe(0);
+    expect(parseJson<HistoryPage>(filtered.stdout).items).toMatchObject([
+      {
+        recordType: "finding",
+        profile: "Profile 1",
+        fields: {
+          url: { state: "value", value: "https://beta.example/" },
+        },
+      },
+    ]);
+
+    const microsecondRange = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--search",
+        "alpha.example",
+        "--from",
+        "2024-01-02T03:04:05.123Z",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(microsecondRange.items).toHaveLength(2);
+
+    const exactMicrosecondRange = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--search",
+        "alpha.example",
+        "--from",
+        "2024-01-02T03:04:05.123456Z",
+        "--to",
+        "2024-01-02T03:04:05.123456Z",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(exactMicrosecondRange.items).toHaveLength(1);
+    expect(exactMicrosecondRange.items[0]?.provenance.rowId).toBe("1");
+
+    const timezoneLess = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--from",
+      "2024-01-02T03:04:05",
+      "--limit",
+      "10",
+      "--json",
+    ]);
+    expect(timezoneLess.status).toBe(1);
+    expect(
+      parseJson<Record<string, unknown>>(timezoneLess.stderr),
+    ).toMatchObject({ code: "INVALID_ARGUMENT" });
+
+    const invalidCalendar = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--from",
+      "2024-02-30T03:04:05Z",
+      "--limit",
+      "10",
+      "--json",
+    ]);
+    expect(invalidCalendar.status).toBe(1);
+    expect(
+      parseJson<Record<string, unknown>>(invalidCalendar.stderr),
+    ).toMatchObject({ code: "INVALID_ARGUMENT" });
+
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const staleCursor = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--view",
+      "visits",
+      "--sort",
+      "visit-time",
+      "--direction",
+      "asc",
+      "--limit",
+      "2",
+      "--after",
+      first.nextCursor as string,
+      "--json",
+    ]);
+    expect(staleCursor.status).toBe(1);
+    expect(
+      parseJson<Record<string, unknown>>(staleCursor.stderr),
+    ).toMatchObject({ code: "INVALID_CURSOR" });
+
+    expect(await readFile(join(source, "Default", "History"))).toEqual(
+      sourceHistoryBytes,
+    );
+  });
+
+  it("returns auditable activity, most-visited, and duration summaries", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-history-summary-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const caseDirectory = join(root, "CASE-SUMMARY");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    expect(
+      runCli([
+        "analyse",
+        "--case",
+        caseDirectory,
+        "--timezone",
+        "America/New_York",
+        "--json",
+      ]).status,
+    ).toBe(0);
+
+    const activity = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--view",
+        "activity",
+        "--sort",
+        "local-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(activity.items[0]?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ table: "visits", rowId: "2" }),
+        expect.objectContaining({ table: "urls", rowId: "10" }),
+        expect.objectContaining({ table: "urls", rowId: "11" }),
+        expect.objectContaining({ table: "visit_source", rowId: "2" }),
+      ]),
+    );
+    expect(activity.items[0]).toMatchObject({
+      recordType: "finding",
+      findingKind: "history_activity_summary",
+      profile: "Default",
+      commitState: "committed",
+      fields: {
+        localDate: { state: "value", value: "2024-01-01" },
+        localHour: { state: "value", value: "22" },
+        declaredTimezone: {
+          state: "value",
+          value: "America/New_York",
+        },
+        supportingVisitCount: { state: "value", value: "2" },
+        visitsWithDurationCount: { state: "value", value: "2" },
+        visitsWithoutDurationCount: { state: "value", value: "0" },
+        totalDurationMicros: { state: "value", value: "7500000" },
+      },
+    });
+    const mostVisited = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--view",
+        "most-visited",
+        "--search",
+        "redirected",
+        "--sort",
+        "visit-count",
+        "--direction",
+        "desc",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(mostVisited.items).toMatchObject([
+      {
+        recordType: "finding",
+        findingKind: "history_most_visited_summary",
+        fields: {
+          url: {
+            state: "value",
+            value: "https://alpha.example/redirected",
+          },
+          supportingVisitCount: { state: "value", value: "1" },
+        },
+      },
+    ]);
+
+    const durations = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--view",
+        "durations",
+        "--profile",
+        "Default",
+        "--sort",
+        "duration",
+        "--direction",
+        "desc",
+        "--limit",
+        "1",
+        "--json",
+      ]).stdout,
+    );
+    expect(durations.items).toHaveLength(1);
+    expect(durations.items[0]).toMatchObject({
+      recordType: "finding",
+      findingKind: "history_duration_summary",
+      fields: {
+        supportingVisitCount: { state: "value", value: "1" },
+        visitsWithDurationCount: { state: "value", value: "1" },
+        visitsWithoutDurationCount: { state: "value", value: "0" },
+        totalDurationMicros: { state: "value", value: "5000000" },
+        averageDurationMicros: { state: "value", value: "5000000" },
+      },
+    });
+    expect(durations.nextCursor).not.toBeNull();
+    const decodedCursor = JSON.parse(
+      Buffer.from(durations.nextCursor as string, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    const oversizedCursor = Buffer.from(
+      JSON.stringify({ ...decodedCursor, key: "9223372036854775808" }),
+      "utf8",
+    ).toString("base64url");
+    const oversized = runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--view",
+      "durations",
+      "--profile",
+      "Default",
+      "--sort",
+      "duration",
+      "--direction",
+      "desc",
+      "--limit",
+      "1",
+      "--after",
+      oversizedCursor,
+      "--json",
+    ]);
+    expect(oversized.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(oversized.stderr)).toMatchObject({
+      code: "INVALID_CURSOR",
+    });
+  });
+
+  it("keeps WAL-resident visits separate with sidecar Provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-history-wal-"));
+    temporaryRoots.push(root);
+    const { source, writer } = await createWalSource(root);
+    const caseDirectory = join(root, "CASE-WAL");
+    try {
+      const ingest = runCli([
+        "ingest",
+        source,
+        "--case",
+        caseDirectory,
+        "--json",
+      ]);
+      expect(ingest.status).toBe(0);
+    } finally {
+      writer.close();
+    }
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      history: {
+        committedVisitCount: 3,
+        recoveredVisitCount: 4,
+        candidateCount: 0,
+      },
+    });
+
+    const committed = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(3);
+    const committedParent = committed.items.find(
+      (item) => item.provenance.rowId === "1",
+    );
+    expect(committedParent?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          manifestPath: "Default/History-wal",
+          table: "visits",
+          rowId: "2",
+        }),
+      ]),
+    );
+    expect(committedParent).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/History" },
+      fields: {
+        url: { state: "value", value: "https://committed.example/" },
+        redirectToVisitIds: { state: "value", value: ["2"] },
+      },
+    });
+
+    const recovered = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--search",
+        "wal.example",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/History-wal",
+        database: "Default/History",
+        table: "visits",
+        rowId: "2",
+      },
+      fields: {
+        url: { state: "value", value: "https://wal.example/" },
+        redirectFromVisitId: { state: "value", value: "1" },
+      },
+    });
+    expect(recovered.items[0]?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          manifestPath: "Default/History-wal",
+          table: "urls",
+          rowId: "20",
+        }),
+      ]),
+    );
+    const recoveredProvenanceKeys = (
+      recovered.items[0]?.provenance.supportingRows ?? []
+    ).map(
+      (row) =>
+        `${row.manifestEntryId}:${row.database}:${row.table}:${row.rowId}`,
+    );
+    expect(new Set(recoveredProvenanceKeys).size).toBe(
+      recoveredProvenanceKeys.length,
+    );
+
+    const urlOnly = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--search",
+        "url changed in wal",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(urlOnly.items).toHaveLength(1);
+    expect(urlOnly.items[0]).toMatchObject({
+      provenance: {
+        manifestPath: "Default/History",
+        table: "visits",
+        rowId: "1",
+      },
+      fields: { title: { state: "value", value: "URL changed in WAL" } },
+    });
+    expect(urlOnly.items[0]?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          manifestPath: "Default/History-wal",
+          table: "urls",
+          rowId: "10",
+        }),
+      ]),
+    );
+
+    const visitOnly = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--search",
+        "visit-update.example",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(visitOnly.items).toHaveLength(1);
+    expect(visitOnly.items[0]).toMatchObject({
+      provenance: {
+        manifestPath: "Default/History-wal",
+        table: "visits",
+        rowId: "3",
+      },
+      fields: { visitDurationMicros: { state: "value", value: "333" } },
+    });
+    expect(visitOnly.items[0]?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          manifestPath: "Default/History",
+          table: "urls",
+          rowId: "30",
+        }),
+      ]),
+    );
+
+    const deletedJoinedRows = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--sort",
+        "visit-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "100",
+        "--json",
+      ]).stdout,
+    ).items.find((item) => item.provenance.rowId === "4");
+    expect(deletedJoinedRows).toMatchObject({
+      provenance: {
+        manifestPath: "Default/History",
+        table: "visits",
+        rowId: "4",
+      },
+      fields: {
+        url: { state: "unavailable", reason: "related_row_missing" },
+        visitSource: { state: "value", value: "browsed" },
+      },
+    });
+    expect(deletedJoinedRows?.provenance.supportingRows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          manifestPath: "Default/History-wal",
+          table: "urls",
+          rowId: "40",
+        }),
+        expect.objectContaining({
+          manifestPath: "Default/History-wal",
+          table: "visit_source",
+          rowId: "4",
+        }),
+      ]),
+    );
+  });
+
+  it("recovers rollback-journal rows without merging their Commit State", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-history-journal-"));
+    temporaryRoots.push(root);
+    const { source, writer } = await createHotJournalSource(root);
+    const caseDirectory = join(root, "CASE-JOURNAL");
+    try {
+      const ingest = runCli([
+        "ingest",
+        source,
+        "--case",
+        caseDirectory,
+        "--json",
+      ]);
+      expect(ingest.status).toBe(0);
+    } finally {
+      await stopHotJournalWriter(writer);
+    }
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      history: {
+        committedVisitCount: expect.any(Number),
+        recoveredVisitCount: 300,
+        candidateCount: 0,
+      },
+    });
+
+    const committed = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--search",
+        "journal-target",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(0);
+
+    const recovered = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "journal_resident",
+        "--search",
+        "journal-target",
+        "--limit",
+        "10",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      recordType: "finding",
+      commitState: "journal_resident",
+      provenance: {
+        manifestPath: "Default/History-journal",
+        database: "Default/History",
+        table: "visits",
+        rowId: "1",
+      },
+      fields: {
+        url: {
+          state: "value",
+          value: "https://journal-target.example/",
+        },
+      },
+    });
+  });
+
+  it("requires Declared Origin OS for version-16 epochs without creating Candidates", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-history-origin-"));
+    temporaryRoots.push(root);
+    const source = await createLegacyHistorySource(root);
+    const caseDirectory = join(root, "CASE-ORIGIN");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const withoutOrigin = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--json",
+    ]);
+    expect(withoutOrigin.status).toBe(0);
+    expect(
+      parseJson<Record<string, unknown>>(withoutOrigin.stdout),
+    ).toMatchObject({
+      history: { candidateCount: 0, declaredOriginOs: null },
+    });
+    const unavailableTimestamp = parseJson<HistoryPage>(
+      runCli(["history", "--case", caseDirectory, "--limit", "10", "--json"])
+        .stdout,
+    );
+    expect(unavailableTimestamp.items[0]).toMatchObject({
+      recordType: "finding",
+      fields: {
+        visitTime: {
+          state: "unavailable",
+          reason: "epoch_requires_declared_origin_os",
+        },
+        externalReferrerUrl: { state: "absent" },
+        appId: { state: "absent" },
+      },
+    });
+
+    const withOrigin = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--origin-os",
+      "linux",
+      "--timezone",
+      "UTC",
+      "--json",
+    ]);
+    expect(withOrigin.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(withOrigin.stdout)).toMatchObject(
+      {
+        history: { candidateCount: 0, declaredOriginOs: "linux" },
+      },
+    );
+    const resolvedTimestamp = parseJson<HistoryPage>(
+      runCli(["history", "--case", caseDirectory, "--limit", "10", "--json"])
+        .stdout,
+    );
+    expect(resolvedTimestamp.items).toHaveLength(1);
+    expect(resolvedTimestamp.items[0]).toMatchObject({
+      recordType: "finding",
+      fields: {
+        visitTime: {
+          state: "value",
+          value: {
+            raw: "1704164645123456",
+            epochFamily: "unix-us",
+            utc: "2024-01-02T03:04:05.123456Z",
+            declaredTimezone: "UTC",
+            resolution: "verified_schema_version_16_declared_origin_os_linux",
+          },
+          synthetic: false,
+        },
+      },
+    });
+
+    const caseDatabase = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readBigInts: true,
+    });
+    try {
+      expect(
+        caseDatabase
+          .prepare("SELECT count(*) AS count FROM analysis_runs")
+          .get(),
+      ).toEqual({ count: 2n });
+      expect(
+        caseDatabase
+          .prepare("SELECT count(*) AS count FROM forensic_candidates")
+          .get(),
+      ).toEqual({ count: 0n });
+      expect(
+        caseDatabase
+          .prepare(
+            "SELECT count(*) AS count FROM history_artifact_results WHERE active = 1",
+          )
+          .get(),
+      ).toEqual({ count: 1n });
+    } finally {
+      caseDatabase.close();
+    }
+  });
+});

--- a/e2e/history-cli.test.ts
+++ b/e2e/history-cli.test.ts
@@ -1210,7 +1210,7 @@ describe("compiled analyzer CLI History Finding pipeline", () => {
         },
       },
     });
-  });
+  }, 30_000);
 
   it("requires Declared Origin OS for version-16 epochs without creating Candidates", async () => {
     const root = await mkdtemp(join(tmpdir(), "forensix-history-origin-"));

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   },
   "scripts": {
     "build": "pnpm -r --if-present build",
-    "typecheck": "pnpm build && pnpm -r --if-present typecheck",
+    "typecheck": "pnpm build && pnpm -r --if-present typecheck && tsc -p tsconfig.contracts.json",
     "lint": "eslint core/src core/test cli/src server/src client/src e2e eslint.config.mjs vitest.config.ts && depcruise core/src cli/src server/src client/src --config .dependency-cruiser.cjs",
-    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
-    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
+    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
+    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
     "test": "pnpm build && vitest run",
     "verify": "pnpm format:check && pnpm lint && pnpm typecheck && vitest run"
   },

--- a/tsconfig.contracts.json
+++ b/tsconfig.contracts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["core/test/forensic-model.typecheck.ts"]
+}


### PR DESCRIPTION
Closes #168

## Scope

- Parse current History schemas across all Profiles in a Case.
- Keep committed, `wal_resident`, and `journal_resident` content separate.
- Enforce Field State, Finding/Candidate separation, and resolvable Provenance.
- Preserve raw timestamps, Epoch Family, UTC, Declared Timezone, and Declared Origin OS.
- Add bounded, searchable, filterable, sortable, keyset-paginated CLI queries.

## Verification

- `corepack pnpm verify`
- 13 tests covering History, WAL, hot journal, legacy epochs, pagination, and summaries

## Base

Started from `v2@ba690473dd65a24ddae9afbd0782329925e09d11` with no research ancestry.

## Residual risks

- Recovery reads SQLite-visible sidecar rows; it does not carve free pages.
- Tests use controlled History databases rather than a pinned real-Chrome fixture matrix.
- Million-row latency has not been measured.