### PR TITLE
feat(#187): capture authorized sealed key material

### DIFF
--- a/collector/CONFORMANCE.md
+++ b/collector/CONFORMANCE.md
@@ -31,3 +31,12 @@ The tests compare Manifest bytes and both digests exactly, run every language-ne
 The Evidence Set Digest is SHA-256 over canonical Manifest bytes.
 The Working Copy Digest uses the same construction over entries where `copied` is `true`.
 Both include the final LF for each line.
+
+## Key-material boundary
+
+Issue #187 adds a separate Collector-owned contract under `contracts/key-material/`.
+It does not add key files to the User Data Dir Manifest or the Selection Policy.
+
+Each key-material subtree has its own canonical Manifest and digest.
+The Acquisition Bundle Manifest covers that Manifest, its header, all sealed records, and all opaque wrapper evidence.
+The `strip-keys` operation removes the complete subtree and writes a new Acquisition Bundle Manifest and digest.

--- a/collector/README.md
+++ b/collector/README.md
@@ -1,19 +1,26 @@
 # ForensiX Collector
 
-`forensix-collect` is the independent, offline Go Collector for ForensiX v2. It scans live Windows, macOS, and Linux accounts and emits a directory-tree Acquisition Bundle.
+`forensix-collect` is the independent, offline Go Collector for ForensiX v2.
+It scans live Windows, macOS, and Linux accounts.
+It emits a directory-tree Acquisition Bundle.
 
 ## Safety boundary
 
 The Collector:
 
-- opens Source paths for reading only;
-- never starts, stops, or signals Chrome;
-- links no Go networking package and performs no update or telemetry check;
-- copies bytes without parsing Chrome artifacts or opening SQLite;
-- copies required browser evidence such as `Local State`, but does not perform the separate opt-in capture of live derived keys or key-store backing evidence;
-- records authorization as an operator-supplied claim that it witnesses but does not verify.
+- opens Source paths for reading only
+- never starts, stops, or signals Chrome
+- opens no IP network endpoint and imports no process-control package
+- performs no update or telemetry check
+- copies Source bytes without opening SQLite or decrypting Source data
+- reads Windows `Local State` only for the authorized OSCrypt wrapper capture
+- reads a live key store only after explicit key-capture opt-in
+- seals each derived row key before it writes the Acquisition Bundle
+- never writes a plaintext provider secret or derived row key
+- records authorization as an operator claim that it witnesses but does not verify
 
-Run it from removable media. Do not download it on the Source machine.
+Run the Collector from removable media.
+Do not download the Collector on the Source machine.
 
 ## Build and test
 
@@ -25,7 +32,9 @@ go vet ./...
 go build -trimpath ./cmd/forensix-collect
 ```
 
-The module is intentionally outside the analyzer pnpm workspace. It has no runtime dependencies; `golang.org/x/sys` provides native read-only OS account and environment APIs.
+The Collector is outside the analyzer pnpm workspace.
+The Collector has no runtime service dependency.
+It uses native key-store APIs and local Unix D-Bus only.
 
 ## Collect
 
@@ -33,12 +42,98 @@ The module is intentionally outside the analyzer pnpm workspace. It has no runti
 forensix-collect \
   --out ./BUNDLE-2026-014 \
   --operator examiner-7 \
-  --authorization-reference "CASE-2026-014; authorized by lab lead"
+  --authorization-reference "CASE-2026-014, authorized by lab lead"
 ```
 
-If confirmed liveness evidence is present, that User Data Dir is not copied until the operator either waits for Chrome to close or reruns with `--continue-if-chrome-running`. The Collector does not touch the process. A stale `SingletonLock` is recorded as Liveness Evidence but does not by itself prove Chrome is running.
+If Chrome Liveness Evidence is present, the Collector does not copy that User Data Dir.
+Wait for Chrome to stop, or add `--continue-if-chrome-running`.
+The Collector does not touch the Chrome process.
 
-Tier 2 bulk content is off by default. Add `--include-bulk` to opt in. Every source entry is still hashed and manifested when bulk content is not copied.
+Tier 2 bulk content is off by default.
+Add `--include-bulk` to copy Tier 2 content.
+The Collector always hashes and manifests every Source entry.
+
+## Capture authorized key material
+
+Key capture is off by default.
+It requires `--capture-key-material`, the Authorization Reference, and an X25519 public key.
+The private key stays with the investigator.
+
+1. Create an X25519 private key.
+
+   ```sh
+   openssl genpkey -algorithm X25519 -out key-material-private.pem
+   ```
+
+2. Create its public key file.
+
+   ```sh
+   openssl pkey -in key-material-private.pem -pubout -out key-material-public.pem
+   ```
+
+3. Store the private key away from the live machine.
+
+4. Run authorized capture with the public key.
+
+   ```sh
+   forensix-collect \
+     --out ./BUNDLE-2026-014 \
+     --operator examiner-7 \
+     --authorization-reference "CASE-2026-014, authorized by lab lead" \
+     --capture-key-material \
+     --key-material-recipient-file ./key-material-public.pem
+   ```
+
+The sealed record uses X25519, HKDF-SHA-256, and AES-256-GCM.
+The associated data covers the provider, context, policy, and wrapper references.
+The Collector records the public-key fingerprint in `collector_record.json`.
+
+### Provider bounds
+
+- macOS reads `Chrome Safe Storage` for account `Chrome` through the Keychain API.
+- Linux `basic` derives the demonstrated `v10` key from the Chrome basic provider.
+- Linux `gnome-libsecret` reads unlocked `application=chrome` items through a local Unix D-Bus session.
+- Linux `kwallet`, `kwallet5`, and `kwallet6` read an already-open `Chrome Keys/Chrome Safe Storage` entry.
+- Windows unwraps only the legacy current-user `DPAPI` wrapper from `Local State`.
+- Windows App-Bound `v20` records wrapper, version, and policy evidence only.
+
+Use `--linux-key-provider` to select a Linux provider.
+The value can be `auto`, `basic`, `gnome-libsecret`, `kwallet`, `kwallet5`, or `kwallet6`.
+The `auto` value selects KWallet for KDE sessions and Secret Service for other sessions.
+It never falls back to the known basic key.
+
+The Collector binds live key-store access to the current OS account.
+Other scanned accounts get reason `live-key-store-account-context-mismatch`.
+The Collector never attaches the current account key to another account.
+
+The Linux adapters refuse non-Unix D-Bus addresses.
+They do not create, unlock, or update key-store items.
+A locked or absent provider produces an `unavailable` record.
+
+Windows `v20` records use reason `unsupported-google-app-bound-key-variant`.
+They always set `usable_row_key` to `false`.
+The Collector never attempts an App-Bound unwrap.
+
+## Strip key material
+
+Create a new Acquisition Bundle without the key-material subtree:
+
+```sh
+forensix-collect strip-keys \
+  --out ./BUNDLE-2026-014-without-keys \
+  ./BUNDLE-2026-014
+```
+
+The command verifies the input Acquisition Bundle before it copies files.
+It refuses a missing, changed, or unmanifested file.
+It does not change the input Acquisition Bundle.
+
+The new `bundle_manifest.json` has these fields:
+
+- `key_material_captured: false`
+- `key_material_stripped: true`
+- `original_bundle_digest` with the input digest
+- a new `files` Manifest and `bundle_digest`
 
 ## Acquisition Bundle
 
@@ -53,8 +148,16 @@ The bundle root contains:
 - `bundle_manifest.json`
 - `collector_record.json`
 - `scan_record.json`
+- `key_material/` only after explicit key capture
 
-Reproduce an Evidence Set Digest with standard tools:
+Each key-material directory contains:
+
+- `key_material_manifest_header.json`
+- canonical, path-sorted `key_material_manifest.jsonl`
+- `records/` with sealed key records
+- `evidence/` with opaque provider wrappers, when present
+
+Reproduce the digests with standard tools:
 
 ```sh
 # Evidence Set Digest
@@ -62,12 +165,20 @@ LC_ALL=C sort manifest.jsonl | sha256sum
 
 # Working Copy Digest
 grep '"copied":true' manifest.jsonl | LC_ALL=C sort | sha256sum
+
+# Key-material Manifest digest
+LC_ALL=C sort key_material_manifest.jsonl | sha256sum
 ```
 
-`manifest.jsonl` is already emitted in byte order, so hashing it directly gives the same Evidence Set Digest.
+The Manifest files are already in byte order.
+A direct SHA-256 hash gives the same digest.
 
 ## Conformance status
 
-The Collector implements the canonical Analyzer contract owned by issue #167.
-Its Go tests consume the shared Manifest and Selection Policy fixtures directly and compare wire bytes and both digests exactly.
-See [`CONFORMANCE.md`](CONFORMANCE.md) for the boundary decisions and the explicit external-cache limitation.
+The Collector implements the canonical Analyzer contract from issue #167.
+Its tests read the shared Manifest and Selection Policy fixtures.
+The tests compare wire bytes and both Source digests.
+
+The key-material subtree has a separate Collector-owned contract.
+Read [`contracts/key-material/README.md`](contracts/key-material/README.md) for its schemas and digest rules.
+Read [`CONFORMANCE.md`](CONFORMANCE.md) for the Analyzer boundary.

--- a/collector/cmd/forensix-collect/main.go
+++ b/collector/cmd/forensix-collect/main.go
@@ -18,6 +18,13 @@ var (
 func main() { os.Exit(run(os.Args[1:])) }
 
 func run(args []string) int {
+	if len(args) > 0 && args[0] == "strip-keys" {
+		return runStripKeys(args[1:])
+	}
+	return runCollect(args)
+}
+
+func runCollect(args []string) int {
 	flags := flag.NewFlagSet("forensix-collect", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
 	out := flags.String("out", "", "new Acquisition Bundle directory")
@@ -25,6 +32,9 @@ func run(args []string) int {
 	authorization := flags.String("authorization-reference", "", "operator-supplied case and authorizing person/role claim")
 	includeBulk := flags.Bool("include-bulk", false, "copy Selection Policy Tier 2 bulk content")
 	continueRunning := flags.Bool("continue-if-chrome-running", false, "record liveness warning and collect without signaling Chrome")
+	captureKeys := flags.Bool("capture-key-material", false, "capture authorized derived key material sealed to an X25519 recipient")
+	keyRecipientFile := flags.String("key-material-recipient-file", "", "X25519 public key PEM or forensix recipient file")
+	linuxKeyProvider := flags.String("linux-key-provider", "auto", "Linux provider: auto, basic, gnome-libsecret, kwallet, kwallet5, or kwallet6")
 	showVersion := flags.Bool("version", false, "print collector version")
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -38,13 +48,51 @@ func run(args []string) int {
 		return 1
 	}
 
+	var recipient []byte
+	if *keyRecipientFile != "" {
+		content, err := os.ReadFile(*keyRecipientFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "collection failed: read key-material recipient: %v\n", err)
+			return 1
+		}
+		recipient, err = collector.ParseKeyMaterialRecipient(content)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "collection failed: %v\n", err)
+			return 1
+		}
+	}
 	runner := collector.Collector{Scanner: platformscanner.NewHostScanner()}
-	bundle, err := runner.Run(collector.Options{Output: *out, OperatorIdentifier: *operator, AuthorizationReference: *authorization, IncludeBulk: *includeBulk, ContinueIfRunning: *continueRunning, Version: version, Commit: commit})
+	bundle, err := runner.Run(collector.Options{
+		Output: *out, OperatorIdentifier: *operator, AuthorizationReference: *authorization,
+		IncludeBulk: *includeBulk, ContinueIfRunning: *continueRunning,
+		CaptureKeyMaterial: *captureKeys, KeyMaterialRecipient: recipient, LinuxKeyProvider: *linuxKeyProvider,
+		Version: version, Commit: commit,
+	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "collection failed: %v\n", err)
 		return 1
 	}
 	return reportResult(bundle, *out, os.Stderr)
+}
+
+func runStripKeys(args []string) int {
+	flags := flag.NewFlagSet("forensix-collect strip-keys", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	out := flags.String("out", "", "new Acquisition Bundle directory without key material")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(os.Stderr, "strip-keys requires one input Acquisition Bundle")
+		return 1
+	}
+	bundle, err := collector.StripKeys(flags.Arg(0), *out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "strip-keys failed: %v\n", err)
+		return 1
+	}
+	fmt.Printf("Acquisition Bundle: %s\nBundle Digest: %s\nOriginal Bundle Digest: %s\n", *out, bundle.BundleDigest, bundle.OriginalBundleDigest)
+	return 0
 }
 
 func reportResult(bundle collector.BundleManifest, output string, stderr io.Writer) int {

--- a/collector/cmd/forensix-collect/main_test.go
+++ b/collector/cmd/forensix-collect/main_test.go
@@ -2,9 +2,15 @@ package main
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/ChmaraX/forensix/collector/internal/collector"
+	"github.com/ChmaraX/forensix/collector/internal/conformance"
 )
 
 func TestExitCodeForPartialBundle(t *testing.T) {
@@ -18,5 +24,64 @@ func TestExitCodeForCompleteBundle(t *testing.T) {
 	bundle := collector.BundleManifest{BundleDigest: "digest", UserDataDirs: []collector.BundleUserDataDir{{Outcome: collector.Collected}}}
 	if got := reportResult(bundle, "/bundle", &bytes.Buffer{}); got != 0 {
 		t.Fatalf("exit=%d want=0", got)
+	}
+}
+
+func TestStripKeysSubcommandWritesNewBundle(t *testing.T) {
+	input := filepath.Join(t.TempDir(), "input")
+	if err := os.MkdirAll(filepath.Join(input, "key_material", "a", "udd-1"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	write := func(relative, content string) collector.BundleFile {
+		t.Helper()
+		path := filepath.Join(input, filepath.FromSlash(relative))
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256([]byte(content))
+		return collector.BundleFile{Path: relative, Size: int64(len(content)), SHA256: hex.EncodeToString(sum[:])}
+	}
+	files := []collector.BundleFile{
+		write("collector_record.json", "record"),
+		write("key_material/a/udd-1/key_material_manifest.jsonl", "key manifest"),
+		write("scan_record.json", "scan"),
+	}
+	encoded, err := json.Marshal(files)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifest := collector.BundleManifest{
+		SchemaVersion: "forensix-acquisition-bundle-draft/2", HashAlgorithm: conformance.HashAlgorithm,
+		KeyMaterialCaptureRequested: true, KeyMaterialCaptured: true,
+		UserDataDirs: []collector.BundleUserDataDir{}, KeyMaterial: []collector.BundleKeyMaterial{{AccountID: "a", BundlePath: "key_material/a/udd-1"}},
+		Files: files, BundleDigest: conformance.Digest(append(encoded, '\n')),
+	}
+	manifestBytes, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(input, "bundle_manifest.json"), append(manifestBytes, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	output := filepath.Join(t.TempDir(), "output")
+	if exit := run([]string{"strip-keys", "--out", output, input}); exit != 0 {
+		t.Fatalf("exit=%d", exit)
+	}
+	content, err := os.ReadFile(filepath.Join(output, "bundle_manifest.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stripped collector.BundleManifest
+	if err := json.Unmarshal(content, &stripped); err != nil {
+		t.Fatal(err)
+	}
+	if stripped.KeyMaterialCaptured || !stripped.KeyMaterialStripped || stripped.OriginalBundleDigest != manifest.BundleDigest {
+		t.Fatalf("strip-keys output=%#v", stripped)
+	}
+	if _, err := os.Stat(filepath.Join(output, "key_material")); !os.IsNotExist(err) {
+		t.Fatal("key-material subtree remains after strip-keys")
 	}
 }

--- a/collector/contracts/key-material/README.md
+++ b/collector/contracts/key-material/README.md
@@ -1,0 +1,56 @@
+# Key-material subtree contract
+
+This Collector-owned contract defines the separable `key_material/` subtree in an Acquisition Bundle.
+It does not change the canonical User Data Dir Manifest or Selection Policy.
+
+Each collected User Data Dir has this shape when the operator explicitly enables authorized key capture:
+
+```text
+key_material/<account-id>/udd-N/
+  key_material_manifest_header.json
+  key_material_manifest.jsonl
+  records/<record-id>.json
+  evidence/<opaque-wrapper>.bin      # when a provider has wrapper evidence
+```
+
+## Sealed material
+
+A `captured` record contains a derived OSCrypt row key sealed to an operator-supplied X25519 public key.
+The Collector creates one ephemeral X25519 key for each record.
+It derives a 32-byte seal key with HKDF-SHA-256.
+The HKDF salt is the decoded `salt` field.
+The HKDF info string is `forensix/key-material-seal/1`.
+
+The Collector seals the row key with AES-256-GCM.
+The `nonce` and `ciphertext` fields use padded standard base64.
+The ciphertext includes the 16-byte GCM tag.
+
+The associated data is one compact JSON line with `sealed_material` set to `null`.
+The line uses the record schema field order and ends with LF.
+This data authenticates the provider, context, policy, and evidence references.
+No plaintext provider secret or derived row key is serialized.
+
+`unsupported` and `unavailable` records have `usable_row_key: false` and `sealed_material: null`.
+A Windows App-Bound `v20` record preserves the exact decoded `Local State` wrapper as opaque evidence and records version `v20` plus policy reason `unsupported-google-app-bound-key-variant`.
+It never claims a usable row key.
+
+## Canonical Manifest
+
+`key_material_manifest.jsonl` contains every regular payload file under that User Data Dir's key-material subtree, excluding the Manifest and its header.
+Each line uses the field order in `key-material-manifest-entry.schema.json`, UTF-8, and LF.
+Lines are sorted by path in unsigned byte order.
+`manifest_digest` is SHA-256 over those exact Manifest bytes.
+
+Reproduce the digest with standard tools:
+
+```sh
+LC_ALL=C sort key_material_manifest.jsonl | sha256sum
+```
+
+The Acquisition Bundle's `bundle_manifest.json` also covers the key-material Manifest, header, sealed records, and opaque wrapper evidence.
+
+## Strip operation
+
+`forensix-collect strip-keys --out <new-bundle> <input-bundle>` verifies the input bundle, copies only manifested non-key files, removes the complete `key_material/` subtree, and writes a new bundle Manifest and digest.
+The new bundle records the original bundle digest and remains self-consistent without key material.
+The input Acquisition Bundle is never modified.

--- a/collector/contracts/key-material/key-material-manifest-entry.schema.json
+++ b/collector/contracts/key-material/key-material-manifest-entry.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forensix.dev/contracts/key-material-manifest-entry-v1.schema.json",
+  "title": "ForensiX key-material Manifest entry v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["path", "size", "hash_algorithm", "sha256"],
+  "properties": {
+    "path": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^(?!/)(?!.*\\\\)(?!.*(?:^|/)\\.\\.?(/|$)).+$"
+    },
+    "size": { "type": "integer", "minimum": 0 },
+    "hash_algorithm": { "const": "sha-256" },
+    "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+  }
+}

--- a/collector/contracts/key-material/key-material-manifest-header.schema.json
+++ b/collector/contracts/key-material/key-material-manifest-header.schema.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forensix.dev/contracts/key-material-manifest-header-v1.schema.json",
+  "title": "ForensiX key-material Manifest header v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["manifest_schema", "hash_algorithm", "manifest_digest", "entry_count"],
+  "properties": {
+    "manifest_schema": { "const": "forensix/key-material-manifest/1" },
+    "hash_algorithm": { "const": "sha-256" },
+    "manifest_digest": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+    "entry_count": { "type": "integer", "minimum": 1 }
+  }
+}

--- a/collector/contracts/key-material/key-material-record.schema.json
+++ b/collector/contracts/key-material/key-material-record.schema.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://forensix.dev/contracts/key-material-record-v1.schema.json",
+  "title": "ForensiX sealed key-material record v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "record_id",
+    "capture_state",
+    "key_kind",
+    "usable_row_key",
+    "provider",
+    "context",
+    "policy",
+    "evidence",
+    "sealed_material"
+  ],
+  "properties": {
+    "schema_version": { "const": "forensix/key-material-record/1" },
+    "record_id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$" },
+    "capture_state": { "enum": ["captured", "unsupported", "unavailable"] },
+    "key_kind": { "const": "oscrypt_row_key" },
+    "usable_row_key": { "type": "boolean" },
+    "provider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["platform", "name", "item", "scope"],
+      "properties": {
+        "platform": { "enum": ["darwin", "linux", "windows", "unknown"] },
+        "name": { "type": "string", "minLength": 1 },
+        "item": { "type": "string", "minLength": 1 },
+        "scope": { "type": "string", "minLength": 1 }
+      }
+    },
+    "context": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "value"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "value": { "type": "string" }
+        }
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["row_prefix", "support"],
+      "properties": {
+        "row_prefix": { "enum": ["", "v10", "v11", "v20"] },
+        "support": { "enum": ["supported", "unsupported", "unavailable"] },
+        "reason": { "type": "string", "minLength": 1 }
+      }
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "sha256"],
+        "properties": {
+          "path": { "type": "string", "pattern": "^evidence/" },
+          "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+          "version": { "type": "string", "minLength": 1 },
+          "policy": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "sealed_material": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "algorithm",
+            "recipient_fingerprint",
+            "ephemeral_public_key",
+            "salt",
+            "nonce",
+            "ciphertext",
+            "associated_data_sha256"
+          ],
+          "properties": {
+            "algorithm": { "const": "x25519-hkdf-sha256-aes-256-gcm" },
+            "recipient_fingerprint": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+            "ephemeral_public_key": { "type": "string", "contentEncoding": "base64" },
+            "salt": { "type": "string", "contentEncoding": "base64" },
+            "nonce": { "type": "string", "contentEncoding": "base64" },
+            "ciphertext": { "type": "string", "contentEncoding": "base64" },
+            "associated_data_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      ]
+    }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "capture_state": { "const": "captured" } }, "required": ["capture_state"] },
+      "then": {
+        "properties": {
+          "usable_row_key": { "const": true },
+          "sealed_material": { "type": "object" }
+        }
+      },
+      "else": {
+        "properties": {
+          "usable_row_key": { "const": false },
+          "sealed_material": { "type": "null" }
+        }
+      }
+    }
+  ]
+}

--- a/collector/go.mod
+++ b/collector/go.mod
@@ -2,4 +2,8 @@ module github.com/ChmaraX/forensix/collector
 
 go 1.24.0
 
-require golang.org/x/sys v0.41.0
+require (
+	github.com/ebitengine/purego v0.10.2
+	github.com/godbus/dbus/v5 v5.2.2
+	golang.org/x/sys v0.41.0
+)

--- a/collector/go.sum
+++ b/collector/go.sum
@@ -1,2 +1,6 @@
+github.com/ebitengine/purego v0.10.2 h1:W809HbnvzAxgdm+aOvlSekrM16wGCdT/e76+9tS7gzE=
+github.com/ebitengine/purego v0.10.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 golang.org/x/sys v0.41.0 h1:Ivj+2Cp/ylzLiEU89QhWblYnOE9zerudt9Ftecq2C6k=
 golang.org/x/sys v0.41.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=

--- a/collector/internal/collector/accountidentity_unix.go
+++ b/collector/internal/collector/accountidentity_unix.go
@@ -1,0 +1,15 @@
+//go:build linux || darwin
+
+package collector
+
+import "os/user"
+
+func currentAccountID() (string, error) {
+	account, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	return account.Username, nil
+}
+
+func accountIDsEqual(current, scanned string) bool { return current == scanned }

--- a/collector/internal/collector/accountidentity_windows.go
+++ b/collector/internal/collector/accountidentity_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package collector
+
+import (
+	"strings"
+
+	"golang.org/x/sys/windows"
+)
+
+func currentAccountID() (string, error) {
+	account, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+	return account.User.Sid.String(), nil
+}
+
+func accountIDsEqual(current, scanned string) bool { return strings.EqualFold(current, scanned) }

--- a/collector/internal/collector/bundle.go
+++ b/collector/internal/collector/bundle.go
@@ -40,11 +40,19 @@ func bundleFiles(root string) ([]BundleFile, string, error) {
 		return nil, "", err
 	}
 	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
-	encoded, err := json.Marshal(files)
+	digest, err := bundleFileDigest(files)
 	if err != nil {
 		return nil, "", err
 	}
-	return files, conformance.Digest(append(encoded, '\n')), nil
+	return files, digest, nil
+}
+
+func bundleFileDigest(files []BundleFile) (string, error) {
+	encoded, err := json.Marshal(files)
+	if err != nil {
+		return "", err
+	}
+	return conformance.Digest(append(encoded, '\n')), nil
 }
 
 func rejectOutputInsideSources(output string, found []platformscanner.UserDataDir) error {

--- a/collector/internal/collector/collector.go
+++ b/collector/internal/collector/collector.go
@@ -1,8 +1,10 @@
 package collector
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,12 +22,19 @@ type Options struct {
 	AuthorizationReference string
 	IncludeBulk            bool
 	ContinueIfRunning      bool
+	CaptureKeyMaterial     bool
+	KeyMaterialRecipient   []byte
+	LinuxKeyProvider       string
 	Version                string
 	Commit                 string
 	Now                    func() time.Time
 }
 
-type Collector struct{ Scanner platformscanner.Scanner }
+type Collector struct {
+	Scanner     platformscanner.Scanner
+	KeyCapturer KeyCapturer
+	Random      io.Reader
+}
 
 type CollectionOutcome string
 
@@ -50,15 +59,23 @@ type CollectorRecord struct {
 		WitnessedByCollector bool   `json:"witnessed_by_collector"`
 		AuthorityVerified    bool   `json:"authority_verified"`
 	} `json:"authorization_claim"`
-	StartedAt         time.Time        `json:"started_at"`
-	EndedAt           time.Time        `json:"ended_at"`
-	HostReportedLocal HostReportedTime `json:"host_reported_local_time"`
-	Hostname          string           `json:"hostname"`
-	OS                string           `json:"os"`
-	OSVersion         EnvironmentValue `json:"os_version"`
-	Architecture      string           `json:"architecture"`
-	MachineIdentifier EnvironmentValue `json:"machine_identifier"`
-	NetworkCalls      string           `json:"network_calls"`
+	StartedAt          time.Time          `json:"started_at"`
+	EndedAt            time.Time          `json:"ended_at"`
+	HostReportedLocal  HostReportedTime   `json:"host_reported_local_time"`
+	Hostname           string             `json:"hostname"`
+	OS                 string             `json:"os"`
+	OSVersion          EnvironmentValue   `json:"os_version"`
+	Architecture       string             `json:"architecture"`
+	MachineIdentifier  EnvironmentValue   `json:"machine_identifier"`
+	NetworkCalls       string             `json:"network_calls"`
+	KeyMaterialCapture KeyMaterialCapture `json:"key_material_capture"`
+}
+
+type KeyMaterialCapture struct {
+	Requested              bool   `json:"requested"`
+	AuthorizationReference string `json:"authorization_reference,omitempty"`
+	SealingAlgorithm       string `json:"sealing_algorithm,omitempty"`
+	RecipientFingerprint   string `json:"recipient_fingerprint,omitempty"`
 }
 
 type EnvironmentValue struct {
@@ -91,13 +108,27 @@ type BundleFile struct {
 	Size   int64  `json:"size"`
 	SHA256 string `json:"sha256"`
 }
+
+type BundleKeyMaterial struct {
+	AccountID         string `json:"account_id"`
+	BundlePath        string `json:"bundle_path"`
+	CaptureState      string `json:"capture_state"`
+	ManifestDigest    string `json:"manifest_digest"`
+	EntryCount        int    `json:"entry_count"`
+	UsableRowKeyCount int    `json:"usable_row_key_count"`
+}
+
 type BundleManifest struct {
-	SchemaVersion       string              `json:"schema_version"`
-	HashAlgorithm       string              `json:"hash_algorithm"`
-	KeyMaterialCaptured bool                `json:"key_material_captured"`
-	UserDataDirs        []BundleUserDataDir `json:"user_data_dirs"`
-	Files               []BundleFile        `json:"files"`
-	BundleDigest        string              `json:"bundle_digest"`
+	SchemaVersion               string              `json:"schema_version"`
+	HashAlgorithm               string              `json:"hash_algorithm"`
+	KeyMaterialCaptureRequested bool                `json:"key_material_capture_requested"`
+	KeyMaterialCaptured         bool                `json:"key_material_captured"`
+	KeyMaterialStripped         bool                `json:"key_material_stripped"`
+	OriginalBundleDigest        string              `json:"original_bundle_digest,omitempty"`
+	UserDataDirs                []BundleUserDataDir `json:"user_data_dirs"`
+	KeyMaterial                 []BundleKeyMaterial `json:"key_material"`
+	Files                       []BundleFile        `json:"files"`
+	BundleDigest                string              `json:"bundle_digest"`
 }
 
 func (c Collector) Run(opts Options) (BundleManifest, error) {
@@ -106,6 +137,12 @@ func (c Collector) Run(opts Options) (BundleManifest, error) {
 	}
 	if opts.Now == nil {
 		opts.Now = time.Now
+	}
+	if c.Random == nil {
+		c.Random = rand.Reader
+	}
+	if opts.CaptureKeyMaterial && c.KeyCapturer == nil {
+		c.KeyCapturer = NewHostKeyCapturer(opts.LinuxKeyProvider)
 	}
 	startedHost := opts.Now()
 	scan := c.Scanner.Scan()
@@ -123,7 +160,10 @@ func (c Collector) Run(opts Options) (BundleManifest, error) {
 			_ = os.RemoveAll(tmp)
 		}
 	}()
-	manifest := BundleManifest{SchemaVersion: "forensix-acquisition-bundle-draft/1", HashAlgorithm: conformance.HashAlgorithm}
+	manifest := BundleManifest{
+		SchemaVersion: "forensix-acquisition-bundle-draft/2", HashAlgorithm: conformance.HashAlgorithm,
+		KeyMaterialCaptureRequested: opts.CaptureKeyMaterial, KeyMaterial: []BundleKeyMaterial{},
+	}
 	if err := conformance.WriteJSON(filepath.Join(tmp, "scan_record.json"), ScanRecord{Attempts: scan.Attempts}); err != nil {
 		return manifest, err
 	}
@@ -143,7 +183,17 @@ func (c Collector) Run(opts Options) (BundleManifest, error) {
 			_ = os.RemoveAll(staging)
 		}
 		manifest.UserDataDirs = append(manifest.UserDataDirs, outcome)
+		if opts.CaptureKeyMaterial && outcome.Outcome == Collected {
+			keyRel := filepath.ToSlash(filepath.Join("key_material", safeComponent(found.AccountID), fmt.Sprintf("udd-%d", indexForAccount(scan.Found, index))))
+			capture := c.KeyCapturer.Capture(found)
+			summary, err := writeKeyMaterialSubtree(filepath.Join(tmp, filepath.FromSlash(keyRel)), keyRel, found.AccountID, capture, opts.KeyMaterialRecipient, c.Random)
+			if err != nil {
+				return manifest, err
+			}
+			manifest.KeyMaterial = append(manifest.KeyMaterial, summary)
+		}
 	}
+	manifest.KeyMaterialCaptured = len(manifest.KeyMaterial) > 0
 
 	endedHost := opts.Now()
 	record := collectorRecord(opts, startedHost, endedHost)
@@ -254,8 +304,17 @@ func validateOptions(scanner platformscanner.Scanner, opts Options) error {
 	if opts.OperatorIdentifier == "" {
 		return errors.New("operator identifier is required")
 	}
-	if opts.AuthorizationReference == "" {
+	if strings.TrimSpace(opts.AuthorizationReference) == "" {
 		return errors.New("authorization reference is required as a witnessed operator claim")
+	}
+	if opts.CaptureKeyMaterial && len(opts.KeyMaterialRecipient) != 32 {
+		return errors.New("key-material capture requires a 32-byte X25519 recipient public key")
+	}
+	if !opts.CaptureKeyMaterial && len(opts.KeyMaterialRecipient) != 0 {
+		return errors.New("key-material recipient requires explicit key-material capture opt-in")
+	}
+	if opts.LinuxKeyProvider != "" && !validLinuxKeyProvider(opts.LinuxKeyProvider) {
+		return fmt.Errorf("unsupported Linux key provider %q", opts.LinuxKeyProvider)
 	}
 	return nil
 }
@@ -276,7 +335,7 @@ func prepareOutput(output string) error {
 }
 
 func safeComponent(value string) string {
-	value = strings.ReplaceAll(value, string(filepath.Separator), "_")
+	value = strings.NewReplacer("/", "_", `\`, "_", ":", "_").Replace(value)
 	if value == "" || value == "." || value == ".." {
 		return "unknown"
 	}

--- a/collector/internal/collector/environment.go
+++ b/collector/internal/collector/environment.go
@@ -21,6 +21,12 @@ func collectorRecord(opts Options, startedHost, endedHost time.Time) CollectorRe
 	record.AuthorizationClaim.Reference = opts.AuthorizationReference
 	record.AuthorizationClaim.WitnessedByCollector = true
 	record.AuthorizationClaim.AuthorityVerified = false
+	record.KeyMaterialCapture.Requested = opts.CaptureKeyMaterial
+	if opts.CaptureKeyMaterial {
+		record.KeyMaterialCapture.AuthorizationReference = opts.AuthorizationReference
+		record.KeyMaterialCapture.SealingAlgorithm = keyMaterialSealingAlgorithm
+		record.KeyMaterialCapture.RecipientFingerprint = recipientFingerprint(opts.KeyMaterialRecipient)
+	}
 	return record
 }
 

--- a/collector/internal/collector/keycapture_common.go
+++ b/collector/internal/collector/keycapture_common.go
@@ -1,0 +1,108 @@
+package collector
+
+import (
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+)
+
+const (
+	linuxProviderAuto      = "auto"
+	linuxProviderBasic     = "basic"
+	linuxProviderLibsecret = "gnome-libsecret"
+	linuxProviderKWallet   = "kwallet"
+	linuxProviderKWallet5  = "kwallet5"
+	linuxProviderKWallet6  = "kwallet6"
+)
+
+func currentAccountCanReadLiveStore(found platformscanner.UserDataDir) bool {
+	accountID, err := currentAccountID()
+	if err != nil || found.AccountID == "" || !accountIDsEqual(accountID, found.AccountID) {
+		return false
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+	home, err = realPath(home)
+	if err != nil {
+		return false
+	}
+	source, err := realPath(found.Path)
+	if err != nil {
+		return false
+	}
+	if runtime.GOOS == "windows" {
+		home, source = strings.ToLower(home), strings.ToLower(source)
+	}
+	relative, err := filepath.Rel(home, source)
+	return err == nil && relative != "." && relative != ".." && !strings.HasPrefix(relative, ".."+string(filepath.Separator))
+}
+
+func realPath(value string) (string, error) {
+	resolved, err := filepath.EvalSymlinks(value)
+	if err == nil {
+		return filepath.Abs(resolved)
+	}
+	return filepath.Abs(value)
+}
+
+func validLinuxKeyProvider(provider string) bool {
+	switch provider {
+	case linuxProviderAuto, linuxProviderBasic, linuxProviderLibsecret, linuxProviderKWallet, linuxProviderKWallet5, linuxProviderKWallet6:
+		return true
+	default:
+		return false
+	}
+}
+
+func deriveChromeLegacyKey(secret []byte, iterations int) []byte {
+	const keySize = 16
+	salt := []byte("saltysalt")
+	block := make([]byte, 4)
+	binary.BigEndian.PutUint32(block, 1)
+	mac := hmac.New(sha1.New, secret)
+	_, _ = mac.Write(salt)
+	_, _ = mac.Write(block)
+	u := mac.Sum(nil)
+	result := append([]byte(nil), u...)
+	for i := 1; i < iterations; i++ {
+		mac.Reset()
+		_, _ = mac.Write(u)
+		next := mac.Sum(nil)
+		for j := range result {
+			result[j] ^= next[j]
+		}
+		zeroBytes(u)
+		u = next
+	}
+	zeroBytes(u)
+	zeroBytes(block)
+	return result[:keySize]
+}
+
+func capturedProviderKey(recordID, platform, provider, item, scope, rowPrefix string, secret []byte, iterations int, context []KeyContext) CapturedKeyRecord {
+	derived := deriveChromeLegacyKey(secret, iterations)
+	return CapturedKeyRecord{
+		RecordID: recordID, CaptureState: "captured", KeyKind: "oscrypt_row_key", UsableRowKey: true,
+		Provider:   KeyProviderMetadata{Platform: platform, Name: provider, Item: item, Scope: scope},
+		Context:    context,
+		Policy:     KeyPolicyEvidence{RowPrefix: rowPrefix, Support: "supported"},
+		DerivedKey: derived,
+	}
+}
+
+func unavailableProviderKey(recordID, platform, provider, item, scope, rowPrefix, reason string) CapturedKeyRecord {
+	return CapturedKeyRecord{
+		RecordID: recordID, CaptureState: "unavailable", KeyKind: "oscrypt_row_key", UsableRowKey: false,
+		Provider: KeyProviderMetadata{Platform: platform, Name: provider, Item: item, Scope: scope},
+		Context:  []KeyContext{},
+		Policy:   KeyPolicyEvidence{RowPrefix: rowPrefix, Support: "unavailable", Reason: reason},
+	}
+}

--- a/collector/internal/collector/keycapture_darwin.go
+++ b/collector/internal/collector/keycapture_darwin.go
@@ -1,0 +1,85 @@
+//go:build darwin
+
+package collector
+
+import (
+	"runtime"
+	"unsafe"
+
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+	"github.com/ebitengine/purego"
+)
+
+type darwinKeyCapturer struct{}
+
+func NewHostKeyCapturer(_ string) KeyCapturer { return darwinKeyCapturer{} }
+
+func (darwinKeyCapturer) Capture(found platformscanner.UserDataDir) KeyCaptureResult {
+	if !currentAccountCanReadLiveStore(found) {
+		return unavailableDarwinKey("live-key-store-account-context-mismatch")
+	}
+	handle, err := purego.Dlopen("/System/Library/Frameworks/Security.framework/Security", purego.RTLD_LAZY|purego.RTLD_LOCAL)
+	if err != nil {
+		return unavailableDarwinKey("native-keychain-adapter-unavailable")
+	}
+	defer purego.Dlclose(handle)
+	findAddress, err := purego.Dlsym(handle, "SecKeychainFindGenericPassword")
+	if err != nil || findAddress == 0 {
+		return unavailableDarwinKey("native-keychain-adapter-unavailable")
+	}
+	freeAddress, err := purego.Dlsym(handle, "SecKeychainItemFreeContent")
+	if err != nil || freeAddress == 0 {
+		return unavailableDarwinKey("native-keychain-adapter-unavailable")
+	}
+	var findGenericPassword func(uintptr, uint32, *byte, uint32, *byte, *uint32, *unsafe.Pointer, uintptr) int32
+	var freeContent func(uintptr, unsafe.Pointer) int32
+	purego.RegisterFunc(&findGenericPassword, findAddress)
+	purego.RegisterFunc(&freeContent, freeAddress)
+
+	service := []byte("Chrome Safe Storage")
+	account := []byte("Chrome")
+	var length uint32
+	var data unsafe.Pointer
+	status := findGenericPassword(0, uint32(len(service)), &service[0], uint32(len(account)), &account[0], &length, &data, 0)
+	runtime.KeepAlive(service)
+	runtime.KeepAlive(account)
+	if status != 0 || data == nil || length == 0 {
+		if data != nil {
+			zeroUnsafeBytes(data, length)
+			_ = freeContent(0, data)
+		}
+		reason := "keychain-read-failed"
+		switch status {
+		case -25300:
+			reason = "provider-item-not-found"
+		case -25293:
+			reason = "provider-authorization-denied"
+		case -128:
+			reason = "provider-prompt-cancelled"
+		}
+		return unavailableDarwinKey(reason)
+	}
+	view := unsafe.Slice((*byte)(data), int(length))
+	secret := append([]byte(nil), view...)
+	zeroBytes(view)
+	_ = freeContent(0, data)
+	record := capturedProviderKey("macos-keychain-v10", "darwin", "macos-keychain", "Chrome Safe Storage/Chrome", "live_account_keychain", "v10", secret, 1003, []KeyContext{
+		{Name: "service", Value: "Chrome Safe Storage"},
+		{Name: "account", Value: "Chrome"},
+		{Name: "derivation", Value: "pbkdf2-hmac-sha1"},
+		{Name: "iterations", Value: "1003"},
+		{Name: "salt", Value: "saltysalt"},
+	})
+	zeroBytes(secret)
+	return KeyCaptureResult{Records: []CapturedKeyRecord{record}}
+}
+
+func unavailableDarwinKey(reason string) KeyCaptureResult {
+	return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey(
+		"macos-keychain-unavailable", "darwin", "macos-keychain", "Chrome Safe Storage/Chrome", "live_account_keychain", "v10", reason,
+	)}}
+}
+
+func zeroUnsafeBytes(data unsafe.Pointer, length uint32) {
+	zeroBytes(unsafe.Slice((*byte)(data), int(length)))
+}

--- a/collector/internal/collector/keycapture_linux.go
+++ b/collector/internal/collector/keycapture_linux.go
@@ -1,0 +1,275 @@
+//go:build linux
+
+package collector
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	secretServiceName = "org.freedesktop.secrets"
+	secretServicePath = dbus.ObjectPath("/org/freedesktop/secrets")
+)
+
+type linuxKeyCapturer struct{ provider string }
+
+type providerSecret struct {
+	value   []byte
+	item    string
+	context []KeyContext
+}
+
+type secretServiceValue struct {
+	Session     dbus.ObjectPath
+	Parameters  []byte
+	Value       []byte
+	ContentType string
+}
+
+type kwalletEndpoint struct {
+	mode    string
+	service string
+	path    dbus.ObjectPath
+}
+
+func NewHostKeyCapturer(provider string) KeyCapturer {
+	if provider == "" {
+		provider = linuxProviderAuto
+	}
+	return linuxKeyCapturer{provider: provider}
+}
+
+func (capturer linuxKeyCapturer) Capture(found platformscanner.UserDataDir) KeyCaptureResult {
+	if !currentAccountCanReadLiveStore(found) {
+		return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey(
+			"linux-account-context-unavailable", "linux", capturer.provider, "Chrome Safe Storage", "live_account_session", "v11", "live-key-store-account-context-mismatch",
+		)}}
+	}
+	switch capturer.provider {
+	case linuxProviderBasic:
+		secret := []byte("peanuts")
+		record := capturedProviderKey("linux-basic-v10", "linux", "basic", "hard-coded basic password", "browser_default", "v10", secret, 1, []KeyContext{{Name: "derivation", Value: "pbkdf2-hmac-sha1"}, {Name: "iterations", Value: "1"}, {Name: "salt", Value: "saltysalt"}})
+		zeroBytes(secret)
+		return KeyCaptureResult{Records: []CapturedKeyRecord{record}}
+	case linuxProviderLibsecret:
+		return captureLibsecret()
+	case linuxProviderKWallet, linuxProviderKWallet5, linuxProviderKWallet6:
+		return captureKWallet(endpointForMode(capturer.provider))
+	default:
+		return captureAutomaticLinuxProvider()
+	}
+}
+
+func captureAutomaticLinuxProvider() KeyCaptureResult {
+	desktop := strings.ToLower(os.Getenv("XDG_CURRENT_DESKTOP") + ":" + os.Getenv("DESKTOP_SESSION"))
+	if strings.Contains(desktop, "kde") || strings.Contains(desktop, "plasma") {
+		var attempts []CapturedKeyRecord
+		for _, endpoint := range []kwalletEndpoint{endpointForMode(linuxProviderKWallet6), endpointForMode(linuxProviderKWallet5), endpointForMode(linuxProviderKWallet)} {
+			result := captureKWallet(endpoint)
+			if len(result.Records) > 0 && result.Records[0].CaptureState == "captured" {
+				return result
+			}
+			attempts = append(attempts, result.Records...)
+		}
+		return KeyCaptureResult{Records: attempts}
+	}
+	return captureLibsecret()
+}
+
+func captureLibsecret() KeyCaptureResult {
+	secrets, err := readSecretService()
+	if err != nil {
+		return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey("linux-libsecret-unavailable", "linux", "gnome-libsecret", "Chrome Safe Storage", "live_account_session", "v11", stableProviderReason(err))}}
+	}
+	records := make([]CapturedKeyRecord, 0, len(secrets))
+	for index := range secrets {
+		secret := &secrets[index]
+		record := capturedProviderKey(fmt.Sprintf("linux-libsecret-v11-%d", index+1), "linux", "gnome-libsecret", secret.item, "live_account_session", "v11", secret.value, 1, append(secret.context,
+			KeyContext{Name: "derivation", Value: "pbkdf2-hmac-sha1"}, KeyContext{Name: "iterations", Value: "1"}, KeyContext{Name: "salt", Value: "saltysalt"}))
+		zeroBytes(secret.value)
+		records = append(records, record)
+	}
+	return KeyCaptureResult{Records: records}
+}
+
+func readSecretService() ([]providerSecret, error) {
+	connection, err := dialLocalSessionBus()
+	if err != nil {
+		return nil, err
+	}
+	defer connection.Close()
+	owner, err := nameHasOwner(connection, secretServiceName)
+	if err != nil || !owner {
+		return nil, errors.New("provider-service-unavailable")
+	}
+	service := connection.Object(secretServiceName, secretServicePath)
+	var collection dbus.ObjectPath
+	if err := service.Call("org.freedesktop.Secret.Service.ReadAlias", 0, "default").Store(&collection); err != nil || collection == "/" {
+		return nil, errors.New("default-collection-unavailable")
+	}
+	collectionObject := connection.Object(secretServiceName, collection)
+	locked, err := boolProperty(collectionObject, "org.freedesktop.Secret.Collection.Locked")
+	if err != nil || locked {
+		return nil, errors.New("provider-store-locked")
+	}
+	var output dbus.Variant
+	var session dbus.ObjectPath
+	if err := service.Call("org.freedesktop.Secret.Service.OpenSession", 0, "plain", dbus.MakeVariant("")).Store(&output, &session); err != nil {
+		return nil, errors.New("provider-session-unavailable")
+	}
+	defer connection.Object(secretServiceName, session).Call("org.freedesktop.Secret.Session.Close", 0)
+
+	var items []dbus.ObjectPath
+	attributes := map[string]string{"application": "chrome"}
+	if err := collectionObject.Call("org.freedesktop.Secret.Collection.SearchItems", 0, attributes).Store(&items); err != nil {
+		return nil, errors.New("provider-item-search-failed")
+	}
+	if len(items) == 0 {
+		return nil, errors.New("provider-item-not-found")
+	}
+	sort.Slice(items, func(i, j int) bool { return string(items[i]) < string(items[j]) })
+	results := make([]providerSecret, 0, len(items))
+	for _, itemPath := range items {
+		item := connection.Object(secretServiceName, itemPath)
+		locked, err := boolProperty(item, "org.freedesktop.Secret.Item.Locked")
+		if err != nil || locked {
+			continue
+		}
+		var secret secretServiceValue
+		if err := item.Call("org.freedesktop.Secret.Item.GetSecret", 0, session).Store(&secret); err != nil || len(secret.Value) == 0 {
+			continue
+		}
+		label := "Chrome Safe Storage"
+		if property, err := item.GetProperty("org.freedesktop.Secret.Item.Label"); err == nil {
+			if value, ok := property.Value().(string); ok && value != "" {
+				label = value
+			}
+		}
+		context := []KeyContext{{Name: "application", Value: "chrome"}, {Name: "dbus_item_path", Value: string(itemPath)}, {Name: "label", Value: label}}
+		if secret.ContentType != "" {
+			context = append(context, KeyContext{Name: "content_type", Value: secret.ContentType})
+		}
+		results = append(results, providerSecret{value: secret.Value, item: label, context: context})
+	}
+	if len(results) == 0 {
+		return nil, errors.New("provider-item-locked-or-empty")
+	}
+	return results, nil
+}
+
+func captureKWallet(endpoint kwalletEndpoint) KeyCaptureResult {
+	secret, context, err := readKWallet(endpoint)
+	if err != nil {
+		return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey("linux-"+endpoint.mode+"-unavailable", "linux", endpoint.mode, "Chrome Keys/Chrome Safe Storage", "live_account_session", "v11", stableProviderReason(err))}}
+	}
+	record := capturedProviderKey("linux-"+endpoint.mode+"-v11", "linux", endpoint.mode, "Chrome Keys/Chrome Safe Storage", "live_account_session", "v11", secret, 1, append(context,
+		KeyContext{Name: "derivation", Value: "pbkdf2-hmac-sha1"}, KeyContext{Name: "iterations", Value: "1"}, KeyContext{Name: "salt", Value: "saltysalt"}))
+	zeroBytes(secret)
+	return KeyCaptureResult{Records: []CapturedKeyRecord{record}}
+}
+
+func readKWallet(endpoint kwalletEndpoint) ([]byte, []KeyContext, error) {
+	connection, err := dialLocalSessionBus()
+	if err != nil {
+		return nil, nil, err
+	}
+	defer connection.Close()
+	owner, err := nameHasOwner(connection, endpoint.service)
+	if err != nil || !owner {
+		return nil, nil, errors.New("provider-service-unavailable")
+	}
+	wallet := connection.Object(endpoint.service, endpoint.path)
+	var enabled bool
+	if err := wallet.Call("org.kde.KWallet.isEnabled", 0).Store(&enabled); err != nil || !enabled {
+		return nil, nil, errors.New("provider-disabled")
+	}
+	var walletName string
+	if err := wallet.Call("org.kde.KWallet.networkWallet", 0).Store(&walletName); err != nil || walletName == "" {
+		return nil, nil, errors.New("provider-wallet-unavailable")
+	}
+	var open bool
+	if err := wallet.Call("org.kde.KWallet.isOpen", 0, walletName).Store(&open); err != nil || !open {
+		return nil, nil, errors.New("provider-store-locked")
+	}
+	var handle int32
+	if err := wallet.Call("org.kde.KWallet.open", 0, walletName, int64(0), "forensix-collect").Store(&handle); err != nil || handle < 0 {
+		return nil, nil, errors.New("provider-open-failed")
+	}
+	var present bool
+	if err := wallet.Call("org.kde.KWallet.hasEntry", 0, handle, "Chrome Keys", "Chrome Safe Storage", "forensix-collect").Store(&present); err != nil || !present {
+		return nil, nil, errors.New("provider-item-not-found")
+	}
+	var secret string
+	if err := wallet.Call("org.kde.KWallet.readPassword", 0, handle, "Chrome Keys", "Chrome Safe Storage", "forensix-collect").Store(&secret); err != nil || secret == "" {
+		return nil, nil, errors.New("provider-read-failed")
+	}
+	return []byte(secret), []KeyContext{{Name: "dbus_service", Value: endpoint.service}, {Name: "wallet", Value: walletName}, {Name: "folder", Value: "Chrome Keys"}, {Name: "entry", Value: "Chrome Safe Storage"}}, nil
+}
+
+func endpointForMode(mode string) kwalletEndpoint {
+	switch mode {
+	case linuxProviderKWallet6:
+		return kwalletEndpoint{mode: mode, service: "org.kde.kwalletd6", path: "/modules/kwalletd6"}
+	case linuxProviderKWallet5:
+		return kwalletEndpoint{mode: mode, service: "org.kde.kwalletd5", path: "/modules/kwalletd5"}
+	default:
+		return kwalletEndpoint{mode: linuxProviderKWallet, service: "org.kde.kwalletd", path: "/modules/kwalletd"}
+	}
+}
+
+func dialLocalSessionBus() (*dbus.Conn, error) {
+	address := os.Getenv("DBUS_SESSION_BUS_ADDRESS")
+	if address == "" {
+		return nil, errors.New("local-session-bus-unavailable")
+	}
+	for _, candidate := range strings.Split(address, ";") {
+		if candidate == "" || !strings.HasPrefix(candidate, "unix:") {
+			return nil, errors.New("non-local-session-bus-prohibited")
+		}
+	}
+	connection, err := dbus.Dial(address)
+	if err != nil {
+		return nil, errors.New("local-session-bus-unavailable")
+	}
+	if err := connection.Auth(nil); err != nil {
+		connection.Close()
+		return nil, errors.New("local-session-bus-authentication-failed")
+	}
+	if err := connection.Hello(); err != nil {
+		connection.Close()
+		return nil, errors.New("local-session-bus-handshake-failed")
+	}
+	return connection, nil
+}
+
+func nameHasOwner(connection *dbus.Conn, name string) (bool, error) {
+	var owner bool
+	err := connection.BusObject().Call("org.freedesktop.DBus.NameHasOwner", 0, name).Store(&owner)
+	return owner, err
+}
+
+func boolProperty(object dbus.BusObject, name string) (bool, error) {
+	property, err := object.GetProperty(name)
+	if err != nil {
+		return false, err
+	}
+	value, ok := property.Value().(bool)
+	if !ok {
+		return false, errors.New("provider-property-invalid")
+	}
+	return value, nil
+}
+
+func stableProviderReason(err error) string {
+	if err == nil || err.Error() == "" {
+		return "provider-unavailable"
+	}
+	return err.Error()
+}

--- a/collector/internal/collector/keycapture_linux_test.go
+++ b/collector/internal/collector/keycapture_linux_test.go
@@ -1,0 +1,35 @@
+//go:build linux
+
+package collector
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestLinuxKeyStoreAdapterRejectsNetworkDBusTransportBeforeDial(t *testing.T) {
+	old, present := os.LookupEnv("DBUS_SESSION_BUS_ADDRESS")
+	t.Cleanup(func() {
+		if present {
+			_ = os.Setenv("DBUS_SESSION_BUS_ADDRESS", old)
+		} else {
+			_ = os.Unsetenv("DBUS_SESSION_BUS_ADDRESS")
+		}
+	})
+	if err := os.Setenv("DBUS_SESSION_BUS_ADDRESS", "tcp:host=127.0.0.1,port=1"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := dialLocalSessionBus()
+	if err == nil || !strings.Contains(err.Error(), "non-local") {
+		t.Fatalf("network D-Bus transport was not refused: %v", err)
+	}
+}
+
+func TestLinuxBasicProviderUsesDemonstratedChromeDerivation(t *testing.T) {
+	got := deriveChromeLegacyKey([]byte("peanuts"), 1)
+	if hex := fmt.Sprintf("%x", got); hex != "fd621fe5a2b402539dfa147ca9272778" {
+		t.Fatalf("derived key=%s", hex)
+	}
+}

--- a/collector/internal/collector/keycapture_windows.go
+++ b/collector/internal/collector/keycapture_windows.go
@@ -1,0 +1,42 @@
+//go:build windows
+
+package collector
+
+import (
+	"runtime"
+	"unsafe"
+
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+	"golang.org/x/sys/windows"
+)
+
+type windowsKeyCapturer struct{}
+
+func NewHostKeyCapturer(_ string) KeyCapturer { return windowsKeyCapturer{} }
+
+func (windowsKeyCapturer) Capture(found platformscanner.UserDataDir) KeyCaptureResult {
+	if !currentAccountCanReadLiveStore(found) {
+		return captureWindowsLocalState(found.Path, func([]byte) ([]byte, error) { return nil, errDPAPIAccountContext })
+	}
+	return captureWindowsLocalState(found.Path, unprotectCurrentUserDPAPI)
+}
+
+func unprotectCurrentUserDPAPI(protected []byte) ([]byte, error) {
+	if len(protected) == 0 {
+		return nil, errDPAPIUnprotect
+	}
+	input := windows.DataBlob{Size: uint32(len(protected)), Data: &protected[0]}
+	var output windows.DataBlob
+	if err := windows.CryptUnprotectData(&input, nil, nil, 0, nil, windows.CRYPTPROTECT_UI_FORBIDDEN, &output); err != nil {
+		return nil, errDPAPIUnprotect
+	}
+	runtime.KeepAlive(protected)
+	if output.Data == nil || output.Size == 0 {
+		return nil, errDPAPIUnprotect
+	}
+	decryptedView := unsafe.Slice(output.Data, int(output.Size))
+	decrypted := append([]byte(nil), decryptedView...)
+	zeroBytes(decryptedView)
+	_, _ = windows.LocalFree(windows.Handle(uintptr(unsafe.Pointer(output.Data))))
+	return decrypted, nil
+}

--- a/collector/internal/collector/keycapture_windows_common.go
+++ b/collector/internal/collector/keycapture_windows_common.go
@@ -1,0 +1,97 @@
+package collector
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/ChmaraX/forensix/collector/internal/conformance"
+)
+
+type localStateOSCrypt struct {
+	OSCrypt struct {
+		EncryptedKey         string `json:"encrypted_key"`
+		AppBoundEncryptedKey string `json:"app_bound_encrypted_key"`
+	} `json:"os_crypt"`
+}
+
+func captureWindowsLocalState(userDataDir string, unprotect func([]byte) ([]byte, error)) KeyCaptureResult {
+	content, err := os.ReadFile(filepath.Join(userDataDir, "Local State"))
+	if err != nil {
+		return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey("windows-local-state-unavailable", "windows", "windows-dpapi", "Local State/os_crypt", "current_user", "v10", "local-state-unavailable")}}
+	}
+	var state localStateOSCrypt
+	if err := json.Unmarshal(content, &state); err != nil {
+		return KeyCaptureResult{Records: []CapturedKeyRecord{unavailableProviderKey("windows-local-state-unavailable", "windows", "windows-dpapi", "Local State/os_crypt", "current_user", "v10", "local-state-invalid-json")}}
+	}
+	result := KeyCaptureResult{}
+	if state.OSCrypt.EncryptedKey != "" {
+		wrapper, decodeErr := base64.StdEncoding.DecodeString(state.OSCrypt.EncryptedKey)
+		if decodeErr != nil {
+			result.Records = append(result.Records, unavailableProviderKey("windows-dpapi-v10", "windows", "windows-dpapi", "Local State/os_crypt.encrypted_key", "current_user", "v10", "legacy-wrapper-invalid-base64"))
+		} else {
+			const evidencePath = "evidence/windows-local-state-encrypted-key.bin"
+			result.Evidence = append(result.Evidence, CapturedKeyEvidence{Path: evidencePath, Content: wrapper})
+			record := CapturedKeyRecord{
+				RecordID: "windows-dpapi-v10", CaptureState: "unavailable", KeyKind: "oscrypt_row_key",
+				Provider: KeyProviderMetadata{Platform: "windows", Name: "windows-dpapi", Item: "Local State/os_crypt.encrypted_key", Scope: "current_user"},
+				Context:  []KeyContext{{Name: "wrapper_encoding", Value: "base64-in-local-state"}, {Name: "wrapper_sha256", Value: conformance.Digest(wrapper)}},
+				Policy:   KeyPolicyEvidence{RowPrefix: "v10", Support: "unavailable", Reason: "legacy-wrapper-format-unsupported"},
+				Evidence: []KeyEvidenceReference{{Path: evidencePath, Version: "DPAPI", Policy: "legacy-windows-supported"}},
+			}
+			if bytes.HasPrefix(wrapper, []byte("DPAPI")) && len(wrapper) > len("DPAPI") {
+				record.Context = append(record.Context, KeyContext{Name: "wrapper_prefix", Value: "DPAPI"})
+				key, unwrapErr := unprotect(wrapper[len("DPAPI"):])
+				if unwrapErr == nil && len(key) == 32 {
+					record.CaptureState, record.UsableRowKey, record.DerivedKey = "captured", true, key
+					record.Policy.Support, record.Policy.Reason = "supported", ""
+				} else {
+					zeroBytes(key)
+					if errors.Is(unwrapErr, errDPAPIAccountContext) {
+						record.Policy.Reason = errDPAPIAccountContext.Error()
+					} else {
+						record.Policy.Reason = "dpapi-unprotect-failed"
+					}
+				}
+			}
+			result.Records = append(result.Records, record)
+		}
+	}
+	if state.OSCrypt.AppBoundEncryptedKey != "" {
+		wrapper, decodeErr := base64.StdEncoding.DecodeString(state.OSCrypt.AppBoundEncryptedKey)
+		if decodeErr != nil {
+			result.Records = append(result.Records, CapturedKeyRecord{
+				RecordID: "windows-app-bound-v20", CaptureState: "unsupported", KeyKind: "oscrypt_row_key",
+				Provider: KeyProviderMetadata{Platform: "windows", Name: "windows-app-bound-encryption", Item: "Local State/os_crypt.app_bound_encrypted_key", Scope: "system_and_current_user"},
+				Context:  []KeyContext{{Name: "wrapper_encoding", Value: "invalid-base64-in-local-state"}},
+				Policy:   KeyPolicyEvidence{RowPrefix: "v20", Support: "unsupported", Reason: "unsupported-google-app-bound-key-variant"},
+			})
+		} else {
+			const evidencePath = "evidence/windows-local-state-app-bound-encrypted-key.bin"
+			result.Evidence = append(result.Evidence, CapturedKeyEvidence{Path: evidencePath, Content: wrapper})
+			prefix := "unidentified"
+			if len(wrapper) >= 4 {
+				prefix = string(wrapper[:4])
+			}
+			result.Records = append(result.Records, CapturedKeyRecord{
+				RecordID: "windows-app-bound-v20", CaptureState: "unsupported", KeyKind: "oscrypt_row_key", UsableRowKey: false,
+				Provider: KeyProviderMetadata{Platform: "windows", Name: "windows-app-bound-encryption", Item: "Local State/os_crypt.app_bound_encrypted_key", Scope: "system_and_current_user"},
+				Context:  []KeyContext{{Name: "wrapper_encoding", Value: "base64-in-local-state"}, {Name: "wrapper_prefix", Value: prefix}, {Name: "wrapper_sha256", Value: conformance.Digest(wrapper)}, {Name: "usable_row_key", Value: "false"}},
+				Policy:   KeyPolicyEvidence{RowPrefix: "v20", Support: "unsupported", Reason: "unsupported-google-app-bound-key-variant"},
+				Evidence: []KeyEvidenceReference{{Path: evidencePath, Version: "v20", Policy: "unsupported-google-app-bound-key-variant"}},
+			})
+		}
+	}
+	if len(result.Records) == 0 {
+		result.Records = []CapturedKeyRecord{unavailableProviderKey("windows-wrapper-unavailable", "windows", "windows-dpapi", "Local State/os_crypt", "current_user", "v10", "oscrypt-wrapper-absent")}
+	}
+	return result
+}
+
+var (
+	errDPAPIUnprotect      = errors.New("dpapi-unprotect-failed")
+	errDPAPIAccountContext = errors.New("live-key-store-account-context-mismatch")
+)

--- a/collector/internal/collector/keymaterial.go
+++ b/collector/internal/collector/keymaterial.go
@@ -1,0 +1,393 @@
+package collector
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/ChmaraX/forensix/collector/internal/conformance"
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+)
+
+const (
+	keyMaterialRecordSchema     = "forensix/key-material-record/1"
+	keyMaterialManifestSchema   = "forensix/key-material-manifest/1"
+	keyMaterialSealingAlgorithm = "x25519-hkdf-sha256-aes-256-gcm"
+)
+
+var safeRecordID = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+type KeyCapturer interface {
+	Capture(platformscanner.UserDataDir) KeyCaptureResult
+}
+
+type KeyCaptureResult struct {
+	Records  []CapturedKeyRecord
+	Evidence []CapturedKeyEvidence
+}
+
+type CapturedKeyRecord struct {
+	RecordID     string
+	CaptureState string
+	KeyKind      string
+	UsableRowKey bool
+	Provider     KeyProviderMetadata
+	Context      []KeyContext
+	Policy       KeyPolicyEvidence
+	Evidence     []KeyEvidenceReference
+	DerivedKey   []byte
+}
+
+type CapturedKeyEvidence struct {
+	Path    string
+	Content []byte
+}
+
+type KeyProviderMetadata struct {
+	Platform string `json:"platform"`
+	Name     string `json:"name"`
+	Item     string `json:"item"`
+	Scope    string `json:"scope"`
+}
+
+type KeyContext struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+type KeyPolicyEvidence struct {
+	RowPrefix string `json:"row_prefix"`
+	Support   string `json:"support"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+type KeyEvidenceReference struct {
+	Path    string `json:"path"`
+	SHA256  string `json:"sha256"`
+	Version string `json:"version,omitempty"`
+	Policy  string `json:"policy,omitempty"`
+}
+
+type sealedKeyMaterial struct {
+	Algorithm            string `json:"algorithm"`
+	RecipientFingerprint string `json:"recipient_fingerprint"`
+	EphemeralPublicKey   string `json:"ephemeral_public_key"`
+	Salt                 string `json:"salt"`
+	Nonce                string `json:"nonce"`
+	Ciphertext           string `json:"ciphertext"`
+	AssociatedDataSHA256 string `json:"associated_data_sha256"`
+}
+
+type keyMaterialRecord struct {
+	SchemaVersion  string                 `json:"schema_version"`
+	RecordID       string                 `json:"record_id"`
+	CaptureState   string                 `json:"capture_state"`
+	KeyKind        string                 `json:"key_kind"`
+	UsableRowKey   bool                   `json:"usable_row_key"`
+	Provider       KeyProviderMetadata    `json:"provider"`
+	Context        []KeyContext           `json:"context"`
+	Policy         KeyPolicyEvidence      `json:"policy"`
+	Evidence       []KeyEvidenceReference `json:"evidence"`
+	SealedMaterial *sealedKeyMaterial     `json:"sealed_material"`
+}
+
+type KeyMaterialManifestEntry struct {
+	Path          string `json:"path"`
+	Size          int64  `json:"size"`
+	HashAlgorithm string `json:"hash_algorithm"`
+	SHA256        string `json:"sha256"`
+}
+
+type KeyMaterialManifestHeader struct {
+	ManifestSchema string `json:"manifest_schema"`
+	HashAlgorithm  string `json:"hash_algorithm"`
+	ManifestDigest string `json:"manifest_digest"`
+	EntryCount     int    `json:"entry_count"`
+}
+
+func ParseKeyMaterialRecipient(content []byte) ([]byte, error) {
+	if block, _ := pem.Decode(content); block != nil {
+		public, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, errors.New("parse key-material recipient PEM")
+		}
+		key, ok := public.(*ecdh.PublicKey)
+		if !ok || len(key.Bytes()) != 32 {
+			return nil, errors.New("key-material recipient must be an X25519 public key")
+		}
+		return append([]byte(nil), key.Bytes()...), nil
+	}
+
+	text := strings.TrimSpace(string(content))
+	const prefix = "forensix-x25519-public-v1:"
+	if !strings.HasPrefix(text, prefix) {
+		return nil, errors.New("key-material recipient must be X25519 PEM or forensix-x25519-public-v1 base64")
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(text, prefix))
+	if err != nil || len(decoded) != 32 {
+		return nil, errors.New("key-material recipient contains an invalid X25519 public key")
+	}
+	return decoded, nil
+}
+
+func recipientFingerprint(recipient []byte) string {
+	if len(recipient) == 0 {
+		return ""
+	}
+	sum := sha256.Sum256(recipient)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func writeKeyMaterialSubtree(destination, bundlePath, accountID string, capture KeyCaptureResult, recipient []byte, random io.Reader) (BundleKeyMaterial, error) {
+	defer func() {
+		for i := range capture.Records {
+			zeroBytes(capture.Records[i].DerivedKey)
+		}
+	}()
+	summary := BundleKeyMaterial{AccountID: accountID, BundlePath: bundlePath, CaptureState: "unavailable"}
+	if err := os.MkdirAll(destination, 0o700); err != nil {
+		return summary, err
+	}
+	if len(capture.Records) == 0 {
+		capture.Records = []CapturedKeyRecord{{
+			RecordID: "provider-unavailable", CaptureState: "unavailable", KeyKind: "oscrypt_row_key",
+			Provider: KeyProviderMetadata{Platform: "unknown", Name: "unavailable", Item: "Chrome Safe Storage", Scope: "live_account"},
+			Policy:   KeyPolicyEvidence{Support: "unavailable", Reason: "provider-returned-no-record"},
+		}}
+	}
+
+	evidenceDigests := make(map[string]string, len(capture.Evidence))
+	sort.Slice(capture.Evidence, func(i, j int) bool { return capture.Evidence[i].Path < capture.Evidence[j].Path })
+	for _, evidence := range capture.Evidence {
+		if !canonicalKeyMaterialPath(evidence.Path) || !strings.HasPrefix(evidence.Path, "evidence/") {
+			return summary, fmt.Errorf("key-material evidence path is not canonical: %q", evidence.Path)
+		}
+		if _, exists := evidenceDigests[evidence.Path]; exists {
+			return summary, fmt.Errorf("duplicate key-material evidence path %q", evidence.Path)
+		}
+		evidenceDigests[evidence.Path] = conformance.Digest(evidence.Content)
+		evidencePath := filepath.Join(destination, filepath.FromSlash(evidence.Path))
+		if err := os.MkdirAll(filepath.Dir(evidencePath), 0o700); err != nil {
+			return summary, err
+		}
+		if err := conformance.WriteFile(evidencePath, evidence.Content); err != nil {
+			return summary, err
+		}
+	}
+
+	sort.Slice(capture.Records, func(i, j int) bool { return capture.Records[i].RecordID < capture.Records[j].RecordID })
+	seenRecords := make(map[string]bool, len(capture.Records))
+	unsupported := false
+	for i := range capture.Records {
+		record := &capture.Records[i]
+		if !safeRecordID.MatchString(record.RecordID) || seenRecords[record.RecordID] {
+			zeroBytes(record.DerivedKey)
+			return summary, fmt.Errorf("invalid or duplicate key-material record id %q", record.RecordID)
+		}
+		seenRecords[record.RecordID] = true
+		if record.CaptureState == "unsupported" {
+			unsupported = true
+		}
+		if record.UsableRowKey != (record.CaptureState == "captured") || (record.UsableRowKey && len(record.DerivedKey) == 0) || (!record.UsableRowKey && len(record.DerivedKey) != 0) {
+			zeroBytes(record.DerivedKey)
+			return summary, fmt.Errorf("key-material record %q has inconsistent capture state", record.RecordID)
+		}
+		sort.Slice(record.Context, func(i, j int) bool {
+			if record.Context[i].Name == record.Context[j].Name {
+				return record.Context[i].Value < record.Context[j].Value
+			}
+			return record.Context[i].Name < record.Context[j].Name
+		})
+		sort.Slice(record.Evidence, func(i, j int) bool { return record.Evidence[i].Path < record.Evidence[j].Path })
+		for j := range record.Evidence {
+			digest, ok := evidenceDigests[record.Evidence[j].Path]
+			if !ok {
+				zeroBytes(record.DerivedKey)
+				return summary, fmt.Errorf("key-material record %q references missing evidence %q", record.RecordID, record.Evidence[j].Path)
+			}
+			record.Evidence[j].SHA256 = digest
+		}
+		wire := keyMaterialRecord{
+			SchemaVersion: keyMaterialRecordSchema, RecordID: record.RecordID, CaptureState: record.CaptureState,
+			KeyKind: record.KeyKind, UsableRowKey: record.UsableRowKey, Provider: record.Provider,
+			Context: record.Context, Policy: record.Policy, Evidence: record.Evidence,
+		}
+		if wire.Context == nil {
+			wire.Context = []KeyContext{}
+		}
+		if wire.Evidence == nil {
+			wire.Evidence = []KeyEvidenceReference{}
+		}
+		if record.UsableRowKey {
+			aad, err := keyMaterialAssociatedData(wire)
+			if err != nil {
+				zeroBytes(record.DerivedKey)
+				return summary, err
+			}
+			wire.SealedMaterial, err = sealDerivedKey(recipient, record.DerivedKey, aad, random)
+			zeroBytes(record.DerivedKey)
+			if err != nil {
+				return summary, fmt.Errorf("seal key-material record %q: %w", record.RecordID, err)
+			}
+			summary.UsableRowKeyCount++
+		}
+		recordPath := filepath.Join(destination, "records", record.RecordID+".json")
+		if err := os.MkdirAll(filepath.Dir(recordPath), 0o700); err != nil {
+			return summary, err
+		}
+		if err := conformance.WriteJSON(recordPath, wire); err != nil {
+			return summary, err
+		}
+	}
+
+	entries, lines, err := keyMaterialManifest(destination)
+	if err != nil {
+		return summary, err
+	}
+	digest := conformance.Digest(lines)
+	if err := conformance.WriteFile(filepath.Join(destination, "key_material_manifest.jsonl"), lines); err != nil {
+		return summary, err
+	}
+	header := KeyMaterialManifestHeader{ManifestSchema: keyMaterialManifestSchema, HashAlgorithm: conformance.HashAlgorithm, ManifestDigest: digest, EntryCount: len(entries)}
+	if err := conformance.WriteJSON(filepath.Join(destination, "key_material_manifest_header.json"), header); err != nil {
+		return summary, err
+	}
+	summary.ManifestDigest, summary.EntryCount = digest, len(entries)
+	if summary.UsableRowKeyCount > 0 {
+		summary.CaptureState = "captured"
+	} else if unsupported {
+		summary.CaptureState = "evidence_only"
+	}
+	return summary, nil
+}
+
+func keyMaterialAssociatedData(record keyMaterialRecord) ([]byte, error) {
+	record.SealedMaterial = nil
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		return nil, err
+	}
+	return append(encoded, '\n'), nil
+}
+
+func sealDerivedKey(recipient, plaintext, aad []byte, random io.Reader) (*sealedKeyMaterial, error) {
+	curve := ecdh.X25519()
+	recipientKey, err := curve.NewPublicKey(recipient)
+	if err != nil {
+		return nil, errors.New("invalid X25519 recipient public key")
+	}
+	ephemeral, err := curve.GenerateKey(random)
+	if err != nil {
+		return nil, err
+	}
+	shared, err := ephemeral.ECDH(recipientKey)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroBytes(shared)
+	salt := make([]byte, 32)
+	if _, err := io.ReadFull(random, salt); err != nil {
+		return nil, err
+	}
+	wrappingKey, err := hkdf.Key(sha256.New, shared, salt, "forensix/key-material-seal/1", 32)
+	if err != nil {
+		return nil, err
+	}
+	defer zeroBytes(wrappingKey)
+	block, err := aes.NewCipher(wrappingKey)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(random, nonce); err != nil {
+		return nil, err
+	}
+	ciphertext := gcm.Seal(nil, nonce, plaintext, aad)
+	return &sealedKeyMaterial{
+		Algorithm: keyMaterialSealingAlgorithm, RecipientFingerprint: recipientFingerprint(recipient),
+		EphemeralPublicKey: base64.StdEncoding.EncodeToString(ephemeral.PublicKey().Bytes()),
+		Salt:               base64.StdEncoding.EncodeToString(salt), Nonce: base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext), AssociatedDataSHA256: conformance.Digest(aad),
+	}, nil
+}
+
+func keyMaterialManifest(root string) ([]KeyMaterialManifestEntry, []byte, error) {
+	var entries []KeyMaterialManifestEntry
+	err := filepath.WalkDir(root, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("unsupported key-material node %q", filePath)
+		}
+		rel, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "key_material_manifest.jsonl" || rel == "key_material_manifest_header.json" {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return err
+		}
+		digest, err := hashFile(filePath)
+		if err != nil {
+			return err
+		}
+		entries = append(entries, KeyMaterialManifestEntry{Path: rel, Size: info.Size(), HashAlgorithm: conformance.HashAlgorithm, SHA256: digest})
+		return nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	var lines bytes.Buffer
+	for _, entry := range entries {
+		if !canonicalKeyMaterialPath(entry.Path) {
+			return nil, nil, fmt.Errorf("key-material Manifest path is not canonical: %q", entry.Path)
+		}
+		encoded, err := json.Marshal(entry)
+		if err != nil {
+			return nil, nil, err
+		}
+		lines.Write(encoded)
+		lines.WriteByte('\n')
+	}
+	return entries, lines.Bytes(), nil
+}
+
+func canonicalKeyMaterialPath(value string) bool {
+	return value != "" && !strings.HasPrefix(value, "/") && !strings.ContainsAny(value, `\:`) && path.Clean(value) == value && value != "." && value != ".." && !strings.HasPrefix(value, "../")
+}
+
+func zeroBytes(value []byte) {
+	for i := range value {
+		value[i] = 0
+	}
+}

--- a/collector/internal/collector/keymaterial_contract_test.go
+++ b/collector/internal/collector/keymaterial_contract_test.go
@@ -1,0 +1,34 @@
+package collector
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestKeyMaterialCanonicalSchemasAreValidJSON(t *testing.T) {
+	_, current, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate key-material schema tests")
+	}
+	contractRoot := filepath.Join(filepath.Dir(current), "..", "..", "contracts", "key-material")
+	for _, name := range []string{
+		"key-material-manifest-entry.schema.json",
+		"key-material-manifest-header.schema.json",
+		"key-material-record.schema.json",
+	} {
+		content, err := os.ReadFile(filepath.Join(contractRoot, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(content, &schema); err != nil {
+			t.Fatalf("%s is not valid JSON: %v", name, err)
+		}
+		if schema["$schema"] != "https://json-schema.org/draft/2020-12/schema" || schema["additionalProperties"] != false {
+			t.Fatalf("%s does not declare the closed canonical JSON Schema contract", name)
+		}
+	}
+}

--- a/collector/internal/collector/keymaterial_test.go
+++ b/collector/internal/collector/keymaterial_test.go
@@ -1,0 +1,408 @@
+package collector
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/ecdh"
+	"crypto/hkdf"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ChmaraX/forensix/collector/internal/conformance"
+	"github.com/ChmaraX/forensix/collector/internal/platformscanner"
+)
+
+type fixedKeyCapturer struct{ result KeyCaptureResult }
+
+func (capturer fixedKeyCapturer) Capture(platformscanner.UserDataDir) KeyCaptureResult {
+	return capturer.result
+}
+
+type panicKeyCapturer struct{}
+
+func (panicKeyCapturer) Capture(platformscanner.UserDataDir) KeyCaptureResult {
+	panic("key capturer called without opt-in")
+}
+
+func TestKeyMaterialCaptureIsDisabledByDefault(t *testing.T) {
+	source := t.TempDir()
+	mustWrite(t, filepath.Join(source, "Local State"), "state")
+	out := filepath.Join(t.TempDir(), "bundle")
+	scan := platformscanner.ScanResult{Found: []platformscanner.UserDataDir{{AccountID: "a", Path: source}}}
+	bundle, err := (Collector{Scanner: fixedScanner{scan}, KeyCapturer: panicKeyCapturer{}}).Run(Options{
+		Output: out, OperatorIdentifier: "examiner", AuthorizationReference: "CASE-187/lab-lead",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bundle.KeyMaterialCaptureRequested || bundle.KeyMaterialCaptured || bundle.KeyMaterialStripped || len(bundle.KeyMaterial) != 0 {
+		t.Fatalf("key capture was not disabled: %#v", bundle)
+	}
+	if _, err := os.Stat(filepath.Join(out, "key_material")); !os.IsNotExist(err) {
+		t.Fatal("key-material subtree exists without opt-in")
+	}
+	var record CollectorRecord
+	readJSON(t, filepath.Join(out, "collector_record.json"), &record)
+	if record.KeyMaterialCapture.Requested || record.KeyMaterialCapture.RecipientFingerprint != "" {
+		t.Fatalf("collector record claims key capture: %#v", record.KeyMaterialCapture)
+	}
+}
+
+func TestLiveKeyStoreAccessIsBoundToCurrentAccountIdentityAndHome(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	accountID, err := currentAccountID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	inside := platformscanner.UserDataDir{AccountID: accountID, Path: filepath.Join(home, ".config", "google-chrome")}
+	wrongIdentity := platformscanner.UserDataDir{AccountID: accountID + "-different", Path: inside.Path}
+	outside := platformscanner.UserDataDir{AccountID: accountID, Path: filepath.Join(filepath.Dir(home), "different-account", ".config", "google-chrome")}
+	if !currentAccountCanReadLiveStore(inside) {
+		t.Fatal("current account User Data Dir was not recognized")
+	}
+	if currentAccountCanReadLiveStore(wrongIdentity) {
+		t.Fatal("different account identity was allowed to use the current process live key store")
+	}
+	if currentAccountCanReadLiveStore(outside) {
+		t.Fatal("path outside the current account home was allowed to use its live key store")
+	}
+}
+
+func TestKeyMaterialCaptureRequiresOptInAuthorizationAndRecipient(t *testing.T) {
+	scanner := fixedScanner{}
+	private, recipient := x25519Recipient(t)
+	_ = private
+	cases := []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{name: "authorization", opts: Options{Output: filepath.Join(t.TempDir(), "a"), OperatorIdentifier: "examiner", CaptureKeyMaterial: true, KeyMaterialRecipient: recipient}, want: "authorization"},
+		{name: "whitespace authorization", opts: Options{Output: filepath.Join(t.TempDir(), "whitespace"), OperatorIdentifier: "examiner", AuthorizationReference: " \t\n", CaptureKeyMaterial: true, KeyMaterialRecipient: recipient}, want: "authorization"},
+		{name: "recipient", opts: Options{Output: filepath.Join(t.TempDir(), "b"), OperatorIdentifier: "examiner", AuthorizationReference: "CASE-187", CaptureKeyMaterial: true}, want: "recipient"},
+		{name: "opt-in", opts: Options{Output: filepath.Join(t.TempDir(), "c"), OperatorIdentifier: "examiner", AuthorizationReference: "CASE-187", KeyMaterialRecipient: recipient}, want: "opt-in"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := (Collector{Scanner: scanner}).Run(test.opts)
+			if err == nil || !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error=%v want substring %q", err, test.want)
+			}
+		})
+	}
+}
+
+func TestAuthorizedKeyCaptureSealsDerivedKeyAndPreservesSourceBytes(t *testing.T) {
+	source := t.TempDir()
+	mustWrite(t, filepath.Join(source, "Local State"), `{"os_crypt":"opaque"}`)
+	mustWrite(t, filepath.Join(source, "Default", "Login Data"), "encrypted Source row: v10-not-decrypted")
+	before := snapshot(t, source)
+	private, recipient := x25519Recipient(t)
+	secret := []byte("0123456789abcdef0123456789abcdef")
+	capturer := fixedKeyCapturer{KeyCaptureResult{
+		Evidence: []CapturedKeyEvidence{{Path: "evidence/provider-context.bin", Content: []byte("opaque provider context")}},
+		Records: []CapturedKeyRecord{{
+			RecordID: "test-provider-v10", CaptureState: "captured", KeyKind: "oscrypt_row_key", UsableRowKey: true,
+			Provider:   KeyProviderMetadata{Platform: "linux", Name: "gnome-libsecret", Item: "Chrome Safe Storage", Scope: "live_account_session"},
+			Context:    []KeyContext{{Name: "application", Value: "chrome"}},
+			Policy:     KeyPolicyEvidence{RowPrefix: "v10", Support: "supported"},
+			Evidence:   []KeyEvidenceReference{{Path: "evidence/provider-context.bin", Version: "fixture", Policy: "authorized-copy"}},
+			DerivedKey: append([]byte(nil), secret...),
+		}},
+	}}
+	out := filepath.Join(t.TempDir(), "bundle")
+	scan := platformscanner.ScanResult{Found: []platformscanner.UserDataDir{{AccountID: "alice", Path: source}}}
+	bundle, err := (Collector{Scanner: fixedScanner{scan}, KeyCapturer: capturer, Random: bytes.NewReader(bytes.Repeat([]byte{0x5a}, 4096))}).Run(Options{
+		Output: out, OperatorIdentifier: "examiner-7", AuthorizationReference: "CASE-187; authorized by lab lead",
+		CaptureKeyMaterial: true, KeyMaterialRecipient: recipient,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after := snapshot(t, source); !reflect.DeepEqual(before, after) {
+		t.Fatalf("Source changed during key capture\nbefore=%#v\nafter=%#v", before, after)
+	}
+	if !bundle.KeyMaterialCaptureRequested || !bundle.KeyMaterialCaptured || len(bundle.KeyMaterial) != 1 || bundle.KeyMaterial[0].UsableRowKeyCount != 1 {
+		t.Fatalf("key-material summary incomplete: %#v", bundle)
+	}
+	keyRoot := filepath.Join(out, "key_material", "alice", "udd-1")
+	manifestBytes, err := os.ReadFile(filepath.Join(keyRoot, "key_material_manifest.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var header KeyMaterialManifestHeader
+	readJSON(t, filepath.Join(keyRoot, "key_material_manifest_header.json"), &header)
+	if header.ManifestSchema != keyMaterialManifestSchema || header.ManifestDigest != conformance.Digest(manifestBytes) || header.ManifestDigest != bundle.KeyMaterial[0].ManifestDigest || header.EntryCount != 2 {
+		t.Fatalf("independent key-material Manifest is invalid: %#v", header)
+	}
+	lines := strings.Split(strings.TrimSpace(string(manifestBytes)), "\n")
+	if len(lines) != 2 || !strings.Contains(lines[0], `"path":"evidence/provider-context.bin"`) || !strings.Contains(lines[1], `"path":"records/test-provider-v10.json"`) {
+		t.Fatalf("key-material Manifest is incomplete or not path-sorted: %s", manifestBytes)
+	}
+
+	var record keyMaterialRecord
+	readJSON(t, filepath.Join(keyRoot, "records", "test-provider-v10.json"), &record)
+	if record.Provider.Name != "gnome-libsecret" || record.Policy.RowPrefix != "v10" || record.SealedMaterial == nil || !record.UsableRowKey {
+		t.Fatalf("provider/context metadata incomplete: %#v", record)
+	}
+	if got := unsealTestRecord(t, private, record); !bytes.Equal(got, secret) {
+		t.Fatalf("sealed key mismatch: %x", got)
+	}
+	assertTreeDoesNotContain(t, out, secret)
+
+	var collectorRecord CollectorRecord
+	readJSON(t, filepath.Join(out, "collector_record.json"), &collectorRecord)
+	if !collectorRecord.KeyMaterialCapture.Requested || collectorRecord.KeyMaterialCapture.AuthorizationReference == "" || collectorRecord.KeyMaterialCapture.SealingAlgorithm != keyMaterialSealingAlgorithm || collectorRecord.KeyMaterialCapture.RecipientFingerprint != recipientFingerprint(recipient) {
+		t.Fatalf("authorization or sealing claim missing: %#v", collectorRecord.KeyMaterialCapture)
+	}
+	assertBundleFiles(t, out, bundle)
+}
+
+func TestLegacyWindowsCaptureReturnsOnlyTheDPAPIDerivedRowKey(t *testing.T) {
+	source := t.TempDir()
+	protected := []byte("opaque-dpapi-wrapper")
+	wrapper := append([]byte("DPAPI"), protected...)
+	state := `{"os_crypt":{"encrypted_key":"` + base64.StdEncoding.EncodeToString(wrapper) + `"}}`
+	mustWrite(t, filepath.Join(source, "Local State"), state)
+	rowKey := bytes.Repeat([]byte{0x8a}, 32)
+	capture := captureWindowsLocalState(source, func(got []byte) ([]byte, error) {
+		if !bytes.Equal(got, protected) {
+			t.Fatalf("DPAPI input=%x want=%x", got, protected)
+		}
+		return append([]byte(nil), rowKey...), nil
+	})
+	if len(capture.Records) != 1 || !capture.Records[0].UsableRowKey || capture.Records[0].CaptureState != "captured" || !bytes.Equal(capture.Records[0].DerivedKey, rowKey) {
+		t.Fatalf("legacy Windows row key was not captured: %#v", capture.Records)
+	}
+	if len(capture.Evidence) != 1 || !bytes.Equal(capture.Evidence[0].Content, wrapper) || capture.Records[0].Evidence[0].Version != "DPAPI" {
+		t.Fatal("exact legacy Local State wrapper or DPAPI context was not preserved")
+	}
+}
+
+func TestWindowsV20CapturePreservesWrapperVersionAndPolicyWithoutUsableKey(t *testing.T) {
+	source := t.TempDir()
+	wrapper := append([]byte("APPB"), []byte{0x01, 0x02, 0x03, 0x04}...)
+	state := `{"os_crypt":{"app_bound_encrypted_key":"` + base64.StdEncoding.EncodeToString(wrapper) + `"}}`
+	mustWrite(t, filepath.Join(source, "Local State"), state)
+	capture := captureWindowsLocalState(source, func([]byte) ([]byte, error) {
+		t.Fatal("v20 wrapper must not be unwrapped as a usable row key")
+		return nil, nil
+	})
+	if len(capture.Records) != 1 || capture.Records[0].CaptureState != "unsupported" || capture.Records[0].UsableRowKey || len(capture.Records[0].DerivedKey) != 0 {
+		t.Fatalf("v20 support was overstated: %#v", capture.Records)
+	}
+	record := capture.Records[0]
+	if record.Policy.RowPrefix != "v20" || record.Policy.Reason != "unsupported-google-app-bound-key-variant" || len(record.Evidence) != 1 || record.Evidence[0].Version != "v20" {
+		t.Fatalf("v20 wrapper/version/policy evidence incomplete: %#v", record)
+	}
+	if len(capture.Evidence) != 1 || !bytes.Equal(capture.Evidence[0].Content, wrapper) {
+		t.Fatal("exact App-Bound wrapper was not preserved")
+	}
+}
+
+func TestStripKeysProducesIndependentSelfConsistentBundle(t *testing.T) {
+	source := t.TempDir()
+	mustWrite(t, filepath.Join(source, "Local State"), "state")
+	mustWrite(t, filepath.Join(source, "Default", "History"), "history")
+	private, recipient := x25519Recipient(t)
+	_ = private
+	secret := []byte("abcdef0123456789")
+	capture := KeyCaptureResult{Records: []CapturedKeyRecord{{
+		RecordID: "linux-basic-v10", CaptureState: "captured", KeyKind: "oscrypt_row_key", UsableRowKey: true,
+		Provider: KeyProviderMetadata{Platform: "linux", Name: "basic", Item: "hard-coded basic password", Scope: "browser_default"},
+		Policy:   KeyPolicyEvidence{RowPrefix: "v10", Support: "supported"}, DerivedKey: append([]byte(nil), secret...),
+	}}}
+	original := filepath.Join(t.TempDir(), "with-keys")
+	scan := platformscanner.ScanResult{Found: []platformscanner.UserDataDir{{AccountID: "a", Path: source}}}
+	originalManifest, err := (Collector{Scanner: fixedScanner{scan}, KeyCapturer: fixedKeyCapturer{capture}, Random: bytes.NewReader(bytes.Repeat([]byte{0x33}, 4096))}).Run(Options{
+		Output: original, OperatorIdentifier: "examiner", AuthorizationReference: "CASE-187", CaptureKeyMaterial: true, KeyMaterialRecipient: recipient,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalSourceManifest, err := os.ReadFile(filepath.Join(original, "accounts", "a", "udd-1", "manifest.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stripped := filepath.Join(t.TempDir(), "without-keys")
+	strippedManifest, err := StripKeys(original, stripped)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strippedManifest.KeyMaterialCaptured || !strippedManifest.KeyMaterialStripped || strippedManifest.OriginalBundleDigest != originalManifest.BundleDigest || strippedManifest.BundleDigest == originalManifest.BundleDigest || len(strippedManifest.KeyMaterial) != 0 {
+		t.Fatalf("strip provenance or digest invalid: %#v", strippedManifest)
+	}
+	if _, err := os.Stat(filepath.Join(stripped, "key_material")); !os.IsNotExist(err) {
+		t.Fatal("stripped bundle still contains key-material subtree")
+	}
+	if _, err := os.Stat(filepath.Join(original, "key_material")); err != nil {
+		t.Fatal("strip operation modified original Acquisition Bundle")
+	}
+	strippedSourceManifest, err := os.ReadFile(filepath.Join(stripped, "accounts", "a", "udd-1", "manifest.jsonl"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(originalSourceManifest, strippedSourceManifest) {
+		t.Fatal("strip operation changed the Source Manifest")
+	}
+	if err := verifyBundleManifest(stripped, strippedManifest); err != nil {
+		t.Fatalf("stripped Acquisition Bundle is not self-consistent: %v", err)
+	}
+	for _, file := range strippedManifest.Files {
+		if strings.HasPrefix(file.Path, "key_material/") {
+			t.Fatalf("stripped bundle Manifest retains key-material path %q", file.Path)
+		}
+	}
+}
+
+func TestCanonicalBundlePathsRejectTraversalAndWindowsVolumes(t *testing.T) {
+	for _, value := range []string{"../outside", "nested/../outside", `/absolute`, `C:/outside`, `nested\\outside`} {
+		if canonicalKeyMaterialPath(value) {
+			t.Errorf("unsafe bundle path accepted: %q", value)
+		}
+	}
+	for _, value := range []string{"accounts/a/udd-1/manifest.jsonl", "key_material/a/udd-1/records/key.json"} {
+		if !canonicalKeyMaterialPath(value) {
+			t.Errorf("safe bundle path refused: %q", value)
+		}
+	}
+}
+
+func TestStripKeysRefusesToRemanifestDivergentBundle(t *testing.T) {
+	source := t.TempDir()
+	mustWrite(t, filepath.Join(source, "Local State"), "state")
+	_, recipient := x25519Recipient(t)
+	capture := KeyCaptureResult{Records: []CapturedKeyRecord{{
+		RecordID: "test", CaptureState: "captured", KeyKind: "oscrypt_row_key", UsableRowKey: true,
+		Provider: KeyProviderMetadata{Platform: "linux", Name: "basic", Item: "item", Scope: "browser_default"},
+		Policy:   KeyPolicyEvidence{RowPrefix: "v10", Support: "supported"}, DerivedKey: []byte("0123456789abcdef"),
+	}}}
+	original := filepath.Join(t.TempDir(), "with-keys")
+	scan := platformscanner.ScanResult{Found: []platformscanner.UserDataDir{{AccountID: "a", Path: source}}}
+	_, err := (Collector{Scanner: fixedScanner{scan}, KeyCapturer: fixedKeyCapturer{capture}, Random: bytes.NewReader(bytes.Repeat([]byte{0x44}, 4096))}).Run(Options{
+		Output: original, OperatorIdentifier: "examiner", AuthorizationReference: "CASE-187", CaptureKeyMaterial: true, KeyMaterialRecipient: recipient,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(original, "not-manifested.txt"), "divergence")
+	output := filepath.Join(t.TempDir(), "stripped")
+	if _, err := StripKeys(original, output); err == nil || !strings.Contains(err.Error(), "divergent") {
+		t.Fatalf("error=%v", err)
+	}
+	if _, err := os.Stat(output); !os.IsNotExist(err) {
+		t.Fatal("strip published output from a divergent bundle")
+	}
+}
+
+func TestRecipientParserAcceptsPEMAndForensixFormat(t *testing.T) {
+	private, public := x25519Recipient(t)
+	_ = private
+	der, err := x509MarshalPublic(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemContent := pemEncodePublic(der)
+	parsedPEM, err := ParseKeyMaterialRecipient(pemContent)
+	if err != nil || !bytes.Equal(parsedPEM, public) {
+		t.Fatalf("PEM parse failed: %v", err)
+	}
+	text := []byte("forensix-x25519-public-v1:" + base64.StdEncoding.EncodeToString(public) + "\n")
+	parsedText, err := ParseKeyMaterialRecipient(text)
+	if err != nil || !bytes.Equal(parsedText, public) {
+		t.Fatalf("text parse failed: %v", err)
+	}
+}
+
+func x25519Recipient(t *testing.T) (*ecdh.PrivateKey, []byte) {
+	t.Helper()
+	private, err := ecdh.X25519().GenerateKey(bytes.NewReader(bytes.Repeat([]byte{0x71}, 64)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return private, private.PublicKey().Bytes()
+}
+
+func unsealTestRecord(t *testing.T, private *ecdh.PrivateKey, record keyMaterialRecord) []byte {
+	t.Helper()
+	aad, err := keyMaterialAssociatedData(record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ephemeralBytes, _ := base64.StdEncoding.DecodeString(record.SealedMaterial.EphemeralPublicKey)
+	ephemeral, err := ecdh.X25519().NewPublicKey(ephemeralBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	shared, err := private.ECDH(ephemeral)
+	if err != nil {
+		t.Fatal(err)
+	}
+	salt, _ := base64.StdEncoding.DecodeString(record.SealedMaterial.Salt)
+	wrappingKey, err := hkdf.Key(sha256.New, shared, salt, "forensix/key-material-seal/1", 32)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := aes.NewCipher(wrappingKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce, _ := base64.StdEncoding.DecodeString(record.SealedMaterial.Nonce)
+	ciphertext, _ := base64.StdEncoding.DecodeString(record.SealedMaterial.Ciphertext)
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plaintext
+}
+
+func assertTreeDoesNotContain(t *testing.T, root string, secret []byte) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		content, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		if bytes.Contains(content, secret) {
+			t.Errorf("plaintext derived key leaked to bundle file %s", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Kept in helpers so the production parser stays limited to public-key input.
+func x509MarshalPublic(public []byte) ([]byte, error) {
+	key, err := ecdh.X25519().NewPublicKey(public)
+	if err != nil {
+		return nil, err
+	}
+	return x509.MarshalPKIXPublicKey(key)
+}
+
+func pemEncodePublic(der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}

--- a/collector/internal/collector/strip.go
+++ b/collector/internal/collector/strip.go
@@ -1,0 +1,234 @@
+package collector
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ChmaraX/forensix/collector/internal/conformance"
+)
+
+func StripKeys(input, output string) (BundleManifest, error) {
+	if input == "" || output == "" {
+		return BundleManifest{}, errors.New("input Acquisition Bundle and output are required")
+	}
+	inputPath, err := filepath.EvalSymlinks(input)
+	if err != nil {
+		return BundleManifest{}, fmt.Errorf("open input Acquisition Bundle: %w", err)
+	}
+	inputPath, err = filepath.Abs(inputPath)
+	if err != nil {
+		return BundleManifest{}, err
+	}
+	outputPath, err := prospectiveRealPath(output)
+	if err != nil {
+		return BundleManifest{}, err
+	}
+	if inside, err := pathContains(inputPath, outputPath); err != nil {
+		return BundleManifest{}, err
+	} else if inside {
+		return BundleManifest{}, errors.New("stripped Acquisition Bundle output must be outside the input bundle")
+	}
+
+	manifest, err := readBundleManifest(filepath.Join(inputPath, "bundle_manifest.json"))
+	if err != nil {
+		return BundleManifest{}, err
+	}
+	if err := verifyBundleManifest(inputPath, manifest); err != nil {
+		return BundleManifest{}, fmt.Errorf("refuse to strip divergent Acquisition Bundle: %w", err)
+	}
+	if !manifest.KeyMaterialCaptured || manifest.KeyMaterialStripped {
+		return BundleManifest{}, errors.New("Acquisition Bundle has no captured key material to strip")
+	}
+	hasKeyFile := false
+	for _, file := range manifest.Files {
+		if strings.HasPrefix(file.Path, "key_material/") {
+			hasKeyFile = true
+			break
+		}
+	}
+	if !hasKeyFile {
+		return BundleManifest{}, errors.New("Acquisition Bundle claims captured key material but has no key-material subtree")
+	}
+
+	if err := prepareOutput(output); err != nil {
+		return BundleManifest{}, err
+	}
+	tmp := output + ".partial"
+	committed := false
+	defer func() {
+		if !committed {
+			_ = os.RemoveAll(tmp)
+		}
+	}()
+	for _, file := range manifest.Files {
+		if strings.HasPrefix(file.Path, "key_material/") {
+			continue
+		}
+		if err := copyVerifiedBundleFile(inputPath, tmp, file); err != nil {
+			return BundleManifest{}, err
+		}
+	}
+
+	originalDigest := manifest.BundleDigest
+	manifest.SchemaVersion = "forensix-acquisition-bundle-draft/2"
+	manifest.KeyMaterialCaptured = false
+	manifest.KeyMaterialStripped = true
+	manifest.OriginalBundleDigest = originalDigest
+	manifest.KeyMaterial = []BundleKeyMaterial{}
+	manifest.Files, manifest.BundleDigest, err = bundleFiles(tmp)
+	if err != nil {
+		return BundleManifest{}, err
+	}
+	if err := conformance.WriteJSON(filepath.Join(tmp, "bundle_manifest.json"), manifest); err != nil {
+		return BundleManifest{}, err
+	}
+	if err := os.Rename(tmp, output); err != nil {
+		return BundleManifest{}, fmt.Errorf("publish stripped Acquisition Bundle: %w", err)
+	}
+	committed = true
+	return manifest, nil
+}
+
+func readBundleManifest(filePath string) (BundleManifest, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return BundleManifest{}, fmt.Errorf("open bundle Manifest: %w", err)
+	}
+	defer file.Close()
+	decoder := json.NewDecoder(file)
+	decoder.DisallowUnknownFields()
+	var manifest BundleManifest
+	if err := decoder.Decode(&manifest); err != nil {
+		return BundleManifest{}, fmt.Errorf("decode bundle Manifest: %w", err)
+	}
+	var trailing any
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		return BundleManifest{}, errors.New("bundle Manifest has trailing data")
+	}
+	return manifest, nil
+}
+
+func verifyBundleManifest(root string, manifest BundleManifest) error {
+	if manifest.HashAlgorithm != conformance.HashAlgorithm {
+		return fmt.Errorf("unsupported bundle hash algorithm %q", manifest.HashAlgorithm)
+	}
+	expected := make(map[string]BundleFile, len(manifest.Files))
+	for index, file := range manifest.Files {
+		if !canonicalKeyMaterialPath(file.Path) || file.Path == "bundle_manifest.json" || file.Size < 0 || len(file.SHA256) != 64 {
+			return fmt.Errorf("invalid bundle Manifest entry %q", file.Path)
+		}
+		if index > 0 && manifest.Files[index-1].Path >= file.Path {
+			return errors.New("bundle Manifest entries are not uniquely path-sorted")
+		}
+		if _, duplicate := expected[file.Path]; duplicate {
+			return fmt.Errorf("duplicate bundle Manifest path %q", file.Path)
+		}
+		expected[file.Path] = file
+		filePath := filepath.Join(root, filepath.FromSlash(file.Path))
+		info, err := os.Lstat(filePath)
+		if err != nil || !info.Mode().IsRegular() {
+			return fmt.Errorf("bundle file missing or not regular: %s", file.Path)
+		}
+		if info.Size() != file.Size {
+			return fmt.Errorf("bundle file size mismatch: %s", file.Path)
+		}
+		digest, err := hashFile(filePath)
+		if err != nil {
+			return err
+		}
+		if digest != file.SHA256 {
+			return fmt.Errorf("bundle file digest mismatch: %s", file.Path)
+		}
+	}
+	actual := make([]string, 0, len(expected))
+	err := filepath.WalkDir(root, func(filePath string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(root, filePath)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "bundle_manifest.json" {
+			if !entry.Type().IsRegular() {
+				return errors.New("bundle Manifest is not a regular file")
+			}
+			return nil
+		}
+		if !entry.Type().IsRegular() {
+			return fmt.Errorf("unsupported bundle node %q", rel)
+		}
+		actual = append(actual, rel)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	sort.Strings(actual)
+	if len(actual) != len(expected) {
+		return errors.New("bundle Manifest is not exhaustive over bundle files")
+	}
+	for _, filePath := range actual {
+		if _, ok := expected[filePath]; !ok {
+			return fmt.Errorf("bundle file missing from Manifest: %s", filePath)
+		}
+	}
+	digest, err := bundleFileDigest(manifest.Files)
+	if err != nil {
+		return err
+	}
+	if digest != manifest.BundleDigest {
+		return errors.New("bundle digest mismatch")
+	}
+	return nil
+}
+
+func copyVerifiedBundleFile(sourceRoot, destinationRoot string, expected BundleFile) error {
+	sourcePath := filepath.Join(sourceRoot, filepath.FromSlash(expected.Path))
+	destinationPath := filepath.Join(destinationRoot, filepath.FromSlash(expected.Path))
+	input, err := os.Open(sourcePath)
+	if err != nil {
+		return err
+	}
+	defer input.Close()
+	info, err := input.Stat()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o700); err != nil {
+		return err
+	}
+	output, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, info.Mode().Perm())
+	if err != nil {
+		return err
+	}
+	hash := sha256.New()
+	written, copyErr := io.Copy(io.MultiWriter(output, hash), input)
+	syncErr := output.Sync()
+	closeErr := output.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if syncErr != nil {
+		return syncErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	if written != expected.Size || hex.EncodeToString(hash.Sum(nil)) != expected.SHA256 {
+		return fmt.Errorf("bundle file changed while stripping: %s", expected.Path)
+	}
+	return nil
+}

--- a/collector/internal/safety/no_network_test.go
+++ b/collector/internal/safety/no_network_test.go
@@ -11,10 +11,12 @@ import (
 	"testing"
 )
 
-func TestProductionCodeHasNoNetworkOrProcessControlImports(t *testing.T) {
+func TestProductionCodeHasNoNetworkProcessControlOrLoggingImports(t *testing.T) {
 	_, current, _, _ := runtime.Caller(0)
 	moduleRoot := filepath.Clean(filepath.Join(filepath.Dir(current), "..", ".."))
-	forbidden := []string{"net", "net/", "os/exec", "syscall", "unsafe"}
+	// The Windows DPAPI adapter needs unsafe only to copy and immediately zero
+	// the OS-owned DATA_BLOB. Network, process-control, and logging packages remain banned.
+	forbidden := []string{"net", "net/", "os/exec", "syscall", "log", "log/"}
 	err := filepath.WalkDir(moduleRoot, func(path string, entry os.DirEntry, err error) error {
 		if err != nil {
 			return err


### PR DESCRIPTION
Closes #187

## Scope

- Keep key capture disabled by default and require explicit opt-in, Authorization Reference, and recipient.
- Capture sealed derived key material with provider and context metadata, never plaintext keys.
- Preserve unsupported Windows v20 wrapper, version, and policy evidence without claiming a usable row key.
- Add an independent canonical Manifest and digest for `key_material/`.
- Add a first-class `strip-keys` operation that remanifests and redigests the Acquisition Bundle.

## Verification

- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- `go mod verify`
- Static builds for six release targets

## Base

Started from `v2@ba690473dd65a24ddae9afbd0782329925e09d11` with no research ancestry.

## Residual risk

Native Keychain, Secret Service, KWallet, and DPAPI capture was not exercised against real target-platform stores; cross-builds and adapter tests passed.