### PR TITLE
feat(#173): ingest all supported Source kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,22 @@ Version 2 is a rebuild and does not use version 1 as a behavior reference.
 
 ## Current implementation
 
-The Wave 1 tracer bullet can ingest a Chrome User Data Dir.
-It creates one Case Directory for all detected Profiles.
+The Analyzer ingests all five Source kinds: `USER_DATA_DIR`, `PROFILE_DIR`, `FILESYSTEM_ROOT`, `IMAGE_CONTAINER`, and `ACQUISITION_BUNDLE`.
+A Case can hold multiple Sources and Profiles.
+Each Source has an independent Manifest identity, Evidence Set Digest, and Working Copy Digest.
 
-The Case Directory contains:
+A single User Data Dir or Profile Dir keeps the Wave 1 Case Directory layout:
 
 - `case.fxdb`: the SQLite Case and its recorded Manifest
 - `manifest.jsonl`: the canonical, path-sorted Manifest
 - `manifest_header.json`: the Selection Policy, counts, and both digests
 - `working-copy/`: the selected content for later analysis
 
-The compiled CLI checks the Working Copy before each analysis.
-It parses History from all Profiles and writes Findings to the Case.
+A Filesystem Root, Image Container, or Acquisition Bundle stores each Source under `sources/<source-id>/`.
+The Case records all identities and paths.
 
+The compiled CLI checks every Working Copy before each analysis.
+It parses History from all Profiles and Sources, then writes Findings to the Case.
 Committed and recovery content use separate passes.
 Recovered rows keep the `wal_resident` or `journal_resident` Commit State.
 
@@ -42,10 +45,9 @@ pnpm build
 The workspace members are `core`, `cli`, `server`, and `client`.
 The Collector and the tools under `tools/` are not workspace members.
 
-## Ingest a User Data Dir
+## Ingest a Source
 
-Run the compiled CLI against the top-level Chrome directory.
-Do not select one Profile directory for this command.
+A User Data Dir is the canonical Source kind and remains the default:
 
 ```sh
 node cli/dist/cli.js ingest "/path/to/User Data" \
@@ -53,8 +55,30 @@ node cli/dist/cli.js ingest "/path/to/User Data" \
   --json
 ```
 
-Tier 2 content is off by default.
-Add `--include-tier-2` to copy the Tier 2 paths from Selection Policy `chrome-userdata/1`.
+Select another Source kind explicitly:
+
+```sh
+node cli/dist/cli.js ingest "/path/to/Default" --source-kind PROFILE_DIR --case "/path/to/CASE-002" --json
+node cli/dist/cli.js ingest "/mnt/filesystem" --source-kind FILESYSTEM_ROOT --case "/path/to/CASE-003" --json
+node cli/dist/cli.js ingest "/mnt/image" --source-kind IMAGE_CONTAINER --case "/path/to/CASE-004" --json
+node cli/dist/cli.js ingest "/path/to/bundle" --source-kind ACQUISITION_BUNDLE --case "/path/to/CASE-005" --json
+```
+
+A Profile Dir is a partial Source.
+The Case records browser-level evidence such as `Local State` as `unavailable(outside_source)` without adding paths outside the Profile Dir to its Manifest.
+
+A Filesystem Root is searched recursively for supported Chrome Sources.
+Discovery does not assume one account or installation path.
+For Image Containers, mount or extract the container offline and read-only first.
+The Analyzer does not boot images, write to them, or parse opaque E01 files directly.
+
+An Acquisition Bundle preserves every supplied acquisition-time Manifest in the Case.
+Verification reports `match`, `mismatch`, `missing_on_disk`, and `missing_in_manifest` per file.
+Divergent files do not enter the Working Copy; unaffected evidence remains available.
+
+Tier 2 content is off by default for direct, filesystem, and image ingestion.
+Add `--include-tier-2` to copy Tier 2 paths from Selection Policy `chrome-userdata/1`.
+An Acquisition Bundle retains the Collector's recorded Tier 2 choice.
 
 ## Analyze History
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -3,9 +3,10 @@
 import {
   ForensixError,
   MINIMUM_NODE_VERSION,
+  SOURCE_KINDS,
   TOOL_VERSION,
   analyseCase,
-  ingestUserDataDir,
+  ingestSource,
   queryHistory,
   type CommitState,
   type DeclaredOriginOs,
@@ -14,10 +15,11 @@ import {
   type HistoryView,
   type IngestProgress,
   type IngestResult,
+  type SourceKind,
 } from "@forensix/core";
 
 const USAGE = `Usage:
-  forensix ingest <user-data-dir> --case <case-directory> [--include-tier-2] [--json]
+  forensix ingest <source> --case <case-directory> [--source-kind <kind>] [--include-tier-2] [--json]
   forensix analyse --case <case-directory> [--timezone <iana-zone>] [--origin-os <windows|macos|linux>] [--json]
   forensix history --case <case-directory> [--view <visits|activity|most-visited|durations>]
                    [--profile <profile>]... [--search <text>]
@@ -26,6 +28,9 @@ const USAGE = `Usage:
                    [--sort <field>] [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix --version
+
+Source kinds:
+  USER_DATA_DIR (default), PROFILE_DIR, FILESYSTEM_ROOT, IMAGE_CONTAINER, ACQUISITION_BUNDLE
 `;
 
 type OptionValue = string | true;
@@ -39,6 +44,7 @@ interface ParsedArguments {
 const FLAG_OPTIONS = new Set(["--json", "--include-tier-2"]);
 const VALUE_OPTIONS = new Set([
   "--case",
+  "--source-kind",
   "--timezone",
   "--origin-os",
   "--view",
@@ -228,12 +234,12 @@ async function run(arguments_: readonly string[]): Promise<number> {
   if (parsed.command === "ingest") {
     assertAllowedOptions(
       parsed,
-      new Set(["--case", "--json", "--include-tier-2"]),
+      new Set(["--case", "--json", "--include-tier-2", "--source-kind"]),
     );
     if (parsed.positionals.length !== 1) {
       throw new ForensixError(
         "INVALID_ARGUMENT",
-        "The ingest command needs one User Data Dir path.",
+        "The ingest command needs one Source path.",
       );
     }
     const sourcePath = parsed.positionals[0];
@@ -243,9 +249,18 @@ async function run(arguments_: readonly string[]): Promise<number> {
         "The Source path is missing.",
       );
     }
+    const requestedKind =
+      optionValue(parsed, "--source-kind") ?? "USER_DATA_DIR";
+    if (!SOURCE_KINDS.includes(requestedKind as SourceKind)) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        `Unsupported Source kind: ${String(requestedKind)}`,
+      );
+    }
     const result = await consumeIngest(
-      ingestUserDataDir({
+      ingestSource({
         sourcePath,
+        sourceKind: requestedKind as SourceKind,
         caseDirectory: requiredCasePath(parsed),
         includeTier2: hasOption(parsed, "--include-tier-2"),
       }),

--- a/contracts/manifest/README.md
+++ b/contracts/manifest/README.md
@@ -13,9 +13,13 @@ The Manifest contains each descendant of the Source root.
 The Manifest does not contain the Source root itself.
 It also contains expected Tier 1 paths that are absent or unavailable.
 Each `path` is relative to the Source root and uses `/` separators.
+A Profile Dir Manifest uses Profile-relative paths such as `History`.
+It does not add `../Local State` or another path outside the Source.
+The Case records that browser-level evidence is unavailable for this partial Source.
 
 `manifest_header.json` obeys `manifest-header.schema.json`.
-The header records whether the operator included Tier 2 content.
+The header records the Source kind and whether the operator included Tier 2 content.
+The supported Source kinds are `USER_DATA_DIR`, `PROFILE_DIR`, `FILESYSTEM_ROOT`, `IMAGE_CONTAINER`, and `ACQUISITION_BUNDLE`.
 The header does not contribute bytes to either digest.
 
 The object keys have this fixed order:

--- a/contracts/manifest/manifest-header.schema.json
+++ b/contracts/manifest/manifest-header.schema.json
@@ -21,7 +21,15 @@
   ],
   "properties": {
     "manifest_schema": { "const": "forensix/manifest/1" },
-    "source_kind": { "const": "USER_DATA_DIR" },
+    "source_kind": {
+      "enum": [
+        "USER_DATA_DIR",
+        "PROFILE_DIR",
+        "FILESYSTEM_ROOT",
+        "IMAGE_CONTAINER",
+        "ACQUISITION_BUNDLE"
+      ]
+    },
     "selection_policy": { "const": "chrome-userdata/1" },
     "selection_policy_diff": {
       "type": "array",

--- a/core/src/acquisition-bundle.ts
+++ b/core/src/acquisition-bundle.ts
@@ -1,0 +1,765 @@
+import type { BigIntStats } from "node:fs";
+import type { FileHandle } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  readlink,
+  rm,
+} from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+import { ForensixError } from "./errors.js";
+import {
+  HASH_ALGORITHM,
+  decodeManifestEntry,
+  decodeManifestHeader,
+  evidenceSetDigest,
+  manifestBytes,
+  representationDigest,
+  sha256,
+  sortManifestEntries,
+  workingCopyDigest,
+  type ManifestEntry,
+  type ManifestHeader,
+} from "./manifest.js";
+import { classifySourcePath } from "./selection-policy.js";
+import { readStableRegularFile } from "./stable-file.js";
+
+export type AcquisitionVerificationOutcome =
+  | "match"
+  | "mismatch"
+  | "missing_on_disk"
+  | "missing_in_manifest";
+
+export type AcquisitionBundleStatus =
+  | "verified"
+  | "verified_with_divergence"
+  | "failed_to_open";
+
+export interface AcquisitionVerificationRecord {
+  readonly scope: "bundle" | "source_manifest";
+  readonly sourceIndex: number | null;
+  readonly path: string;
+  readonly outcome: AcquisitionVerificationOutcome;
+  readonly expectedSize: number | null;
+  readonly actualSize: number | null;
+  readonly expectedSha256: string | null;
+  readonly actualSha256: string | null;
+}
+
+export interface AcquisitionBundleSource {
+  readonly sourceIndex: number;
+  readonly bundlePath: string;
+  readonly bundleSourcePath: string;
+  readonly originSourcePath: string;
+  readonly acquisitionHeader: ManifestHeader;
+  readonly acquisitionEntries: readonly ManifestEntry[];
+  readonly acquisitionManifestBytes: Buffer;
+  readonly profiles: readonly string[];
+  readonly workingCopyNodes: ReadonlyMap<string, ActualNode>;
+}
+
+export interface AcquisitionBundleInspection {
+  readonly bundleRoot: string;
+  readonly expectedBundleDigest: string;
+  readonly actualBundleDigest: string;
+  readonly sources: readonly AcquisitionBundleSource[];
+  readonly sourceErrors: readonly string[];
+  readonly records: readonly AcquisitionVerificationRecord[];
+}
+
+export interface MaterializedAcquisitionSource {
+  readonly entries: readonly ManifestEntry[];
+  readonly records: readonly AcquisitionVerificationRecord[];
+}
+
+interface ActualNode {
+  readonly path: string;
+  readonly absolutePath: string;
+  readonly nodeType: "file" | "dir" | "symlink" | "socket" | "other";
+  readonly stats: BigIntStats;
+}
+
+interface BundleFile {
+  readonly path: string;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+interface BundleUserDataDir {
+  readonly bundlePath: string;
+  readonly sourcePath: string;
+  readonly outcome: string;
+}
+
+interface DecodedBundleManifest {
+  readonly files: readonly BundleFile[];
+  readonly userDataDirs: readonly BundleUserDataDir[];
+  readonly bundleDigest: string;
+}
+
+function record(value: unknown, name: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new TypeError(`${name} must be an object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringValue(value: unknown, name: string): string {
+  if (typeof value !== "string") {
+    throw new TypeError(`${name} must be a string.`);
+  }
+  return value;
+}
+
+function nonnegativeInteger(value: unknown, name: string): number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new TypeError(`${name} must be a nonnegative safe integer.`);
+  }
+  return value as number;
+}
+
+function canonicalRelativePath(value: unknown, name: string): string {
+  const path = stringValue(value, name);
+  if (
+    path.length === 0 ||
+    path.startsWith("/") ||
+    path.includes("\\") ||
+    path.split("/").some((part) => part === "" || part === "." || part === "..")
+  ) {
+    throw new TypeError(`${name} is not a canonical relative path.`);
+  }
+  return path;
+}
+
+function decodeBundleManifest(value: unknown): DecodedBundleManifest {
+  const object = record(value, "Acquisition Bundle manifest");
+  if (
+    object.schema_version !== "forensix-acquisition-bundle-draft/1" ||
+    object.hash_algorithm !== HASH_ALGORITHM ||
+    !Array.isArray(object.files) ||
+    !Array.isArray(object.user_data_dirs)
+  ) {
+    throw new TypeError("Acquisition Bundle manifest is unsupported.");
+  }
+
+  const paths = new Set<string>();
+  const files = object.files.map((item, index) => {
+    const file = record(item, `files[${index}]`);
+    const path = canonicalRelativePath(file.path, `files[${index}].path`);
+    if (path === "bundle_manifest.json" || paths.has(path)) {
+      throw new TypeError(
+        "Acquisition Bundle file paths must be unique and cannot self-reference.",
+      );
+    }
+    paths.add(path);
+    const digest = stringValue(file.sha256, `files[${index}].sha256`);
+    if (!/^[0-9a-f]{64}$/.test(digest)) {
+      throw new TypeError(`files[${index}].sha256 is invalid.`);
+    }
+    return {
+      path,
+      size: nonnegativeInteger(file.size, `files[${index}].size`),
+      sha256: digest,
+    };
+  });
+
+  const userDataDirs = object.user_data_dirs.map((item, index) => {
+    const source = record(item, `user_data_dirs[${index}]`);
+    return {
+      bundlePath: canonicalRelativePath(
+        source.bundle_path,
+        `user_data_dirs[${index}].bundle_path`,
+      ),
+      sourcePath: stringValue(
+        source.source_path,
+        `user_data_dirs[${index}].source_path`,
+      ),
+      outcome: stringValue(source.outcome, `user_data_dirs[${index}].outcome`),
+    };
+  });
+  const bundleDigest = stringValue(object.bundle_digest, "bundle_digest");
+  if (!/^[0-9a-f]{64}$/.test(bundleDigest)) {
+    throw new TypeError("bundle_digest is invalid.");
+  }
+  return { files, userDataDirs, bundleDigest };
+}
+
+function nodeType(stats: BigIntStats): ActualNode["nodeType"] {
+  if (stats.isFile()) return "file";
+  if (stats.isDirectory()) return "dir";
+  if (stats.isSymbolicLink()) return "symlink";
+  if (stats.isSocket()) return "socket";
+  return "other";
+}
+
+function byteOrder(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+async function enumerateTree(root: string): Promise<Map<string, ActualNode>> {
+  const nodes = new Map<string, ActualNode>();
+
+  async function walk(
+    absoluteDirectory: string,
+    relativeDirectory: string,
+  ): Promise<void> {
+    const names = await readdir(absoluteDirectory);
+    names.sort(byteOrder);
+    for (const name of names) {
+      if (name.includes("\\")) {
+        throw new TypeError(
+          "Acquisition Bundle path cannot be represented canonically.",
+        );
+      }
+      const path = relativeDirectory ? `${relativeDirectory}/${name}` : name;
+      const absolutePath = join(absoluteDirectory, name);
+      const stats = await lstat(absolutePath, { bigint: true });
+      const type = nodeType(stats);
+      nodes.set(path, { path, absolutePath, nodeType: type, stats });
+      if (type === "dir") {
+        await walk(absolutePath, path);
+      }
+    }
+  }
+
+  await walk(root, "");
+  return nodes;
+}
+
+async function digestActualFile(
+  node: ActualNode,
+): Promise<{ size: number; sha256: string } | null> {
+  if (node.nodeType !== "file") {
+    return null;
+  }
+  const result = await readStableRegularFile(node.absolutePath, node.stats);
+  return result.status === "stable"
+    ? { size: result.size, sha256: result.sha256 }
+    : null;
+}
+
+function parseManifestBytes(bytes: Buffer): readonly ManifestEntry[] {
+  const text = bytes.toString("utf8");
+  if (text.length === 0) {
+    return [];
+  }
+  if (!text.endsWith("\n") || text.includes("\r")) {
+    throw new TypeError(
+      "Acquisition Manifest must use canonical LF-terminated JSONL.",
+    );
+  }
+  const entries = text
+    .slice(0, -1)
+    .split("\n")
+    .map((line) => decodeManifestEntry(JSON.parse(line)));
+  if (!manifestBytes(entries).equals(bytes)) {
+    throw new TypeError("Acquisition Manifest bytes are not canonical.");
+  }
+  return entries;
+}
+
+function assertHeaderMatchesEntries(
+  header: ManifestHeader,
+  entries: readonly ManifestEntry[],
+): void {
+  if (
+    header.source_kind !== "USER_DATA_DIR" ||
+    header.entry_count !== entries.length ||
+    header.copied_entry_count !==
+      entries.filter((entry) => entry.copied).length ||
+    header.unavailable_count !==
+      entries.filter((entry) => entry.state === "unavailable").length ||
+    header.unclassified_count !==
+      entries.filter(
+        (entry) =>
+          entry.state === "value" &&
+          entry.unclassified &&
+          entry.node_type !== "dir",
+      ).length ||
+    header.evidence_set_digest !== evidenceSetDigest(entries) ||
+    header.working_copy_digest !== workingCopyDigest(entries)
+  ) {
+    throw new TypeError(
+      "Acquisition Manifest header does not match its entries.",
+    );
+  }
+}
+
+function profilesFromEntries(entries: readonly ManifestEntry[]): string[] {
+  return entries
+    .filter(
+      (entry) =>
+        !entry.path.includes("/") &&
+        entry.state === "value" &&
+        entry.node_type === "dir" &&
+        entry.file_kind === "directory" &&
+        entry.selection_tier === "tier_1",
+    )
+    .map((entry) => entry.path)
+    .sort(byteOrder);
+}
+
+function childNodes(
+  nodes: ReadonlyMap<string, ActualNode>,
+  root: string,
+): Map<string, ActualNode> {
+  const prefix = `${root}/`;
+  const result = new Map<string, ActualNode>();
+  for (const [path, node] of nodes) {
+    if (path.startsWith(prefix)) {
+      result.set(path.slice(prefix.length), node);
+    }
+  }
+  return result;
+}
+
+export async function inspectAcquisitionBundle(
+  bundleRoot: string,
+): Promise<AcquisitionBundleInspection> {
+  let nodes: Map<string, ActualNode>;
+  let manifest: DecodedBundleManifest;
+  try {
+    nodes = await enumerateTree(bundleRoot);
+    const manifestNode = nodes.get("bundle_manifest.json");
+    if (manifestNode?.nodeType !== "file") {
+      throw new TypeError(
+        "bundle_manifest.json is missing or is not a regular file.",
+      );
+    }
+    manifest = decodeBundleManifest(
+      JSON.parse(await readFile(manifestNode.absolutePath, "utf8")),
+    );
+  } catch (error) {
+    throw new ForensixError(
+      "INGEST_FAILED",
+      "Acquisition Bundle could not be opened.",
+      { source_path: bundleRoot, bundle_status: "failed_to_open" },
+      { cause: error },
+    );
+  }
+
+  const expectedByPath = new Map(
+    manifest.files.map((file) => [file.path, file]),
+  );
+  const actualByPath = new Map<string, BundleFile>();
+  for (const [path, node] of nodes) {
+    if (path === "bundle_manifest.json" || node.nodeType !== "file") {
+      continue;
+    }
+    const digest = await digestActualFile(node);
+    if (digest !== null) {
+      actualByPath.set(path, {
+        path,
+        size: digest.size,
+        sha256: digest.sha256,
+      });
+    }
+  }
+  const actualBundleFiles = [...actualByPath.values()].sort((left, right) =>
+    byteOrder(left.path, right.path),
+  );
+
+  const records: AcquisitionVerificationRecord[] = [];
+  for (const expected of manifest.files) {
+    const actualNode = nodes.get(expected.path);
+    const actual = actualByPath.get(expected.path);
+    if (actualNode === undefined) {
+      records.push({
+        scope: "bundle",
+        sourceIndex: null,
+        path: expected.path,
+        outcome: "missing_on_disk",
+        expectedSize: expected.size,
+        actualSize: null,
+        expectedSha256: expected.sha256,
+        actualSha256: null,
+      });
+      continue;
+    }
+    records.push({
+      scope: "bundle",
+      sourceIndex: null,
+      path: expected.path,
+      outcome:
+        actual !== undefined &&
+        actual.size === expected.size &&
+        actual.sha256 === expected.sha256
+          ? "match"
+          : "mismatch",
+      expectedSize: expected.size,
+      actualSize: actual?.size ?? Number(actualNode.stats.size),
+      expectedSha256: expected.sha256,
+      actualSha256: actual?.sha256 ?? null,
+    });
+  }
+  for (const [path, actualNode] of nodes) {
+    if (
+      path === "bundle_manifest.json" ||
+      expectedByPath.has(path) ||
+      actualNode.nodeType === "dir"
+    ) {
+      continue;
+    }
+    const actual = actualByPath.get(path);
+    records.push({
+      scope: "bundle",
+      sourceIndex: null,
+      path,
+      outcome: "missing_in_manifest",
+      expectedSize: null,
+      actualSize: actual?.size ?? Number(actualNode.stats.size),
+      expectedSha256: null,
+      actualSha256: actual?.sha256 ?? null,
+    });
+  }
+  records.sort((left, right) => byteOrder(left.path, right.path));
+
+  const sourceErrors: string[] = [];
+  const sources: AcquisitionBundleSource[] = [];
+  for (const [sourceIndex, listedSource] of manifest.userDataDirs.entries()) {
+    if (listedSource.outcome !== "collected") {
+      continue;
+    }
+    const manifestPath = `${listedSource.bundlePath}/manifest.jsonl`;
+    const headerPath = `${listedSource.bundlePath}/manifest_header.json`;
+    const manifestNode = nodes.get(manifestPath);
+    const headerNode = nodes.get(headerPath);
+    if (manifestNode?.nodeType !== "file" || headerNode?.nodeType !== "file") {
+      sourceErrors.push(
+        `${listedSource.bundlePath}: acquisition Manifest is missing`,
+      );
+      continue;
+    }
+    try {
+      const acquisitionManifestBytes = await readFile(
+        manifestNode.absolutePath,
+      );
+      const acquisitionEntries = parseManifestBytes(acquisitionManifestBytes);
+      const acquisitionHeader = decodeManifestHeader(
+        JSON.parse(await readFile(headerNode.absolutePath, "utf8")),
+      );
+      assertHeaderMatchesEntries(acquisitionHeader, acquisitionEntries);
+      const profiles = profilesFromEntries(acquisitionEntries);
+      if (acquisitionHeader.profile_count !== profiles.length) {
+        throw new TypeError(
+          "Acquisition Manifest Profile count does not match its entries.",
+        );
+      }
+      sources.push({
+        sourceIndex,
+        bundlePath: listedSource.bundlePath,
+        bundleSourcePath: join(
+          bundleRoot,
+          ...listedSource.bundlePath.split("/"),
+        ),
+        originSourcePath: listedSource.sourcePath,
+        acquisitionHeader,
+        acquisitionEntries,
+        acquisitionManifestBytes,
+        profiles,
+        workingCopyNodes: childNodes(
+          nodes,
+          `${listedSource.bundlePath}/working_copy`,
+        ),
+      });
+    } catch (error) {
+      sourceErrors.push(
+        `${listedSource.bundlePath}: ${error instanceof Error ? error.message : "invalid acquisition Manifest"}`,
+      );
+    }
+  }
+
+  const actualBundleDigest = sha256(`${JSON.stringify(actualBundleFiles)}\n`);
+  return {
+    bundleRoot,
+    expectedBundleDigest: manifest.bundleDigest,
+    actualBundleDigest,
+    sources,
+    sourceErrors,
+    records,
+  };
+}
+
+function absentFrom(entry: ManifestEntry): ManifestEntry {
+  return {
+    ...entry,
+    state: "absent",
+    unavailable_reason: null,
+    node_type: "absent",
+    copied: false,
+    size: null,
+    mtime_ns: null,
+    sha256: representationDigest("absent"),
+    link_target: null,
+  };
+}
+
+async function observeNode(
+  path: string,
+  node: ActualNode,
+  original?: ManifestEntry,
+): Promise<ManifestEntry> {
+  const selection =
+    original === undefined
+      ? classifySourcePath(
+          path,
+          node.nodeType === "other" ? "file" : node.nodeType,
+        )
+      : {
+          tier: original.selection_tier,
+          fileKind: original.file_kind,
+          unclassified: original.unclassified,
+        };
+  if (node.nodeType === "file") {
+    const result = await readStableRegularFile(node.absolutePath, node.stats);
+    if (result.status !== "stable") {
+      return {
+        path,
+        state: "unavailable",
+        unavailable_reason:
+          result.status === "open_failed" || result.status === "read_failed"
+            ? "io_error"
+            : "changed_during_ingest",
+        node_type: "file",
+        file_kind: selection.fileKind,
+        selection_tier: selection.tier,
+        copied: false,
+        unclassified: selection.unclassified,
+        size: null,
+        mtime_ns: node.stats.mtimeNs.toString(),
+        hash_algorithm: HASH_ALGORITHM,
+        sha256: null,
+        link_target: null,
+      };
+    }
+    return {
+      path,
+      state: "value",
+      unavailable_reason: null,
+      node_type: "file",
+      file_kind: selection.fileKind,
+      selection_tier: selection.tier,
+      copied: false,
+      unclassified: selection.unclassified,
+      size: result.size,
+      mtime_ns: node.stats.mtimeNs.toString(),
+      hash_algorithm: HASH_ALGORITHM,
+      sha256: result.sha256,
+      link_target: null,
+    };
+  }
+  if (node.nodeType === "symlink") {
+    const target = await readlink(node.absolutePath, { encoding: "utf8" });
+    return {
+      path,
+      state: "value",
+      unavailable_reason: null,
+      node_type: "symlink",
+      file_kind: selection.fileKind,
+      selection_tier: selection.tier,
+      copied: false,
+      unclassified: selection.unclassified,
+      size: Buffer.byteLength(target, "utf8"),
+      mtime_ns: node.stats.mtimeNs.toString(),
+      hash_algorithm: HASH_ALGORITHM,
+      sha256: representationDigest("symlink", target),
+      link_target: target,
+    };
+  }
+  if (node.nodeType === "dir" || node.nodeType === "socket") {
+    return {
+      path,
+      state: "value",
+      unavailable_reason: null,
+      node_type: node.nodeType,
+      file_kind: node.nodeType === "dir" ? "directory" : selection.fileKind,
+      selection_tier: selection.tier,
+      copied: false,
+      unclassified: selection.unclassified,
+      size: null,
+      mtime_ns: node.stats.mtimeNs.toString(),
+      hash_algorithm: HASH_ALGORITHM,
+      sha256: representationDigest(node.nodeType),
+      link_target: null,
+    };
+  }
+  return {
+    path,
+    state: "unavailable",
+    unavailable_reason: "io_error",
+    node_type: "file",
+    file_kind: selection.fileKind,
+    selection_tier: selection.tier,
+    copied: false,
+    unclassified: selection.unclassified,
+    size: null,
+    mtime_ns: node.stats.mtimeNs.toString(),
+    hash_algorithm: HASH_ALGORITHM,
+    sha256: null,
+    link_target: null,
+  };
+}
+
+async function writeAll(destination: FileHandle, chunk: Buffer): Promise<void> {
+  let written = 0;
+  while (written < chunk.length) {
+    const result = await destination.write(
+      chunk,
+      written,
+      chunk.length - written,
+    );
+    written += result.bytesWritten;
+  }
+}
+
+async function copyVerifiedFile(
+  node: ActualNode,
+  destinationPath: string,
+  expected: ManifestEntry,
+): Promise<void> {
+  await mkdir(dirname(destinationPath), { recursive: true, mode: 0o700 });
+  const destination = await open(destinationPath, "wx", 0o600);
+  let keep = false;
+  try {
+    const result = await readStableRegularFile(
+      node.absolutePath,
+      node.stats,
+      async (chunk) => writeAll(destination, chunk),
+    );
+    if (
+      result.status !== "stable" ||
+      result.size !== expected.size ||
+      result.sha256 !== expected.sha256
+    ) {
+      throw new ForensixError(
+        "INGEST_FAILED",
+        "Acquisition Bundle file changed while it was copied.",
+        { path: expected.path },
+      );
+    }
+    await destination.sync();
+    keep = true;
+  } finally {
+    await destination.close().catch(() => undefined);
+    if (!keep) {
+      await rm(destinationPath, { force: true }).catch(() => undefined);
+    }
+  }
+}
+
+export async function materializeAcquisitionBundleSource(
+  source: AcquisitionBundleSource,
+  workingCopyRoot: string,
+): Promise<MaterializedAcquisitionSource> {
+  await mkdir(workingCopyRoot, { recursive: true, mode: 0o700 });
+  const entries: ManifestEntry[] = [];
+  const records: AcquisitionVerificationRecord[] = [];
+  const expectedPaths = new Set(
+    source.acquisitionEntries.map((entry) => entry.path),
+  );
+
+  for (const original of source.acquisitionEntries) {
+    const actual = source.workingCopyNodes.get(original.path);
+    if (!original.copied) {
+      if (actual === undefined || actual.nodeType === "dir") {
+        entries.push(original);
+        continue;
+      }
+      const observed = await observeNode(original.path, actual, original);
+      entries.push(observed);
+      records.push({
+        scope: "source_manifest",
+        sourceIndex: source.sourceIndex,
+        path: original.path,
+        outcome: "mismatch",
+        expectedSize: original.size,
+        actualSize: observed.size,
+        expectedSha256: original.sha256,
+        actualSha256: observed.sha256,
+      });
+      continue;
+    }
+
+    if (actual === undefined) {
+      entries.push(absentFrom(original));
+      records.push({
+        scope: "source_manifest",
+        sourceIndex: source.sourceIndex,
+        path: original.path,
+        outcome: "missing_on_disk",
+        expectedSize: original.size,
+        actualSize: null,
+        expectedSha256: original.sha256,
+        actualSha256: null,
+      });
+      continue;
+    }
+
+    const observed = await observeNode(original.path, actual, original);
+    const matches =
+      observed.state === "value" &&
+      observed.node_type === "file" &&
+      observed.size === original.size &&
+      observed.sha256 === original.sha256;
+    if (matches) {
+      await copyVerifiedFile(
+        actual,
+        join(workingCopyRoot, ...original.path.split("/")),
+        original,
+      );
+      entries.push(original);
+    } else {
+      entries.push(observed);
+    }
+    records.push({
+      scope: "source_manifest",
+      sourceIndex: source.sourceIndex,
+      path: original.path,
+      outcome: matches ? "match" : "mismatch",
+      expectedSize: original.size,
+      actualSize: observed.size,
+      expectedSha256: original.sha256,
+      actualSha256: observed.sha256,
+    });
+  }
+
+  for (const [path, actual] of source.workingCopyNodes) {
+    if (expectedPaths.has(path)) {
+      continue;
+    }
+    const observed = await observeNode(path, actual);
+    entries.push(observed);
+    if (actual.nodeType !== "dir") {
+      records.push({
+        scope: "source_manifest",
+        sourceIndex: source.sourceIndex,
+        path,
+        outcome: "missing_in_manifest",
+        expectedSize: null,
+        actualSize: observed.size,
+        expectedSha256: null,
+        actualSha256: observed.sha256,
+      });
+    }
+  }
+
+  records.sort((left, right) => byteOrder(left.path, right.path));
+  return { entries: sortManifestEntries(entries), records };
+}
+
+export function acquisitionBundleStatus(
+  inspection: AcquisitionBundleInspection,
+  sourceRecords: readonly AcquisitionVerificationRecord[],
+): AcquisitionBundleStatus {
+  const diverged =
+    inspection.expectedBundleDigest !== inspection.actualBundleDigest ||
+    inspection.sourceErrors.length > 0 ||
+    [...inspection.records, ...sourceRecords].some(
+      (record) => record.outcome !== "match",
+    );
+  return diverged ? "verified_with_divergence" : "verified";
+}

--- a/core/src/acquisition.ts
+++ b/core/src/acquisition.ts
@@ -13,9 +13,12 @@ import {
   type UnavailableReason,
 } from "./manifest.js";
 import {
+  classifyProfileSourcePath,
   classifySourcePath,
+  expectedProfileTierOnePaths,
   expectedTierOnePaths,
   isProfileDirectoryName,
+  type Selection,
 } from "./selection-policy.js";
 import { readStableRegularFile, sameNodeMetadata } from "./stable-file.js";
 
@@ -31,6 +34,8 @@ interface ScanContext {
   readonly includeTier2: boolean;
   readonly entries: ManifestEntry[];
   readonly profilePaths: Set<string>;
+  readonly classify: (path: string, nodeType: NodeType) => Selection;
+  readonly sourceLabel: "User Data Dir" | "Profile Dir";
 }
 
 class SourceRootChanged extends Error {}
@@ -74,8 +79,9 @@ function unavailableEntry(
   nodeType: Exclude<NodeType, "absent">,
   reason: UnavailableReason,
   mtimeNs: string | null,
+  classify: (path: string, nodeType: NodeType) => Selection,
 ): ManifestEntry {
-  const selection = classifySourcePath(path, nodeType);
+  const selection = classify(path, nodeType);
   return {
     path,
     state: "unavailable",
@@ -124,7 +130,7 @@ async function inspectFile(
   initialStats: BigIntStats,
   context: ScanContext,
 ): Promise<ManifestEntry> {
-  const selection = classifySourcePath(manifestPath, "file");
+  const selection = context.classify(manifestPath, "file");
   const shouldCopy =
     selection.tier === "tier_1" ||
     (selection.tier === "tier_2" && context.includeTier2);
@@ -181,6 +187,7 @@ async function inspectFile(
         "file",
         unavailableReason(result.error),
         initialStats.mtimeNs.toString(),
+        context.classify,
       );
     }
     if (result.status !== "stable") {
@@ -189,6 +196,7 @@ async function inspectFile(
         "file",
         "changed_during_ingest",
         initialStats.mtimeNs.toString(),
+        context.classify,
       );
     }
 
@@ -225,6 +233,7 @@ async function inspectSymlink(
   absolutePath: string,
   manifestPath: string,
   initialStats: BigIntStats,
+  context: ScanContext,
 ): Promise<ManifestEntry> {
   let target: string;
   try {
@@ -235,6 +244,7 @@ async function inspectSymlink(
       "symlink",
       unavailableReason(error),
       initialStats.mtimeNs.toString(),
+      context.classify,
     );
   }
 
@@ -247,6 +257,7 @@ async function inspectSymlink(
       "symlink",
       "changed_during_ingest",
       initialStats.mtimeNs.toString(),
+      context.classify,
     );
   }
   if (!sameNodeMetadata(initialStats, finalStats)) {
@@ -255,10 +266,11 @@ async function inspectSymlink(
       "symlink",
       "changed_during_ingest",
       initialStats.mtimeNs.toString(),
+      context.classify,
     );
   }
 
-  const selection = classifySourcePath(manifestPath, "symlink");
+  const selection = context.classify(manifestPath, "symlink");
   return {
     path: manifestPath,
     state: "value",
@@ -303,6 +315,7 @@ async function discardDirectoryObservation(
       "dir",
       reason,
       initialStats.mtimeNs.toString(),
+      context.classify,
     ),
   );
 }
@@ -314,7 +327,7 @@ async function inspectDirectory(
   context: ScanContext,
 ): Promise<void> {
   const entryStart = context.entries.length;
-  const selection = classifySourcePath(manifestPath, "dir");
+  const selection = context.classify(manifestPath, "dir");
   context.entries.push({
     path: manifestPath,
     state: "value",
@@ -331,7 +344,11 @@ async function inspectDirectory(
     link_target: null,
   });
 
-  if (!manifestPath.includes("/") && isProfileDirectoryName(manifestPath)) {
+  if (
+    context.sourceLabel === "User Data Dir" &&
+    !manifestPath.includes("/") &&
+    isProfileDirectoryName(manifestPath)
+  ) {
     context.profilePaths.add(manifestPath);
   }
 
@@ -405,7 +422,13 @@ async function inspectNode(
     stats = await lstat(absolutePath, { bigint: true });
   } catch (error) {
     context.entries.push(
-      unavailableEntry(manifestPath, "file", unavailableReason(error), null),
+      unavailableEntry(
+        manifestPath,
+        "file",
+        unavailableReason(error),
+        null,
+        context.classify,
+      ),
     );
     return;
   }
@@ -427,12 +450,12 @@ async function inspectNode(
   }
   if (nodeType === "symlink") {
     context.entries.push(
-      await inspectSymlink(absolutePath, manifestPath, stats),
+      await inspectSymlink(absolutePath, manifestPath, stats, context),
     );
     return;
   }
   if (nodeType === "socket") {
-    const selection = classifySourcePath(manifestPath, "socket");
+    const selection = context.classify(manifestPath, "socket");
     context.entries.push({
       path: manifestPath,
       state: "value",
@@ -473,19 +496,23 @@ function hasUnavailableParent(
 }
 
 function addExpectedEntries(
-  entries: ManifestEntry[],
+  context: ScanContext,
   profilePaths: readonly string[],
 ): void {
-  const actualPaths = new Set(entries.map((entry) => entry.path));
-  for (const path of expectedTierOnePaths(profilePaths)) {
+  const actualPaths = new Set(context.entries.map((entry) => entry.path));
+  const expectedPaths =
+    context.sourceLabel === "Profile Dir"
+      ? expectedProfileTierOnePaths()
+      : expectedTierOnePaths(profilePaths);
+  for (const path of expectedPaths) {
     if (actualPaths.has(path)) {
       continue;
     }
 
-    const parentUnavailable = hasUnavailableParent(path, entries);
+    const parentUnavailable = hasUnavailableParent(path, context.entries);
     const nodeType = parentUnavailable ? "file" : "absent";
-    const selection = classifySourcePath(path, nodeType);
-    entries.push({
+    const selection = context.classify(path, nodeType);
+    context.entries.push({
       path,
       state: parentUnavailable ? "unavailable" : "absent",
       unavailable_reason: parentUnavailable ? "parent_unavailable" : null,
@@ -507,6 +534,8 @@ async function scanOnce(
   sourceRoot: string,
   workingCopyRoot: string,
   includeTier2: boolean,
+  sourceLabel: "User Data Dir" | "Profile Dir",
+  classify: (path: string, nodeType: NodeType) => Selection,
 ): Promise<AcquisitionResult> {
   const initialRootStats = await lstat(sourceRoot, { bigint: true });
   let topLevelNames: string[];
@@ -515,7 +544,7 @@ async function scanOnce(
   } catch (error) {
     throw new ForensixError(
       "INGEST_FAILED",
-      "User Data Dir cannot be enumerated.",
+      `${sourceLabel} cannot be enumerated.`,
       { source_path: sourceRoot, reason: unavailableReason(error) },
       { cause: error },
     );
@@ -526,6 +555,8 @@ async function scanOnce(
     includeTier2,
     entries: [],
     profilePaths: new Set<string>(),
+    classify,
+    sourceLabel,
   };
   for (const childName of topLevelNames) {
     if (childName.includes("\\")) {
@@ -555,23 +586,34 @@ async function scanOnce(
     throw new SourceRootChanged();
   }
 
-  const profiles = [...context.profilePaths].sort((left, right) =>
-    Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8")),
-  );
-  addExpectedEntries(context.entries, profiles);
+  const profiles =
+    sourceLabel === "Profile Dir"
+      ? ["."]
+      : [...context.profilePaths].sort((left, right) =>
+          Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8")),
+        );
+  addExpectedEntries(context, profiles);
   return { entries: sortManifestEntries(context.entries), profiles };
 }
 
-export async function acquireUserDataDir(
+async function acquireDirectory(
   sourceRoot: string,
   workingCopyRoot: string,
   includeTier2: boolean,
+  sourceLabel: "User Data Dir" | "Profile Dir",
+  classify: (path: string, nodeType: NodeType) => Selection,
 ): Promise<AcquisitionResult> {
   for (let attempt = 1; attempt <= ROOT_SCAN_ATTEMPTS; attempt += 1) {
     await rm(workingCopyRoot, { force: true, recursive: true });
     await mkdir(workingCopyRoot, { recursive: true, mode: 0o700 });
     try {
-      return await scanOnce(sourceRoot, workingCopyRoot, includeTier2);
+      return await scanOnce(
+        sourceRoot,
+        workingCopyRoot,
+        includeTier2,
+        sourceLabel,
+        classify,
+      );
     } catch (error) {
       if (!(error instanceof SourceRootChanged)) {
         throw error;
@@ -579,7 +621,7 @@ export async function acquireUserDataDir(
       if (attempt === ROOT_SCAN_ATTEMPTS) {
         throw new ForensixError(
           "INGEST_FAILED",
-          "User Data Dir changed during ingest.",
+          `${sourceLabel} changed during ingest.`,
           { source_path: sourceRoot, reason: "changed_during_ingest" },
         );
       }
@@ -587,4 +629,32 @@ export async function acquireUserDataDir(
   }
 
   throw new Error("Unreachable acquisition retry state.");
+}
+
+export async function acquireUserDataDir(
+  sourceRoot: string,
+  workingCopyRoot: string,
+  includeTier2: boolean,
+): Promise<AcquisitionResult> {
+  return acquireDirectory(
+    sourceRoot,
+    workingCopyRoot,
+    includeTier2,
+    "User Data Dir",
+    classifySourcePath,
+  );
+}
+
+export async function acquireProfileDir(
+  sourceRoot: string,
+  workingCopyRoot: string,
+  includeTier2: boolean,
+): Promise<AcquisitionResult> {
+  return acquireDirectory(
+    sourceRoot,
+    workingCopyRoot,
+    includeTier2,
+    "Profile Dir",
+    classifyProfileSourcePath,
+  );
 }

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -25,6 +25,7 @@ export interface PersistedCandidate {
 }
 
 export interface HistoryArtifactWrite {
+  readonly sourceId: string;
   readonly profile: string;
   readonly status: "complete" | "absent" | "unavailable";
   readonly manifestEntryOrdinal: number | null;
@@ -41,7 +42,7 @@ export interface HistoryArtifactWrite {
 
 export interface StoreHistoryAnalysisOptions {
   readonly caseDirectory: string;
-  readonly sourceId: string;
+  readonly sourceIds: readonly string[];
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
   readonly invocation: readonly string[];
@@ -61,7 +62,6 @@ export function initializeFindingSchema(database: DatabaseSync): void {
 
     CREATE TABLE IF NOT EXISTS analysis_runs (
       run_id TEXT PRIMARY KEY,
-      source_id TEXT NOT NULL REFERENCES sources(source_id),
       artifact TEXT NOT NULL CHECK (artifact = 'History'),
       started_at TEXT NOT NULL,
       finished_at TEXT,
@@ -73,6 +73,12 @@ export function initializeFindingSchema(database: DatabaseSync): void {
         declared_origin_os IN ('windows', 'macos', 'linux')
       ),
       status TEXT NOT NULL CHECK (status IN ('running', 'complete', 'partial'))
+    ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS analysis_run_sources (
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      PRIMARY KEY (run_id, source_id)
     ) STRICT;
 
     CREATE TABLE IF NOT EXISTS history_artifact_results (
@@ -93,7 +99,7 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
       FOREIGN KEY (source_id, manifest_entry_ordinal)
         REFERENCES manifest_entries(source_id, ordinal),
-      UNIQUE (run_id, profile_path, artifact)
+      UNIQUE (run_id, source_id, profile_path, artifact)
     ) STRICT;
 
     CREATE UNIQUE INDEX IF NOT EXISTS history_one_active_result
@@ -222,19 +228,24 @@ export function storeHistoryAnalysis(
       database
         .prepare(
           `INSERT INTO analysis_runs
-             (run_id, source_id, artifact, started_at, tool_version,
-              invocation_json, declared_timezone, declared_origin_os, status)
-           VALUES (?, ?, 'History', ?, ?, ?, ?, ?, 'running')`,
+             (run_id, artifact, started_at, tool_version, invocation_json,
+              declared_timezone, declared_origin_os, status)
+           VALUES (?, 'History', ?, ?, ?, ?, ?, 'running')`,
         )
         .run(
           runId,
-          options.sourceId,
           options.startedAt,
           TOOL_VERSION,
           JSON.stringify(options.invocation),
           options.declaredTimezone,
           options.declaredOriginOs,
         );
+      const insertRunSource = database.prepare(
+        "INSERT INTO analysis_run_sources (run_id, source_id) VALUES (?, ?)",
+      );
+      for (const sourceId of [...new Set(options.sourceIds)].sort()) {
+        insertRunSource.run(runId, sourceId);
+      }
 
       const insertArtifact = database.prepare(
         `INSERT INTO history_artifact_results
@@ -271,7 +282,7 @@ export function storeHistoryAnalysis(
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
           runId,
-          options.sourceId,
+          artifact.sourceId,
           artifact.profile,
           artifact.manifestEntryOrdinal,
           artifact.databasePath,
@@ -299,7 +310,7 @@ export function storeHistoryAnalysis(
           );
         }
         if (artifact.status === "complete") {
-          deactivatePrevious.run(options.sourceId, artifact.profile);
+          deactivatePrevious.run(artifact.sourceId, artifact.profile);
           activateCurrent.run(artifactResultId);
         }
       }

--- a/core/src/case.ts
+++ b/core/src/case.ts
@@ -1,36 +1,100 @@
-import { randomUUID } from "node:crypto";
-import { existsSync } from "node:fs";
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { isAbsolute, join, relative, resolve, sep } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 
+import type {
+  AcquisitionBundleStatus,
+  AcquisitionVerificationOutcome,
+} from "./acquisition-bundle.js";
 import { ForensixError } from "./errors.js";
 import {
+  SOURCE_KINDS,
   decodeManifestEntry,
   type ManifestEntry,
   type ManifestHeader,
+  type SourceKind,
 } from "./manifest.js";
 
-export const CASE_SCHEMA_VERSION = 1;
+export const CASE_SCHEMA_VERSION = 2;
 export const CASE_FILENAME = "case.fxdb";
 export const TOOL_VERSION = "2.0.0-alpha.1";
 
-export interface CreateCaseDatabaseOptions {
-  readonly caseDirectory: string;
+export interface CaseProfileInput {
+  readonly profileId: string;
+  readonly path: string;
+}
+
+export interface SourceEvidenceGap {
+  readonly path: string;
+  readonly state: "unavailable";
+  readonly reason: "outside_source";
+}
+
+export interface AcquisitionManifestInput {
+  readonly manifestPath: string;
+  readonly headerPath: string;
+  readonly header: ManifestHeader;
+  readonly entries: readonly ManifestEntry[];
+}
+
+export interface CreateCaseSourceOptions {
+  readonly sourceId: string;
+  readonly manifestId: string;
+  readonly sourceKind: SourceKind;
   readonly sourcePath: string;
+  readonly sourceOriginPath: string | null;
   readonly workingCopyPath: string;
   readonly manifestPath: string;
   readonly header: ManifestHeader;
   readonly entries: readonly ManifestEntry[];
-  readonly profiles: readonly string[];
+  readonly profiles: readonly CaseProfileInput[];
+  readonly evidenceGaps: readonly SourceEvidenceGap[];
+  readonly acquisitionManifest?: AcquisitionManifestInput;
+}
+
+export interface CaseBundleVerificationFileInput {
+  readonly scope: "bundle" | "source_manifest";
+  readonly sourceId: string | null;
+  readonly path: string;
+  readonly outcome: AcquisitionVerificationOutcome;
+  readonly expectedSize: number | null;
+  readonly actualSize: number | null;
+  readonly expectedSha256: string | null;
+  readonly actualSha256: string | null;
+}
+
+export interface CaseBundleVerificationInput {
+  readonly bundleId: string;
+  readonly status: AcquisitionBundleStatus;
+  readonly expectedBundleDigest: string;
+  readonly actualBundleDigest: string;
+  readonly sourceErrors: readonly string[];
+  readonly files: readonly CaseBundleVerificationFileInput[];
+}
+
+export interface CreateCaseDatabaseOptions {
+  readonly caseDirectory: string;
+  readonly caseId: string;
+  readonly inputSourceKind: SourceKind;
+  readonly inputSourcePath: string;
+  readonly discoveryUnavailablePaths: readonly string[];
+  readonly sources: readonly CreateCaseSourceOptions[];
+  readonly bundleVerification?: CaseBundleVerificationInput;
+}
+
+export interface CaseProfileRecord {
+  readonly profileId: string;
+  readonly path: string;
 }
 
 export interface CaseSourceRecord {
   readonly caseId: string;
   readonly sourceId: string;
-  readonly sourceKind: "USER_DATA_DIR";
+  readonly manifestId: string;
+  readonly sourceKind: SourceKind;
   readonly sourcePath: string;
+  readonly sourceOriginPath: string | null;
   readonly selectionPolicy: "chrome-userdata/1";
   readonly manifestSchema: "forensix/manifest/1";
   readonly manifestPath: string;
@@ -42,10 +106,11 @@ export interface CaseSourceRecord {
   readonly entryCount: number;
   readonly copiedEntryCount: number;
   readonly profileCount: number;
-  readonly profiles: readonly string[];
   readonly unavailableCount: number;
   readonly unclassifiedCount: number;
   readonly entries: readonly ManifestEntry[];
+  readonly profiles: readonly CaseProfileRecord[];
+  readonly evidenceGaps: readonly SourceEvidenceGap[];
 }
 
 interface ManifestEntryRow {
@@ -67,8 +132,10 @@ interface ManifestEntryRow {
 interface SourceRow {
   readonly case_id: string;
   readonly source_id: string;
+  readonly manifest_id: string;
   readonly source_kind: string;
   readonly source_path: string;
+  readonly source_origin_path: string | null;
   readonly selection_policy: string;
   readonly manifest_schema: string;
   readonly manifest_path: string;
@@ -84,81 +151,171 @@ interface SourceRow {
   readonly unclassified_count: number;
 }
 
-export function createCaseDatabase(options: CreateCaseDatabaseOptions): {
-  readonly caseId: string;
-  readonly sourceId: string;
-} {
-  const caseId = randomUUID();
-  const sourceId = randomUUID();
+function createSchema(database: DatabaseSync): void {
+  database.exec(`
+    PRAGMA foreign_keys = ON;
+    PRAGMA journal_mode = WAL;
+    PRAGMA synchronous = FULL;
+    PRAGMA application_id = 0x46584A32;
+    PRAGMA user_version = ${CASE_SCHEMA_VERSION};
+
+    CREATE TABLE case_info (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      case_id TEXT NOT NULL UNIQUE,
+      schema_version INTEGER NOT NULL,
+      created_at TEXT NOT NULL,
+      tool_version TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE ingest_inputs (
+      singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+      case_id TEXT NOT NULL REFERENCES case_info(case_id),
+      source_kind TEXT NOT NULL CHECK (source_kind IN ('USER_DATA_DIR', 'PROFILE_DIR', 'FILESYSTEM_ROOT', 'IMAGE_CONTAINER', 'ACQUISITION_BUNDLE')),
+      source_path TEXT NOT NULL,
+      discovery_unavailable_paths_json TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE sources (
+      source_id TEXT PRIMARY KEY,
+      manifest_id TEXT NOT NULL UNIQUE,
+      case_id TEXT NOT NULL REFERENCES case_info(case_id),
+      source_kind TEXT NOT NULL CHECK (source_kind IN ('USER_DATA_DIR', 'PROFILE_DIR', 'FILESYSTEM_ROOT', 'IMAGE_CONTAINER', 'ACQUISITION_BUNDLE')),
+      source_path TEXT NOT NULL,
+      source_origin_path TEXT,
+      selection_policy TEXT NOT NULL CHECK (selection_policy = 'chrome-userdata/1'),
+      manifest_schema TEXT NOT NULL CHECK (manifest_schema = 'forensix/manifest/1'),
+      manifest_path TEXT NOT NULL UNIQUE,
+      tier_2_included INTEGER NOT NULL CHECK (tier_2_included IN (0, 1)),
+      evidence_set_digest TEXT NOT NULL,
+      working_copy_path TEXT NOT NULL UNIQUE,
+      working_copy_path_kind TEXT NOT NULL CHECK (working_copy_path_kind IN ('relative', 'absolute')),
+      working_copy_digest TEXT NOT NULL,
+      entry_count INTEGER NOT NULL,
+      copied_entry_count INTEGER NOT NULL,
+      profile_count INTEGER NOT NULL,
+      unavailable_count INTEGER NOT NULL,
+      unclassified_count INTEGER NOT NULL
+    ) STRICT;
+
+    CREATE TABLE profiles (
+      profile_id TEXT PRIMARY KEY,
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      path TEXT NOT NULL,
+      UNIQUE (source_id, path)
+    ) STRICT;
+
+    CREATE TABLE source_evidence_gaps (
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      path TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state = 'unavailable'),
+      reason TEXT NOT NULL CHECK (reason = 'outside_source'),
+      PRIMARY KEY (source_id, path)
+    ) STRICT;
+
+    CREATE TABLE manifest_entries (
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      ordinal INTEGER NOT NULL,
+      path TEXT NOT NULL,
+      state TEXT NOT NULL CHECK (state IN ('value', 'absent', 'unavailable')),
+      unavailable_reason TEXT,
+      node_type TEXT NOT NULL CHECK (node_type IN ('file', 'symlink', 'socket', 'dir', 'absent')),
+      file_kind TEXT NOT NULL,
+      selection_tier TEXT NOT NULL CHECK (selection_tier IN ('tier_1', 'tier_2', 'tier_3', 'unclassified')),
+      copied INTEGER NOT NULL CHECK (copied IN (0, 1)),
+      unclassified INTEGER NOT NULL CHECK (unclassified IN (0, 1)),
+      size INTEGER,
+      mtime_ns TEXT,
+      hash_algorithm TEXT NOT NULL CHECK (hash_algorithm = 'sha-256'),
+      sha256 TEXT,
+      link_target TEXT,
+      PRIMARY KEY (source_id, ordinal),
+      UNIQUE (source_id, path)
+    ) STRICT;
+
+    CREATE TABLE acquisition_manifests (
+      source_id TEXT PRIMARY KEY REFERENCES sources(source_id),
+      manifest_path TEXT NOT NULL,
+      header_path TEXT NOT NULL,
+      header_json TEXT NOT NULL,
+      evidence_set_digest TEXT NOT NULL,
+      working_copy_digest TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE acquisition_manifest_entries (
+      source_id TEXT NOT NULL REFERENCES acquisition_manifests(source_id),
+      ordinal INTEGER NOT NULL,
+      path TEXT NOT NULL,
+      state TEXT NOT NULL,
+      unavailable_reason TEXT,
+      node_type TEXT NOT NULL,
+      file_kind TEXT NOT NULL,
+      selection_tier TEXT NOT NULL,
+      copied INTEGER NOT NULL CHECK (copied IN (0, 1)),
+      unclassified INTEGER NOT NULL CHECK (unclassified IN (0, 1)),
+      size INTEGER,
+      mtime_ns TEXT,
+      hash_algorithm TEXT NOT NULL,
+      sha256 TEXT,
+      link_target TEXT,
+      PRIMARY KEY (source_id, ordinal),
+      UNIQUE (source_id, path)
+    ) STRICT;
+
+    CREATE TABLE acquisition_bundle_verifications (
+      bundle_id TEXT PRIMARY KEY,
+      case_id TEXT NOT NULL REFERENCES case_info(case_id),
+      status TEXT NOT NULL CHECK (status IN ('verified', 'verified_with_divergence', 'failed_to_open')),
+      expected_bundle_digest TEXT NOT NULL,
+      actual_bundle_digest TEXT NOT NULL,
+      source_errors_json TEXT NOT NULL
+    ) STRICT;
+
+    CREATE TABLE acquisition_bundle_files (
+      bundle_id TEXT NOT NULL REFERENCES acquisition_bundle_verifications(bundle_id),
+      ordinal INTEGER NOT NULL,
+      scope TEXT NOT NULL CHECK (scope IN ('bundle', 'source_manifest')),
+      source_id TEXT REFERENCES sources(source_id),
+      path TEXT NOT NULL,
+      outcome TEXT NOT NULL CHECK (outcome IN ('match', 'mismatch', 'missing_on_disk', 'missing_in_manifest')),
+      expected_size INTEGER,
+      actual_size INTEGER,
+      expected_sha256 TEXT,
+      actual_sha256 TEXT,
+      PRIMARY KEY (bundle_id, ordinal)
+    ) STRICT;
+  `);
+}
+
+function insertEntry(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  sourceId: string,
+  ordinal: number,
+  entry: ManifestEntry,
+): void {
+  statement.run(
+    sourceId,
+    ordinal,
+    entry.path,
+    entry.state,
+    entry.unavailable_reason,
+    entry.node_type,
+    entry.file_kind,
+    entry.selection_tier,
+    entry.copied ? 1 : 0,
+    entry.unclassified ? 1 : 0,
+    entry.size,
+    entry.mtime_ns,
+    entry.hash_algorithm,
+    entry.sha256,
+    entry.link_target,
+  );
+}
+
+export function createCaseDatabase(options: CreateCaseDatabaseOptions): void {
   const databasePath = join(options.caseDirectory, CASE_FILENAME);
   const database = new DatabaseSync(databasePath);
-
   try {
-    database.exec(`
-      PRAGMA foreign_keys = ON;
-      PRAGMA journal_mode = WAL;
-      PRAGMA synchronous = FULL;
-      PRAGMA application_id = 0x46584A32;
-      PRAGMA user_version = ${CASE_SCHEMA_VERSION};
-
-      CREATE TABLE case_info (
-        singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
-        case_id TEXT NOT NULL UNIQUE,
-        schema_version INTEGER NOT NULL,
-        created_at TEXT NOT NULL,
-        tool_version TEXT NOT NULL
-      ) STRICT;
-
-      CREATE TABLE sources (
-        source_id TEXT PRIMARY KEY,
-        case_id TEXT NOT NULL REFERENCES case_info(case_id),
-        source_kind TEXT NOT NULL CHECK (source_kind = 'USER_DATA_DIR'),
-        source_path TEXT NOT NULL,
-        selection_policy TEXT NOT NULL CHECK (selection_policy = 'chrome-userdata/1'),
-        manifest_schema TEXT NOT NULL CHECK (manifest_schema = 'forensix/manifest/1'),
-        manifest_path TEXT NOT NULL,
-        tier_2_included INTEGER NOT NULL CHECK (tier_2_included IN (0, 1)),
-        evidence_set_digest TEXT NOT NULL,
-        working_copy_path TEXT NOT NULL,
-        working_copy_path_kind TEXT NOT NULL CHECK (working_copy_path_kind IN ('relative', 'absolute')),
-        working_copy_digest TEXT NOT NULL,
-        entry_count INTEGER NOT NULL,
-        copied_entry_count INTEGER NOT NULL,
-        profile_count INTEGER NOT NULL,
-        unavailable_count INTEGER NOT NULL,
-        unclassified_count INTEGER NOT NULL
-      ) STRICT;
-
-      CREATE TABLE profiles (
-        source_id TEXT NOT NULL REFERENCES sources(source_id),
-        path TEXT NOT NULL,
-        PRIMARY KEY (source_id, path)
-      ) STRICT;
-
-      CREATE TABLE manifest_entries (
-        source_id TEXT NOT NULL REFERENCES sources(source_id),
-        ordinal INTEGER NOT NULL,
-        path TEXT NOT NULL,
-        state TEXT NOT NULL CHECK (state IN ('value', 'absent', 'unavailable')),
-        unavailable_reason TEXT,
-        node_type TEXT NOT NULL CHECK (node_type IN ('file', 'symlink', 'socket', 'dir', 'absent')),
-        file_kind TEXT NOT NULL,
-        selection_tier TEXT NOT NULL CHECK (selection_tier IN ('tier_1', 'tier_2', 'tier_3', 'unclassified')),
-        copied INTEGER NOT NULL CHECK (copied IN (0, 1)),
-        unclassified INTEGER NOT NULL CHECK (unclassified IN (0, 1)),
-        size INTEGER,
-        mtime_ns TEXT,
-        hash_algorithm TEXT NOT NULL CHECK (hash_algorithm = 'sha-256'),
-        sha256 TEXT,
-        link_target TEXT,
-        PRIMARY KEY (source_id, ordinal),
-        UNIQUE (source_id, path)
-      ) STRICT;
-    `);
-
-    const workingCopyPathKind = isAbsolute(options.workingCopyPath)
-      ? "absolute"
-      : "relative";
+    createSchema(database);
     database.exec("BEGIN IMMEDIATE;");
     try {
       database
@@ -168,104 +325,186 @@ export function createCaseDatabase(options: CreateCaseDatabaseOptions): {
            VALUES (1, ?, ?, ?, ?)`,
         )
         .run(
-          caseId,
+          options.caseId,
           CASE_SCHEMA_VERSION,
           new Date().toISOString(),
           TOOL_VERSION,
         );
       database
         .prepare(
-          `INSERT INTO sources
-            (source_id, case_id, source_kind, source_path, selection_policy,
-             manifest_schema, manifest_path, tier_2_included, evidence_set_digest,
-             working_copy_path, working_copy_path_kind, working_copy_digest, entry_count,
-             copied_entry_count, profile_count, unavailable_count, unclassified_count)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO ingest_inputs
+            (singleton, case_id, source_kind, source_path, discovery_unavailable_paths_json)
+           VALUES (1, ?, ?, ?, ?)`,
         )
         .run(
-          sourceId,
-          caseId,
-          options.header.source_kind,
-          options.sourcePath,
-          options.header.selection_policy,
-          options.header.manifest_schema,
-          options.manifestPath,
-          options.header.tier_2_included ? 1 : 0,
-          options.header.evidence_set_digest,
-          options.workingCopyPath,
-          workingCopyPathKind,
-          options.header.working_copy_digest,
-          options.header.entry_count,
-          options.header.copied_entry_count,
-          options.header.profile_count,
-          options.header.unavailable_count,
-          options.header.unclassified_count,
+          options.caseId,
+          options.inputSourceKind,
+          options.inputSourcePath,
+          JSON.stringify(options.discoveryUnavailablePaths),
         );
 
+      const insertSource = database.prepare(`
+        INSERT INTO sources
+          (source_id, manifest_id, case_id, source_kind, source_path,
+           source_origin_path, selection_policy, manifest_schema, manifest_path,
+           tier_2_included, evidence_set_digest, working_copy_path,
+           working_copy_path_kind, working_copy_digest, entry_count,
+           copied_entry_count, profile_count, unavailable_count, unclassified_count)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
       const insertProfile = database.prepare(
-        "INSERT INTO profiles (source_id, path) VALUES (?, ?)",
+        "INSERT INTO profiles (profile_id, source_id, path) VALUES (?, ?, ?)",
       );
-      for (const profile of options.profiles) {
-        insertProfile.run(sourceId, profile);
-      }
-
-      const insertEntry = database.prepare(`
+      const insertGap = database.prepare(
+        "INSERT INTO source_evidence_gaps (source_id, path, state, reason) VALUES (?, ?, ?, ?)",
+      );
+      const entrySql = `
         INSERT INTO manifest_entries
           (source_id, ordinal, path, state, unavailable_reason, node_type,
            file_kind, selection_tier, copied, unclassified, size, mtime_ns,
            hash_algorithm, sha256, link_target)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-      `);
-      for (const [ordinal, entry] of options.entries.entries()) {
-        insertEntry.run(
-          sourceId,
-          ordinal,
-          entry.path,
-          entry.state,
-          entry.unavailable_reason,
-          entry.node_type,
-          entry.file_kind,
-          entry.selection_tier,
-          entry.copied ? 1 : 0,
-          entry.unclassified ? 1 : 0,
-          entry.size,
-          entry.mtime_ns,
-          entry.hash_algorithm,
-          entry.sha256,
-          entry.link_target,
+      `;
+      const insertManifestEntry = database.prepare(entrySql);
+      const insertAcquisitionEntry = database.prepare(
+        entrySql.replace("manifest_entries", "acquisition_manifest_entries"),
+      );
+
+      for (const source of options.sources) {
+        const workingCopyPathKind = isAbsolute(source.workingCopyPath)
+          ? "absolute"
+          : "relative";
+        insertSource.run(
+          source.sourceId,
+          source.manifestId,
+          options.caseId,
+          source.sourceKind,
+          source.sourcePath,
+          source.sourceOriginPath,
+          source.header.selection_policy,
+          source.header.manifest_schema,
+          source.manifestPath,
+          source.header.tier_2_included ? 1 : 0,
+          source.header.evidence_set_digest,
+          source.workingCopyPath,
+          workingCopyPathKind,
+          source.header.working_copy_digest,
+          source.header.entry_count,
+          source.header.copied_entry_count,
+          source.header.profile_count,
+          source.header.unavailable_count,
+          source.header.unclassified_count,
         );
+        for (const profile of source.profiles) {
+          insertProfile.run(profile.profileId, source.sourceId, profile.path);
+        }
+        for (const gap of source.evidenceGaps) {
+          insertGap.run(source.sourceId, gap.path, gap.state, gap.reason);
+        }
+        for (const [ordinal, entry] of source.entries.entries()) {
+          insertEntry(insertManifestEntry, source.sourceId, ordinal, entry);
+        }
+        if (source.acquisitionManifest !== undefined) {
+          database
+            .prepare(
+              `INSERT INTO acquisition_manifests
+                (source_id, manifest_path, header_path, header_json,
+                 evidence_set_digest, working_copy_digest)
+               VALUES (?, ?, ?, ?, ?, ?)`,
+            )
+            .run(
+              source.sourceId,
+              source.acquisitionManifest.manifestPath,
+              source.acquisitionManifest.headerPath,
+              JSON.stringify(source.acquisitionManifest.header),
+              source.acquisitionManifest.header.evidence_set_digest,
+              source.acquisitionManifest.header.working_copy_digest,
+            );
+          for (const [
+            ordinal,
+            entry,
+          ] of source.acquisitionManifest.entries.entries()) {
+            insertEntry(
+              insertAcquisitionEntry,
+              source.sourceId,
+              ordinal,
+              entry,
+            );
+          }
+        }
+      }
+
+      if (options.bundleVerification !== undefined) {
+        const verification = options.bundleVerification;
+        database
+          .prepare(
+            `INSERT INTO acquisition_bundle_verifications
+              (bundle_id, case_id, status, expected_bundle_digest,
+               actual_bundle_digest, source_errors_json)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+          )
+          .run(
+            verification.bundleId,
+            options.caseId,
+            verification.status,
+            verification.expectedBundleDigest,
+            verification.actualBundleDigest,
+            JSON.stringify(verification.sourceErrors),
+          );
+        const insertFile = database.prepare(`
+          INSERT INTO acquisition_bundle_files
+            (bundle_id, ordinal, scope, source_id, path, outcome,
+             expected_size, actual_size, expected_sha256, actual_sha256)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `);
+        for (const [ordinal, file] of verification.files.entries()) {
+          insertFile.run(
+            verification.bundleId,
+            ordinal,
+            file.scope,
+            file.sourceId,
+            file.path,
+            file.outcome,
+            file.expectedSize,
+            file.actualSize,
+            file.expectedSha256,
+            file.actualSha256,
+          );
+        }
       }
       database.exec("COMMIT;");
     } catch (error) {
       database.exec("ROLLBACK;");
       throw error;
     }
-
     database.exec("PRAGMA wal_checkpoint(TRUNCATE);");
-    return { caseId, sourceId };
   } finally {
     database.close();
   }
 }
 
-export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
+function openCaseDatabase(caseDirectory: string): {
+  readonly database: DatabaseSync;
+  readonly databasePath: string;
+  readonly resolvedCaseDirectory: string;
+} {
   const resolvedCaseDirectory = resolve(caseDirectory);
   const databasePath = join(resolvedCaseDirectory, CASE_FILENAME);
   if (!existsSync(databasePath)) {
     throw new ForensixError(
       "CASE_NOT_FOUND",
       `Case file does not exist: ${databasePath}`,
-      {
-        case_directory: resolvedCaseDirectory,
-      },
+      { case_directory: resolvedCaseDirectory },
     );
   }
-
-  let database: DatabaseSync;
   try {
     const databaseUrl = pathToFileURL(databasePath);
     databaseUrl.searchParams.set("immutable", "1");
-    database = new DatabaseSync(databaseUrl.href);
+    return {
+      database: new DatabaseSync(databaseUrl.href),
+      databasePath,
+      resolvedCaseDirectory,
+    };
   } catch (error) {
     throw new ForensixError(
       "CASE_INVALID",
@@ -274,123 +513,140 @@ export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
       { cause: error },
     );
   }
+}
 
+function decodeEntryRow(row: ManifestEntryRow): ManifestEntry {
+  if (
+    (row.copied !== 0 && row.copied !== 1) ||
+    (row.unclassified !== 0 && row.unclassified !== 1)
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Manifest boolean.",
+      { path: row.path },
+    );
+  }
+  return decodeManifestEntry({
+    path: row.path,
+    state: row.state,
+    unavailable_reason: row.unavailable_reason,
+    node_type: row.node_type,
+    file_kind: row.file_kind,
+    selection_tier: row.selection_tier,
+    copied: row.copied === 1,
+    unclassified: row.unclassified === 1,
+    size: row.size,
+    mtime_ns: row.mtime_ns,
+    hash_algorithm: row.hash_algorithm,
+    sha256: row.sha256,
+    link_target: row.link_target,
+  });
+}
+
+export function loadCaseSources(
+  caseDirectory: string,
+): readonly CaseSourceRecord[] {
+  const { database, databasePath, resolvedCaseDirectory } =
+    openCaseDatabase(caseDirectory);
   try {
-    const source = database
+    const sourceRows = database
       .prepare(
-        `SELECT c.case_id, s.source_id, s.source_kind, s.source_path,
-                s.selection_policy, s.manifest_schema, s.manifest_path,
-                s.tier_2_included, s.evidence_set_digest, s.working_copy_path,
+        `SELECT c.case_id, s.source_id, s.manifest_id, s.source_kind,
+                s.source_path, s.source_origin_path, s.selection_policy,
+                s.manifest_schema, s.manifest_path, s.tier_2_included,
+                s.evidence_set_digest, s.working_copy_path,
                 s.working_copy_path_kind, s.working_copy_digest,
                 s.entry_count, s.copied_entry_count, s.profile_count,
                 s.unavailable_count, s.unclassified_count
            FROM sources s
            JOIN case_info c ON c.case_id = s.case_id
-          ORDER BY s.source_id
-          LIMIT 1`,
+          ORDER BY s.source_id`,
       )
-      .get() as SourceRow | undefined;
-    if (source === undefined) {
+      .all() as unknown as SourceRow[];
+    if (sourceRows.length === 0) {
       throw new ForensixError("CASE_INVALID", "Case file contains no Source.", {
         case_directory: resolvedCaseDirectory,
       });
     }
-    if (
-      source.source_kind !== "USER_DATA_DIR" ||
-      source.selection_policy !== "chrome-userdata/1" ||
-      source.manifest_schema !== "forensix/manifest/1" ||
-      (source.working_copy_path_kind !== "relative" &&
-        source.working_copy_path_kind !== "absolute")
-    ) {
-      throw new ForensixError(
-        "CASE_INVALID",
-        "Case Source contract is not supported.",
-        {
-          case_directory: resolvedCaseDirectory,
-        },
-      );
-    }
 
-    const profileRows = database
-      .prepare("SELECT path FROM profiles WHERE source_id = ? ORDER BY path")
-      .all(source.source_id) as unknown as { readonly path: string }[];
-    if (profileRows.length !== source.profile_count) {
-      throw new ForensixError(
-        "CASE_INVALID",
-        "Case Profile count does not match.",
-        { expected: source.profile_count, actual: profileRows.length },
-      );
-    }
-
-    const rows = database
-      .prepare(
-        `SELECT path, state, unavailable_reason, node_type, file_kind,
-                selection_tier, copied, unclassified, size, mtime_ns,
-                hash_algorithm, sha256, link_target
-           FROM manifest_entries
-          WHERE source_id = ?
-          ORDER BY ordinal`,
-      )
-      .all(source.source_id) as unknown as ManifestEntryRow[];
-    const entries = rows.map((row) => {
+    return sourceRows.map((source) => {
       if (
-        (row.copied !== 0 && row.copied !== 1) ||
-        (row.unclassified !== 0 && row.unclassified !== 1)
+        !SOURCE_KINDS.includes(source.source_kind as SourceKind) ||
+        source.selection_policy !== "chrome-userdata/1" ||
+        source.manifest_schema !== "forensix/manifest/1" ||
+        (source.working_copy_path_kind !== "relative" &&
+          source.working_copy_path_kind !== "absolute") ||
+        (source.tier_2_included !== 0 && source.tier_2_included !== 1)
       ) {
         throw new ForensixError(
           "CASE_INVALID",
-          "Case contains an invalid Manifest boolean.",
-          { path: row.path },
+          "Case Source contract is not supported.",
+          { case_directory: resolvedCaseDirectory },
         );
       }
-      return decodeManifestEntry({
-        path: row.path,
-        state: row.state,
-        unavailable_reason: row.unavailable_reason,
-        node_type: row.node_type,
-        file_kind: row.file_kind,
-        selection_tier: row.selection_tier,
-        copied: row.copied === 1,
-        unclassified: row.unclassified === 1,
-        size: row.size,
-        mtime_ns: row.mtime_ns,
-        hash_algorithm: row.hash_algorithm,
-        sha256: row.sha256,
-        link_target: row.link_target,
-      });
-    });
-    if (entries.length !== source.entry_count) {
-      throw new ForensixError(
-        "CASE_INVALID",
-        "Case Manifest entry count does not match.",
-        {
-          expected: source.entry_count,
-          actual: entries.length,
-        },
-      );
-    }
+      const rows = database
+        .prepare(
+          `SELECT path, state, unavailable_reason, node_type, file_kind,
+                  selection_tier, copied, unclassified, size, mtime_ns,
+                  hash_algorithm, sha256, link_target
+             FROM manifest_entries
+            WHERE source_id = ?
+            ORDER BY ordinal`,
+        )
+        .all(source.source_id) as unknown as ManifestEntryRow[];
+      const entries = rows.map(decodeEntryRow);
+      if (entries.length !== source.entry_count) {
+        throw new ForensixError(
+          "CASE_INVALID",
+          "Case Manifest entry count does not match.",
+          { expected: source.entry_count, actual: entries.length },
+        );
+      }
+      const profiles = database
+        .prepare(
+          "SELECT profile_id, path FROM profiles WHERE source_id = ? ORDER BY path",
+        )
+        .all(source.source_id) as unknown as CaseProfileRecord[];
+      if (profiles.length !== source.profile_count) {
+        throw new ForensixError(
+          "CASE_INVALID",
+          "Case Profile count does not match.",
+          { expected: source.profile_count, actual: profiles.length },
+        );
+      }
+      const evidenceGaps = database
+        .prepare(
+          "SELECT path, state, reason FROM source_evidence_gaps WHERE source_id = ? ORDER BY path",
+        )
+        .all(source.source_id) as unknown as SourceEvidenceGap[];
 
-    return {
-      caseId: source.case_id,
-      sourceId: source.source_id,
-      sourceKind: "USER_DATA_DIR",
-      sourcePath: source.source_path,
-      selectionPolicy: "chrome-userdata/1",
-      manifestSchema: "forensix/manifest/1",
-      manifestPath: source.manifest_path,
-      tier2Included: source.tier_2_included === 1,
-      evidenceSetDigest: source.evidence_set_digest,
-      workingCopyPath: source.working_copy_path,
-      workingCopyPathKind: source.working_copy_path_kind,
-      workingCopyDigest: source.working_copy_digest,
-      entryCount: source.entry_count,
-      copiedEntryCount: source.copied_entry_count,
-      profileCount: source.profile_count,
-      profiles: profileRows.map((row) => row.path),
-      unavailableCount: source.unavailable_count,
-      unclassifiedCount: source.unclassified_count,
-      entries,
-    };
+      return {
+        caseId: source.case_id,
+        sourceId: source.source_id,
+        manifestId: source.manifest_id,
+        sourceKind: source.source_kind as SourceKind,
+        sourcePath: source.source_path,
+        sourceOriginPath: source.source_origin_path,
+        selectionPolicy: "chrome-userdata/1",
+        manifestSchema: "forensix/manifest/1",
+        manifestPath: source.manifest_path,
+        tier2Included: source.tier_2_included === 1,
+        evidenceSetDigest: source.evidence_set_digest,
+        workingCopyPath: source.working_copy_path,
+        workingCopyPathKind: source.working_copy_path_kind as
+          | "relative"
+          | "absolute",
+        workingCopyDigest: source.working_copy_digest,
+        entryCount: source.entry_count,
+        copiedEntryCount: source.copied_entry_count,
+        profileCount: source.profile_count,
+        unavailableCount: source.unavailable_count,
+        unclassifiedCount: source.unclassified_count,
+        entries,
+        profiles,
+        evidenceGaps,
+      };
+    });
   } catch (error) {
     if (error instanceof ForensixError) {
       throw error;
@@ -404,6 +660,81 @@ export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
   } finally {
     database.close();
   }
+}
+
+export function loadCaseSource(caseDirectory: string): CaseSourceRecord {
+  const source = loadCaseSources(caseDirectory)[0];
+  if (source === undefined) {
+    throw new ForensixError("CASE_INVALID", "Case file contains no Source.");
+  }
+  return source;
+}
+
+export function caseArtifactAbsolutePath(
+  caseDirectory: string,
+  artifactPath: string,
+): string {
+  if (isAbsolute(artifactPath)) {
+    throw new ForensixError("CASE_INVALID", "Case artifact path is absolute.", {
+      artifact_path: artifactPath,
+    });
+  }
+
+  const resolvedCaseDirectory = resolve(caseDirectory);
+  const resolvedArtifactPath = resolve(resolvedCaseDirectory, artifactPath);
+  const difference = relative(resolvedCaseDirectory, resolvedArtifactPath);
+  if (
+    difference === "" ||
+    difference === ".." ||
+    difference.startsWith(`..${sep}`) ||
+    isAbsolute(difference)
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case artifact path escapes the Case Directory.",
+      { artifact_path: artifactPath },
+    );
+  }
+
+  try {
+    const physicalCaseDirectory = realpathSync(resolvedCaseDirectory);
+    const physicalArtifactPath = realpathSync(resolvedArtifactPath);
+    const physicalDifference = relative(
+      physicalCaseDirectory,
+      physicalArtifactPath,
+    );
+    if (
+      physicalDifference === "" ||
+      physicalDifference === ".." ||
+      physicalDifference.startsWith(`..${sep}`) ||
+      isAbsolute(physicalDifference)
+    ) {
+      throw new ForensixError(
+        "CASE_INVALID",
+        "Case artifact path escapes the Case Directory.",
+        { artifact_path: artifactPath },
+      );
+    }
+  } catch (error) {
+    if (error instanceof ForensixError) {
+      throw error;
+    }
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "code" in error &&
+      error.code === "ENOENT"
+    ) {
+      return resolvedArtifactPath;
+    }
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case artifact path cannot be resolved.",
+      { artifact_path: artifactPath },
+      { cause: error },
+    );
+  }
+  return resolvedArtifactPath;
 }
 
 export function workingCopyAbsolutePath(

--- a/core/src/errors.ts
+++ b/core/src/errors.ts
@@ -54,7 +54,9 @@ export type WorkingCopyIssueReason =
   | "entry_hash_mismatch"
   | "entry_size_mismatch"
   | "unexpected_entry"
+  | "manifest_artifact_missing"
   | "manifest_digest_mismatch"
+  | "manifest_header_mismatch"
   | "working_copy_digest_mismatch";
 
 export interface WorkingCopyIssue {

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -7,7 +7,7 @@ import {
   type PersistedFinding,
 } from "./case-findings.js";
 import {
-  loadCaseSource,
+  loadCaseSources,
   workingCopyAbsolutePath,
   type CaseSourceRecord,
 } from "./case.js";
@@ -896,6 +896,7 @@ function manifestIdentity(
 }
 
 function unavailableArtifact(
+  sourceId: string,
   profile: string,
   databasePath: string,
   manifestEntryOrdinal: number | null,
@@ -903,6 +904,7 @@ function unavailableArtifact(
   reason: string,
 ): HistoryArtifactWrite {
   return {
+    sourceId,
     profile,
     status,
     manifestEntryOrdinal,
@@ -924,10 +926,12 @@ async function analyseProfile(options: {
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
 }): Promise<HistoryArtifactWrite> {
-  const databasePath = `${options.profile}/History`;
+  const databasePath =
+    options.profile === "." ? "History" : `${options.profile}/History`;
   const manifest = manifestIdentity(options.source, databasePath);
   if (manifest === null) {
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       null,
@@ -941,6 +945,7 @@ async function analyseProfile(options: {
   }
   if (entry.state === "absent") {
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       manifest.ordinal,
@@ -950,6 +955,7 @@ async function analyseProfile(options: {
   }
   if (entry.state === "unavailable") {
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       manifest.ordinal,
@@ -959,6 +965,7 @@ async function analyseProfile(options: {
   }
   if (!entry.copied) {
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       manifest.ordinal,
@@ -969,6 +976,7 @@ async function analyseProfile(options: {
 
   if (entry.size === null || entry.sha256 === null) {
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       manifest.ordinal,
@@ -1061,6 +1069,7 @@ async function analyseProfile(options: {
           });
     const allVisits = [...committed, ...recovered];
     return {
+      sourceId: options.source.sourceId,
       profile: options.profile,
       status: "complete",
       manifestEntryOrdinal: manifest.ordinal,
@@ -1085,6 +1094,7 @@ async function analyseProfile(options: {
         ? `${error.code}:${error.message}`
         : `history_read_failed:${String(error)}`;
     return unavailableArtifact(
+      options.source.sourceId,
       options.profile,
       databasePath,
       manifest.ordinal,
@@ -1104,36 +1114,40 @@ export async function analyseCase(
   const declaredOriginOs = options.declaredOriginOs ?? null;
   const startedAt = new Date().toISOString();
   const verification = await verifyWorkingCopy(caseDirectory);
-  const source = loadCaseSource(caseDirectory);
-  const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
+  const sources = loadCaseSources(caseDirectory);
   const artifacts: HistoryArtifactWrite[] = [];
-  for (const profile of source.profiles) {
-    artifacts.push(
-      await analyseProfile({
-        source,
-        profile,
-        workingCopyPath,
-        declaredTimezone,
-        declaredOriginOs,
-      }),
-    );
+  for (const source of sources) {
+    const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
+    for (const profile of source.profiles) {
+      artifacts.push(
+        await analyseProfile({
+          source,
+          profile: profile.path,
+          workingCopyPath,
+          declaredTimezone,
+          declaredOriginOs,
+        }),
+      );
+    }
   }
 
   await verifyWorkingCopy(caseDirectory);
   const stored = storeHistoryAnalysis({
     caseDirectory,
-    sourceId: source.sourceId,
+    sourceIds: sources.map((source) => source.sourceId),
     declaredTimezone,
     declaredOriginOs,
     invocation: options.invocation ?? ["analyse", "--case", caseDirectory],
     startedAt,
     artifacts,
   });
-  const singletonLock = source.entries.find(
-    (entry) =>
-      entry.path === "SingletonLock" &&
-      entry.state === "value" &&
-      entry.node_type === "symlink",
+  const singletonLockPresent = sources.some((source) =>
+    source.entries.some(
+      (entry) =>
+        entry.path === "SingletonLock" &&
+        entry.state === "value" &&
+        entry.node_type === "symlink",
+    ),
   );
   const analysed = artifacts.filter(
     (artifact) => artifact.status === "complete",
@@ -1150,7 +1164,10 @@ export async function analyseCase(
     runId: stored.runId,
     history: {
       status: unavailable.length === 0 ? "complete" : "partial",
-      profileCount: source.profiles.length,
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
       analysedProfileCount: analysed.length,
       absentProfileCount: absent.length,
       unavailableProfileCount: unavailable.length,
@@ -1173,7 +1190,7 @@ export async function analyseCase(
       declaredTimezone,
       declaredOriginOs,
       declaredOriginOsConflict:
-        declaredOriginOs === "windows" && singletonLock !== undefined,
+        declaredOriginOs === "windows" && singletonLockPresent,
     },
   };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -2,9 +2,13 @@ export {
   CASE_FILENAME,
   CASE_SCHEMA_VERSION,
   TOOL_VERSION,
+  caseArtifactAbsolutePath,
   loadCaseSource,
+  loadCaseSources,
   workingCopyAbsolutePath,
+  type CaseProfileRecord,
   type CaseSourceRecord,
+  type SourceEvidenceGap,
 } from "./case.js";
 export {
   ForensixError,
@@ -15,14 +19,18 @@ export {
   type WorkingCopyIssueReason,
 } from "./errors.js";
 export {
+  ingestSource,
   ingestUserDataDir,
+  type IngestBundleVerificationResult,
   type IngestOptions,
   type IngestProgress,
   type IngestResult,
+  type IngestSourceResult,
 } from "./ingest.js";
 export {
   HASH_ALGORITHM,
   MANIFEST_SCHEMA,
+  SOURCE_KINDS,
   assertManifestEntry,
   canonicalManifestLine,
   decodeManifestEntry,
@@ -39,19 +47,25 @@ export {
   type ManifestState,
   type NodeType,
   type SelectionTier,
+  type SourceKind,
   type UnavailableReason,
 } from "./manifest.js";
 export {
   CHROME_USERDATA_POLICY,
+  browserLevelEvidence,
+  classifyProfileSourcePath,
   classifySourcePath,
+  expectedProfileTierOnePaths,
   expectedTierOnePaths,
   isProfileDirectoryName,
+  type BrowserLevelEvidence,
   type Selection,
 } from "./selection-policy.js";
 export {
   preflightAnalysis,
   verifyWorkingCopy,
   type AnalysisPreflightResult,
+  type WorkingCopySourceVerification,
   type WorkingCopyVerification,
 } from "./verify.js";
 export {

--- a/core/src/ingest.ts
+++ b/core/src/ingest.ts
@@ -17,19 +17,45 @@ import {
   sep,
 } from "node:path";
 
-import { acquireUserDataDir, filesystemErrorCode } from "./acquisition.js";
-import { createCaseDatabase, TOOL_VERSION } from "./case.js";
+import {
+  acquisitionBundleStatus,
+  inspectAcquisitionBundle,
+  materializeAcquisitionBundleSource,
+  type AcquisitionBundleStatus,
+  type AcquisitionVerificationRecord,
+} from "./acquisition-bundle.js";
+import {
+  acquireProfileDir,
+  acquireUserDataDir,
+  filesystemErrorCode,
+} from "./acquisition.js";
+import {
+  createCaseDatabase,
+  TOOL_VERSION,
+  type CaseBundleVerificationFileInput,
+  type CreateCaseSourceOptions,
+  type SourceEvidenceGap,
+} from "./case.js";
 import { ForensixError } from "./errors.js";
 import {
   HASH_ALGORITHM,
   MANIFEST_SCHEMA,
+  SOURCE_KINDS,
   evidenceSetDigest,
   manifestBytes,
   workingCopyDigest,
   type ManifestEntry,
   type ManifestHeader,
+  type SourceKind,
 } from "./manifest.js";
-import { CHROME_USERDATA_POLICY } from "./selection-policy.js";
+import {
+  CHROME_USERDATA_POLICY,
+  browserLevelEvidence,
+} from "./selection-policy.js";
+import {
+  discoverChromeSources,
+  type DiscoveredChromeSource,
+} from "./source-discovery.js";
 
 const MANIFEST_FILENAME = "manifest.jsonl";
 const MANIFEST_HEADER_FILENAME = "manifest_header.json";
@@ -38,6 +64,7 @@ const WORKING_COPY_DIRECTORY = "working-copy";
 export interface IngestOptions {
   readonly sourcePath: string;
   readonly caseDirectory: string;
+  readonly sourceKind?: SourceKind;
   readonly includeTier2?: boolean;
 }
 
@@ -47,16 +74,55 @@ export interface IngestProgress {
   readonly completedEntries?: number;
 }
 
+export interface IngestProfileResult {
+  readonly profileId: string;
+  readonly path: string;
+}
+
+export interface IngestSourceResult {
+  readonly sourceId: string;
+  readonly manifestId: string;
+  readonly sourceKind: SourceKind;
+  readonly sourcePath: string;
+  readonly sourceOriginPath: string | null;
+  readonly manifestPath: string;
+  readonly workingCopyPath: string;
+  readonly evidenceSetDigest: string;
+  readonly workingCopyDigest: string;
+  readonly profileCount: number;
+  readonly entryCount: number;
+  readonly copiedEntryCount: number;
+  readonly unavailableCount: number;
+  readonly unclassifiedCount: number;
+  readonly profiles: readonly IngestProfileResult[];
+  readonly browserLevelEvidence: readonly SourceEvidenceGap[];
+}
+
+export interface IngestBundleVerificationResult {
+  readonly status: AcquisitionBundleStatus;
+  readonly expectedBundleDigest: string;
+  readonly actualBundleDigest: string;
+  readonly counts: Readonly<
+    Record<
+      "match" | "mismatch" | "missing_on_disk" | "missing_in_manifest",
+      number
+    >
+  >;
+  readonly files: readonly CaseBundleVerificationFileInput[];
+  readonly sourceErrors: readonly string[];
+}
+
 export interface IngestResult {
   readonly status: "ok";
   readonly command: "ingest";
   readonly caseId: string;
   readonly sourceId: string;
+  readonly sourceCount: number;
   readonly caseDirectory: string;
   readonly caseFile: string;
   readonly manifestPath: string;
   readonly workingCopyPath: string;
-  readonly sourceKind: "USER_DATA_DIR";
+  readonly sourceKind: SourceKind;
   readonly selectionPolicy: "chrome-userdata/1";
   readonly tier2Included: boolean;
   readonly evidenceSetDigest: string;
@@ -66,7 +132,30 @@ export interface IngestResult {
   readonly copiedEntryCount: number;
   readonly unavailableCount: number;
   readonly unclassifiedCount: number;
+  readonly discoveryUnavailablePaths: readonly string[];
+  readonly sources: readonly IngestSourceResult[];
+  readonly acquisitionBundleVerification?: IngestBundleVerificationResult;
   readonly toolVersion: string;
+}
+
+interface PreparedIngest {
+  readonly sources: readonly CreateCaseSourceOptions[];
+  readonly discoveryUnavailablePaths: readonly string[];
+  readonly bundleVerification?: {
+    readonly bundleId: string;
+    readonly status: AcquisitionBundleStatus;
+    readonly expectedBundleDigest: string;
+    readonly actualBundleDigest: string;
+    readonly sourceErrors: readonly string[];
+    readonly files: readonly CaseBundleVerificationFileInput[];
+  };
+}
+
+interface SourceArtifactPaths {
+  readonly directory: string;
+  readonly manifestRelative: string;
+  readonly headerRelative: string;
+  readonly workingCopyRelative: string;
 }
 
 function isWithin(parent: string, child: string): boolean {
@@ -131,10 +220,11 @@ function makeManifestHeader(
   entries: readonly ManifestEntry[],
   profileCount: number,
   tier2Included: boolean,
+  sourceKind: SourceKind,
 ): ManifestHeader {
   return {
     manifest_schema: MANIFEST_SCHEMA,
-    source_kind: "USER_DATA_DIR",
+    source_kind: sourceKind,
     selection_policy: CHROME_USERDATA_POLICY.name,
     selection_policy_diff: [],
     tier_2_included: tier2Included,
@@ -155,9 +245,329 @@ function makeManifestHeader(
   };
 }
 
-export async function* ingestUserDataDir(
+function sourceArtifactPaths(
+  stagingDirectory: string,
+  sourceId: string,
+  nested: boolean,
+): SourceArtifactPaths {
+  const relativeDirectory = nested ? `sources/${sourceId}` : ".";
+  const directory =
+    relativeDirectory === "."
+      ? stagingDirectory
+      : join(stagingDirectory, ...relativeDirectory.split("/"));
+  const relativeFile = (name: string): string =>
+    relativeDirectory === "." ? name : `${relativeDirectory}/${name}`;
+  return {
+    directory,
+    manifestRelative: relativeFile(MANIFEST_FILENAME),
+    headerRelative: relativeFile(MANIFEST_HEADER_FILENAME),
+    workingCopyRelative: relativeFile(WORKING_COPY_DIRECTORY),
+  };
+}
+
+function profileInputs(paths: readonly string[]): IngestProfileResult[] {
+  return paths.map((path) => ({ profileId: randomUUID(), path }));
+}
+
+function profileEvidenceGaps(
+  shape: DiscoveredChromeSource["shape"],
+): SourceEvidenceGap[] {
+  if (shape !== "PROFILE_DIR") {
+    return [];
+  }
+  return browserLevelEvidence().map((evidence) => ({
+    path: evidence.path,
+    state: "unavailable",
+    reason: "outside_source",
+  }));
+}
+
+async function writePrimaryManifest(
+  stagingDirectory: string,
+  paths: SourceArtifactPaths,
+  entries: readonly ManifestEntry[],
+  header: ManifestHeader,
+): Promise<void> {
+  await mkdir(paths.directory, { recursive: true, mode: 0o700 });
+  await writeFile(
+    join(stagingDirectory, ...paths.manifestRelative.split("/")),
+    manifestBytes(entries),
+    { flag: "wx", mode: 0o600 },
+  );
+  await writeFile(
+    join(stagingDirectory, ...paths.headerRelative.split("/")),
+    `${JSON.stringify(header, null, 2)}\n`,
+    { flag: "wx", mode: 0o600 },
+  );
+}
+
+async function prepareDirectorySource(
+  stagingDirectory: string,
+  discovered: DiscoveredChromeSource,
+  recordedKind: SourceKind,
+  includeTier2: boolean,
+  nested: boolean,
+): Promise<CreateCaseSourceOptions> {
+  const sourceId = randomUUID();
+  const manifestId = randomUUID();
+  const paths = sourceArtifactPaths(stagingDirectory, sourceId, nested);
+  const workingCopyAbsolute = join(
+    stagingDirectory,
+    ...paths.workingCopyRelative.split("/"),
+  );
+  const acquisition =
+    discovered.shape === "PROFILE_DIR" ? acquireProfileDir : acquireUserDataDir;
+  const { entries, profiles } = await acquisition(
+    discovered.path,
+    workingCopyAbsolute,
+    includeTier2,
+  );
+  const preparedProfiles = profileInputs(profiles);
+  const header = makeManifestHeader(
+    entries,
+    preparedProfiles.length,
+    includeTier2,
+    recordedKind,
+  );
+  await writePrimaryManifest(stagingDirectory, paths, entries, header);
+  return {
+    sourceId,
+    manifestId,
+    sourceKind: recordedKind,
+    sourcePath: discovered.path,
+    sourceOriginPath: null,
+    workingCopyPath: paths.workingCopyRelative,
+    manifestPath: paths.manifestRelative,
+    header,
+    entries,
+    profiles: preparedProfiles,
+    evidenceGaps: profileEvidenceGaps(discovered.shape),
+  };
+}
+
+async function prepareDirectoryInput(
+  stagingDirectory: string,
+  sourcePath: string,
+  sourceKind: Exclude<SourceKind, "ACQUISITION_BUNDLE">,
+  includeTier2: boolean,
+): Promise<PreparedIngest> {
+  if (sourceKind === "USER_DATA_DIR" || sourceKind === "PROFILE_DIR") {
+    const source = await prepareDirectorySource(
+      stagingDirectory,
+      { path: sourcePath, shape: sourceKind },
+      sourceKind,
+      includeTier2,
+      false,
+    );
+    return { sources: [source], discoveryUnavailablePaths: [] };
+  }
+
+  const discovery = await discoverChromeSources(sourcePath);
+  if (discovery.sources.length === 0) {
+    throw new ForensixError(
+      "INGEST_FAILED",
+      `${sourceKind === "IMAGE_CONTAINER" ? "Image Container" : "Filesystem Root"} contains no supported Chrome Source.`,
+      {
+        source_path: sourcePath,
+        discovery_unavailable_paths: discovery.unavailablePaths,
+      },
+    );
+  }
+  const sources: CreateCaseSourceOptions[] = [];
+  for (const discovered of discovery.sources) {
+    sources.push(
+      await prepareDirectorySource(
+        stagingDirectory,
+        discovered,
+        sourceKind,
+        includeTier2,
+        true,
+      ),
+    );
+  }
+  return {
+    sources,
+    discoveryUnavailablePaths: discovery.unavailablePaths,
+  };
+}
+
+function verificationFile(
+  record: AcquisitionVerificationRecord,
+  sourceIds: ReadonlyMap<number, string>,
+): CaseBundleVerificationFileInput {
+  return {
+    scope: record.scope,
+    sourceId:
+      record.sourceIndex === null
+        ? null
+        : (sourceIds.get(record.sourceIndex) ?? null),
+    path: record.path,
+    outcome: record.outcome,
+    expectedSize: record.expectedSize,
+    actualSize: record.actualSize,
+    expectedSha256: record.expectedSha256,
+    actualSha256: record.actualSha256,
+  };
+}
+
+async function prepareAcquisitionBundle(
+  stagingDirectory: string,
+  bundleRoot: string,
+): Promise<PreparedIngest> {
+  const inspection = await inspectAcquisitionBundle(bundleRoot);
+  const sources: CreateCaseSourceOptions[] = [];
+  const sourceIds = new Map<number, string>();
+  const sourceRecords: AcquisitionVerificationRecord[] = [];
+
+  for (const bundleSource of inspection.sources) {
+    const sourceId = randomUUID();
+    const manifestId = randomUUID();
+    sourceIds.set(bundleSource.sourceIndex, sourceId);
+    const paths = sourceArtifactPaths(stagingDirectory, sourceId, true);
+    const workingCopyAbsolute = join(
+      stagingDirectory,
+      ...paths.workingCopyRelative.split("/"),
+    );
+    const materialized = await materializeAcquisitionBundleSource(
+      bundleSource,
+      workingCopyAbsolute,
+    );
+    sourceRecords.push(...materialized.records);
+    const preparedProfiles = profileInputs(bundleSource.profiles);
+    const header = makeManifestHeader(
+      materialized.entries,
+      preparedProfiles.length,
+      bundleSource.acquisitionHeader.tier_2_included,
+      "ACQUISITION_BUNDLE",
+    );
+    await writePrimaryManifest(
+      stagingDirectory,
+      paths,
+      materialized.entries,
+      header,
+    );
+
+    const acquisitionManifestRelative = `sources/${sourceId}/acquisition_manifest.jsonl`;
+    const acquisitionHeaderRelative = `sources/${sourceId}/acquisition_manifest_header.json`;
+    await writeFile(
+      join(stagingDirectory, ...acquisitionManifestRelative.split("/")),
+      bundleSource.acquisitionManifestBytes,
+      { flag: "wx", mode: 0o600 },
+    );
+    await writeFile(
+      join(stagingDirectory, ...acquisitionHeaderRelative.split("/")),
+      `${JSON.stringify(bundleSource.acquisitionHeader, null, 2)}\n`,
+      { flag: "wx", mode: 0o600 },
+    );
+    sources.push({
+      sourceId,
+      manifestId,
+      sourceKind: "ACQUISITION_BUNDLE",
+      sourcePath: bundleSource.bundleSourcePath,
+      sourceOriginPath: bundleSource.originSourcePath,
+      workingCopyPath: paths.workingCopyRelative,
+      manifestPath: paths.manifestRelative,
+      header,
+      entries: materialized.entries,
+      profiles: preparedProfiles,
+      evidenceGaps: [],
+      acquisitionManifest: {
+        manifestPath: acquisitionManifestRelative,
+        headerPath: acquisitionHeaderRelative,
+        header: bundleSource.acquisitionHeader,
+        entries: bundleSource.acquisitionEntries,
+      },
+    });
+  }
+
+  if (sources.length === 0) {
+    throw new ForensixError(
+      "INGEST_FAILED",
+      "Acquisition Bundle contains no readable collected Source.",
+      {
+        source_path: bundleRoot,
+        bundle_status: "verified_with_divergence",
+        source_errors: inspection.sourceErrors,
+      },
+    );
+  }
+
+  const status = acquisitionBundleStatus(inspection, sourceRecords);
+  const files = [...inspection.records, ...sourceRecords].map((record) =>
+    verificationFile(record, sourceIds),
+  );
+  return {
+    sources,
+    discoveryUnavailablePaths: [],
+    bundleVerification: {
+      bundleId: randomUUID(),
+      status,
+      expectedBundleDigest: inspection.expectedBundleDigest,
+      actualBundleDigest: inspection.actualBundleDigest,
+      sourceErrors: inspection.sourceErrors,
+      files,
+    },
+  };
+}
+
+function sourceResult(
+  caseDirectory: string,
+  source: CreateCaseSourceOptions,
+): IngestSourceResult {
+  return {
+    sourceId: source.sourceId,
+    manifestId: source.manifestId,
+    sourceKind: source.sourceKind,
+    sourcePath: source.sourcePath,
+    sourceOriginPath: source.sourceOriginPath,
+    manifestPath: join(caseDirectory, ...source.manifestPath.split("/")),
+    workingCopyPath: isAbsolute(source.workingCopyPath)
+      ? source.workingCopyPath
+      : join(caseDirectory, ...source.workingCopyPath.split("/")),
+    evidenceSetDigest: source.header.evidence_set_digest,
+    workingCopyDigest: source.header.working_copy_digest,
+    profileCount: source.header.profile_count,
+    entryCount: source.header.entry_count,
+    copiedEntryCount: source.header.copied_entry_count,
+    unavailableCount: source.header.unavailable_count,
+    unclassifiedCount: source.header.unclassified_count,
+    profiles: source.profiles,
+    browserLevelEvidence: source.evidenceGaps,
+  };
+}
+
+function bundleVerificationResult(
+  verification: NonNullable<PreparedIngest["bundleVerification"]>,
+): IngestBundleVerificationResult {
+  const counts = {
+    match: 0,
+    mismatch: 0,
+    missing_on_disk: 0,
+    missing_in_manifest: 0,
+  };
+  for (const file of verification.files) {
+    counts[file.outcome] += 1;
+  }
+  return {
+    status: verification.status,
+    expectedBundleDigest: verification.expectedBundleDigest,
+    actualBundleDigest: verification.actualBundleDigest,
+    counts,
+    files: verification.files,
+    sourceErrors: verification.sourceErrors,
+  };
+}
+
+export async function* ingestSource(
   options: IngestOptions,
 ): AsyncGenerator<IngestProgress, IngestResult> {
+  const sourceKind = options.sourceKind ?? "USER_DATA_DIR";
+  if (!SOURCE_KINDS.includes(sourceKind)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Unsupported Source kind: ${String(sourceKind)}`,
+    );
+  }
   const requestedSource = resolve(options.sourcePath);
   let sourceStats;
   try {
@@ -171,10 +581,14 @@ export async function* ingestUserDataDir(
     );
   }
   if (!sourceStats.isDirectory() || sourceStats.isSymbolicLink()) {
+    const description =
+      sourceKind === "IMAGE_CONTAINER"
+        ? "a read-only mounted or extracted Image Container directory"
+        : "a directory";
     throw new ForensixError(
       "SOURCE_NOT_DIRECTORY",
-      `Source is not a User Data Dir: ${requestedSource}`,
-      { source_path: requestedSource },
+      `Source is not ${description}: ${requestedSource}`,
+      { source_path: requestedSource, source_kind: sourceKind },
     );
   }
 
@@ -204,7 +618,7 @@ export async function* ingestUserDataDir(
   await assertCaseOutsideSource(sourcePath, caseDirectory);
   yield {
     phase: "source_validated",
-    message: "User Data Dir is readable and the output path is separate.",
+    message: "Source is readable and the Case Directory path is separate.",
   };
 
   await mkdir(dirname(caseDirectory), { recursive: true, mode: 0o700 });
@@ -213,70 +627,97 @@ export async function* ingestUserDataDir(
     dirname(caseDirectory),
     `${basename(caseDirectory)}.tmp-${randomUUID()}`,
   );
-  const stagingWorkingCopy = join(stagingDirectory, WORKING_COPY_DIRECTORY);
   await mkdir(stagingDirectory, { recursive: false, mode: 0o700 });
 
   try {
-    const tier2Included = options.includeTier2 ?? false;
-    const { entries, profiles } = await acquireUserDataDir(
-      sourcePath,
-      stagingWorkingCopy,
-      tier2Included,
+    const includeTier2 = options.includeTier2 ?? false;
+    const prepared =
+      sourceKind === "ACQUISITION_BUNDLE"
+        ? await prepareAcquisitionBundle(stagingDirectory, sourcePath)
+        : await prepareDirectoryInput(
+            stagingDirectory,
+            sourcePath,
+            sourceKind,
+            includeTier2,
+          );
+    const completedEntries = prepared.sources.reduce(
+      (total, source) => total + source.entries.length,
+      0,
     );
-    const header = makeManifestHeader(entries, profiles.length, tier2Included);
-    await writeFile(
-      join(stagingDirectory, MANIFEST_FILENAME),
-      manifestBytes(entries),
-      { flag: "wx", mode: 0o600 },
-    );
-    await writeFile(
-      join(stagingDirectory, MANIFEST_HEADER_FILENAME),
-      `${JSON.stringify(header, null, 2)}\n`,
-      { flag: "wx", mode: 0o600 },
-    );
-
     yield {
       phase: "manifest_complete",
-      message: "Manifest and both digests are complete.",
-      completedEntries: entries.length,
+      message: `${prepared.sources.length} independent Manifest${prepared.sources.length === 1 ? " is" : "s are"} complete.`,
+      completedEntries,
     };
 
-    const identifiers = createCaseDatabase({
+    const caseId = randomUUID();
+    createCaseDatabase({
       caseDirectory: stagingDirectory,
-      sourcePath,
-      workingCopyPath: WORKING_COPY_DIRECTORY,
-      manifestPath: MANIFEST_FILENAME,
-      header,
-      entries,
-      profiles,
+      caseId,
+      inputSourceKind: sourceKind,
+      inputSourcePath: sourcePath,
+      discoveryUnavailablePaths: prepared.discoveryUnavailablePaths,
+      sources: prepared.sources,
+      bundleVerification: prepared.bundleVerification,
     });
     await rename(stagingDirectory, caseDirectory);
 
     yield {
       phase: "case_written",
       message: "Case Directory is complete.",
-      completedEntries: entries.length,
+      completedEntries,
     };
 
+    const resultSources = prepared.sources.map((source) =>
+      sourceResult(caseDirectory, source),
+    );
+    const first = resultSources[0];
+    if (first === undefined) {
+      throw new Error("Ingest prepared no Source.");
+    }
     return {
       status: "ok",
       command: "ingest",
-      caseId: identifiers.caseId,
-      sourceId: identifiers.sourceId,
+      caseId,
+      sourceId: first.sourceId,
+      sourceCount: resultSources.length,
       caseDirectory,
       caseFile: join(caseDirectory, "case.fxdb"),
-      manifestPath: join(caseDirectory, MANIFEST_FILENAME),
-      workingCopyPath: join(caseDirectory, WORKING_COPY_DIRECTORY),
-      sourceKind: "USER_DATA_DIR",
+      manifestPath: first.manifestPath,
+      workingCopyPath: first.workingCopyPath,
+      sourceKind,
       selectionPolicy: CHROME_USERDATA_POLICY.name,
-      tier2Included,
-      evidenceSetDigest: header.evidence_set_digest,
-      workingCopyDigest: header.working_copy_digest,
-      profileCount: header.profile_count,
-      entryCount: header.entry_count,
-      copiedEntryCount: header.copied_entry_count,
-      unavailableCount: header.unavailable_count,
-      unclassifiedCount: header.unclassified_count,
+      tier2Included: prepared.sources.some(
+        (source) => source.header.tier_2_included,
+      ),
+      evidenceSetDigest: first.evidenceSetDigest,
+      workingCopyDigest: first.workingCopyDigest,
+      profileCount: resultSources.reduce(
+        (total, source) => total + source.profileCount,
+        0,
+      ),
+      entryCount: resultSources.reduce(
+        (total, source) => total + source.entryCount,
+        0,
+      ),
+      copiedEntryCount: resultSources.reduce(
+        (total, source) => total + source.copiedEntryCount,
+        0,
+      ),
+      unavailableCount: resultSources.reduce(
+        (total, source) => total + source.unavailableCount,
+        0,
+      ),
+      unclassifiedCount: resultSources.reduce(
+        (total, source) => total + source.unclassifiedCount,
+        0,
+      ),
+      discoveryUnavailablePaths: prepared.discoveryUnavailablePaths,
+      sources: resultSources,
+      acquisitionBundleVerification:
+        prepared.bundleVerification === undefined
+          ? undefined
+          : bundleVerificationResult(prepared.bundleVerification),
       toolVersion: TOOL_VERSION,
     };
   } catch (error) {
@@ -285,4 +726,10 @@ export async function* ingestUserDataDir(
     );
     throw error;
   }
+}
+
+export function ingestUserDataDir(
+  options: Omit<IngestOptions, "sourceKind">,
+): AsyncGenerator<IngestProgress, IngestResult> {
+  return ingestSource({ ...options, sourceKind: "USER_DATA_DIR" });
 }

--- a/core/src/manifest.ts
+++ b/core/src/manifest.ts
@@ -2,6 +2,15 @@ import { createHash } from "node:crypto";
 
 export const MANIFEST_SCHEMA = "forensix/manifest/1" as const;
 export const HASH_ALGORITHM = "sha-256" as const;
+export const SOURCE_KINDS = [
+  "USER_DATA_DIR",
+  "PROFILE_DIR",
+  "FILESYSTEM_ROOT",
+  "IMAGE_CONTAINER",
+  "ACQUISITION_BUNDLE",
+] as const;
+
+export type SourceKind = (typeof SOURCE_KINDS)[number];
 
 const MANIFEST_ENTRY_KEYS = [
   "path",
@@ -80,7 +89,7 @@ export interface ManifestEntry {
 
 export interface ManifestHeader {
   readonly manifest_schema: typeof MANIFEST_SCHEMA;
-  readonly source_kind: "USER_DATA_DIR";
+  readonly source_kind: SourceKind;
   readonly selection_policy: "chrome-userdata/1";
   readonly selection_policy_diff: readonly [];
   readonly tier_2_included: boolean;
@@ -343,7 +352,7 @@ export function decodeManifestHeader(value: unknown): ManifestHeader {
       MANIFEST_SCHEMA,
       "manifest_schema",
     ),
-    source_kind: exactValue(object.source_kind, "USER_DATA_DIR", "source_kind"),
+    source_kind: enumValue(object.source_kind, SOURCE_KINDS, "source_kind"),
     selection_policy: exactValue(
       object.selection_policy,
       "chrome-userdata/1",

--- a/core/src/selection-policy.ts
+++ b/core/src/selection-policy.ts
@@ -36,6 +36,11 @@ export interface Selection {
   readonly unclassified: boolean;
 }
 
+export interface BrowserLevelEvidence {
+  readonly path: string;
+  readonly fileKind: FileKind;
+}
+
 const POLICY_KEYS = [
   "schema",
   "name",
@@ -361,6 +366,36 @@ export function classifySourcePath(
   }
 
   return unclassified(nodeType);
+}
+
+export function classifyProfileSourcePath(
+  path: string,
+  nodeType: NodeType,
+): Selection {
+  return classifySourcePath(`Default/${path}`, nodeType);
+}
+
+export function browserLevelEvidence(): readonly BrowserLevelEvidence[] {
+  return CHROME_USERDATA_POLICY.browser_tier_1.map((artifact) => ({
+    path: artifact.path,
+    fileKind: artifact.file_kind,
+  }));
+}
+
+export function expectedProfileTierOnePaths(): string[] {
+  const expected: string[] = [];
+  for (const artifact of CHROME_USERDATA_POLICY.profile_tier_1) {
+    if (!artifact.expected) {
+      continue;
+    }
+    expected.push(artifact.path);
+    if (artifact.file_kind === "database") {
+      for (const suffix of CHROME_USERDATA_POLICY.sqlite_sidecar_suffixes) {
+        expected.push(`${artifact.path}${suffix}`);
+      }
+    }
+  }
+  return expected;
 }
 
 export function expectedTierOnePaths(

--- a/core/src/source-discovery.ts
+++ b/core/src/source-discovery.ts
@@ -1,0 +1,96 @@
+import { lstat, readdir, realpath } from "node:fs/promises";
+import { basename, join } from "node:path";
+
+import { filesystemErrorCode } from "./acquisition.js";
+import { isProfileDirectoryName } from "./selection-policy.js";
+
+export interface DiscoveredChromeSource {
+  readonly path: string;
+  readonly shape: "USER_DATA_DIR" | "PROFILE_DIR";
+}
+
+export interface SourceDiscoveryResult {
+  readonly sources: readonly DiscoveredChromeSource[];
+  readonly unavailablePaths: readonly string[];
+}
+
+const PROFILE_MARKERS = new Set([
+  "History",
+  "Favicons",
+  "Top Sites",
+  "Preferences",
+  "Secure Preferences",
+  "Bookmarks",
+  "Login Data",
+  "Web Data",
+  "Network",
+]);
+
+function byteOrder(left: string, right: string): number {
+  return Buffer.compare(Buffer.from(left, "utf8"), Buffer.from(right, "utf8"));
+}
+
+async function isPhysicalDirectory(path: string): Promise<boolean> {
+  try {
+    const stats = await lstat(path, { bigint: true });
+    return stats.isDirectory() && !stats.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+export async function discoverChromeSources(
+  root: string,
+): Promise<SourceDiscoveryResult> {
+  const sources: DiscoveredChromeSource[] = [];
+  const unavailablePaths: string[] = [];
+
+  async function walk(directory: string): Promise<void> {
+    let names: string[];
+    try {
+      names = await readdir(directory);
+    } catch (error) {
+      unavailablePaths.push(
+        `${directory}:${filesystemErrorCode(error) ?? "io_error"}`,
+      );
+      return;
+    }
+    names.sort(byteOrder);
+
+    const hasLocalState = names.includes("Local State");
+    const profileDirectories: string[] = [];
+    for (const name of names) {
+      if (
+        isProfileDirectoryName(name) &&
+        (await isPhysicalDirectory(join(directory, name)))
+      ) {
+        profileDirectories.push(name);
+      }
+    }
+
+    if (hasLocalState && profileDirectories.length > 0) {
+      sources.push({ path: await realpath(directory), shape: "USER_DATA_DIR" });
+      return;
+    }
+
+    if (
+      isProfileDirectoryName(basename(directory)) &&
+      names.some((name) => PROFILE_MARKERS.has(name))
+    ) {
+      sources.push({ path: await realpath(directory), shape: "PROFILE_DIR" });
+      return;
+    }
+
+    for (const name of names) {
+      const child = join(directory, name);
+      if (await isPhysicalDirectory(child)) {
+        await walk(child);
+      }
+    }
+  }
+
+  await walk(root);
+  sources.sort((left, right) => byteOrder(left.path, right.path));
+  unavailablePaths.sort(byteOrder);
+  return { sources, unavailablePaths };
+}

--- a/core/src/verify.ts
+++ b/core/src/verify.ts
@@ -1,26 +1,47 @@
-import { lstat, readdir } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { join, posix, resolve } from "node:path";
 
-import { loadCaseSource, workingCopyAbsolutePath } from "./case.js";
+import {
+  caseArtifactAbsolutePath,
+  loadCaseSources,
+  workingCopyAbsolutePath,
+  type CaseSourceRecord,
+} from "./case.js";
 import {
   WorkingCopyIntegrityRefusal,
   type WorkingCopyIssue,
 } from "./errors.js";
 import {
+  HASH_ALGORITHM,
+  decodeManifestHeader,
   evidenceSetDigest,
+  manifestBytes,
+  sha256,
   workingCopyDigest,
   type ManifestEntry,
+  type ManifestHeader,
 } from "./manifest.js";
 import { readStableRegularFile } from "./stable-file.js";
+
+export interface WorkingCopySourceVerification {
+  readonly sourceId: string;
+  readonly manifestId: string;
+  readonly workingCopyPath: string;
+  readonly evidenceSetDigest: string;
+  readonly workingCopyDigest: string;
+  readonly verifiedFileCount: number;
+}
 
 export interface WorkingCopyVerification {
   readonly status: "verified";
   readonly caseDirectory: string;
   readonly sourceId: string;
+  readonly sourceCount: number;
   readonly workingCopyPath: string;
   readonly evidenceSetDigest: string;
   readonly workingCopyDigest: string;
   readonly verifiedFileCount: number;
+  readonly sources: readonly WorkingCopySourceVerification[];
 }
 
 export interface AnalysisPreflightResult extends WorkingCopyVerification {
@@ -93,16 +114,133 @@ async function findUnexpectedEntries(
   return issues;
 }
 
-export async function verifyWorkingCopy(
+function expectedManifestHeader(source: CaseSourceRecord): ManifestHeader {
+  return {
+    manifest_schema: source.manifestSchema,
+    source_kind: source.sourceKind,
+    selection_policy: source.selectionPolicy,
+    selection_policy_diff: [],
+    tier_2_included: source.tier2Included,
+    hash_algorithm: HASH_ALGORITHM,
+    evidence_set_digest: source.evidenceSetDigest,
+    working_copy_digest: source.workingCopyDigest,
+    entry_count: source.entryCount,
+    copied_entry_count: source.copiedEntryCount,
+    profile_count: source.profileCount,
+    unavailable_count: source.unavailableCount,
+    unclassified_count: source.unclassifiedCount,
+  };
+}
+
+async function verifyManifestArtifacts(
   caseDirectory: string,
-): Promise<WorkingCopyVerification> {
-  const resolvedCaseDirectory = resolve(caseDirectory);
-  const source = loadCaseSource(resolvedCaseDirectory);
-  const workingCopyPath = workingCopyAbsolutePath(
-    resolvedCaseDirectory,
-    source,
-  );
+  source: CaseSourceRecord,
+): Promise<WorkingCopyIssue[]> {
   const issues: WorkingCopyIssue[] = [];
+  const manifestPath = caseArtifactAbsolutePath(
+    caseDirectory,
+    source.manifestPath,
+  );
+  let manifestStats;
+  try {
+    manifestStats = await lstat(manifestPath, { bigint: true });
+  } catch {
+    issues.push({
+      path: source.manifestPath,
+      reason: "manifest_artifact_missing",
+    });
+  }
+  if (manifestStats !== undefined) {
+    if (!manifestStats.isFile() || manifestStats.isSymbolicLink()) {
+      issues.push({
+        path: source.manifestPath,
+        reason: "manifest_digest_mismatch",
+        expected: source.evidenceSetDigest,
+        actual: manifestStats.isSymbolicLink() ? "symlink" : "not_file",
+      });
+    } else {
+      try {
+        const actualBytes = await readFile(manifestPath);
+        const expectedBytes = manifestBytes(source.entries);
+        if (!actualBytes.equals(expectedBytes)) {
+          issues.push({
+            path: source.manifestPath,
+            reason: "manifest_digest_mismatch",
+            expected: source.evidenceSetDigest,
+            actual: sha256(actualBytes),
+          });
+        }
+      } catch {
+        issues.push({
+          path: source.manifestPath,
+          reason: "manifest_digest_mismatch",
+          expected: source.evidenceSetDigest,
+          actual: "unreadable",
+        });
+      }
+    }
+  }
+
+  const headerPath = posix.join(
+    posix.dirname(source.manifestPath),
+    "manifest_header.json",
+  );
+  const absoluteHeaderPath = caseArtifactAbsolutePath(
+    caseDirectory,
+    headerPath,
+  );
+  let headerStats;
+  try {
+    headerStats = await lstat(absoluteHeaderPath, { bigint: true });
+  } catch {
+    issues.push({ path: headerPath, reason: "manifest_artifact_missing" });
+  }
+  if (headerStats !== undefined) {
+    if (!headerStats.isFile() || headerStats.isSymbolicLink()) {
+      issues.push({
+        path: headerPath,
+        reason: "manifest_header_mismatch",
+        expected: "valid_manifest_header",
+        actual: headerStats.isSymbolicLink() ? "symlink" : "not_file",
+      });
+    } else {
+      try {
+        const actualHeader = decodeManifestHeader(
+          JSON.parse(await readFile(absoluteHeaderPath, "utf8")),
+        );
+        if (
+          JSON.stringify(actualHeader) !==
+          JSON.stringify(expectedManifestHeader(source))
+        ) {
+          issues.push({
+            path: headerPath,
+            reason: "manifest_header_mismatch",
+            expected: "case_source_metadata",
+            actual: "different_header_values",
+          });
+        }
+      } catch {
+        issues.push({
+          path: headerPath,
+          reason: "manifest_header_mismatch",
+          expected: "valid_manifest_header",
+          actual: "invalid_or_unreadable",
+        });
+      }
+    }
+  }
+  return issues;
+}
+
+async function verifySource(
+  caseDirectory: string,
+  source: CaseSourceRecord,
+): Promise<{
+  readonly verification: WorkingCopySourceVerification;
+  readonly issues: readonly WorkingCopyIssue[];
+}> {
+  const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
+  const issues = await verifyManifestArtifacts(caseDirectory, source);
 
   const manifestDigest = evidenceSetDigest(source.entries);
   if (manifestDigest !== source.evidenceSetDigest) {
@@ -128,7 +266,17 @@ export async function verifyWorkingCopy(
     workingRootStats = await lstat(workingCopyPath, { bigint: true });
   } catch {
     issues.push({ path: ".", reason: "working_copy_missing" });
-    throw new WorkingCopyIntegrityRefusal(issues);
+    return {
+      verification: {
+        sourceId: source.sourceId,
+        manifestId: source.manifestId,
+        workingCopyPath,
+        evidenceSetDigest: source.evidenceSetDigest,
+        workingCopyDigest: source.workingCopyDigest,
+        verifiedFileCount: 0,
+      },
+      issues,
+    };
   }
   if (!workingRootStats.isDirectory() || workingRootStats.isSymbolicLink()) {
     issues.push({
@@ -136,7 +284,17 @@ export async function verifyWorkingCopy(
       reason: "working_copy_missing",
       actual: workingRootStats.isSymbolicLink() ? "symlink" : "not_directory",
     });
-    throw new WorkingCopyIntegrityRefusal(issues);
+    return {
+      verification: {
+        sourceId: source.sourceId,
+        manifestId: source.manifestId,
+        workingCopyPath,
+        evidenceSetDigest: source.evidenceSetDigest,
+        workingCopyDigest: source.workingCopyDigest,
+        verifiedFileCount: 0,
+      },
+      issues,
+    };
   }
 
   const copiedEntries = source.entries.filter((entry) => entry.copied);
@@ -208,6 +366,41 @@ export async function verifyWorkingCopy(
     }
   }
 
+  return {
+    verification: {
+      sourceId: source.sourceId,
+      manifestId: source.manifestId,
+      workingCopyPath,
+      evidenceSetDigest: source.evidenceSetDigest,
+      workingCopyDigest: source.workingCopyDigest,
+      verifiedFileCount: copiedEntries.length,
+    },
+    issues,
+  };
+}
+
+export async function verifyWorkingCopy(
+  caseDirectory: string,
+): Promise<WorkingCopyVerification> {
+  const resolvedCaseDirectory = resolve(caseDirectory);
+  const caseSources = loadCaseSources(resolvedCaseDirectory);
+  const results = [];
+  const issues: WorkingCopyIssue[] = [];
+
+  for (const source of caseSources) {
+    const result = await verifySource(resolvedCaseDirectory, source);
+    results.push(result.verification);
+    issues.push(
+      ...result.issues.map((issue) => ({
+        ...issue,
+        path:
+          caseSources.length === 1
+            ? issue.path
+            : `${source.sourceId}:${issue.path}`,
+      })),
+    );
+  }
+
   if (issues.length > 0) {
     issues.sort((left, right) => {
       const pathOrder = Buffer.compare(
@@ -221,14 +414,23 @@ export async function verifyWorkingCopy(
     throw new WorkingCopyIntegrityRefusal(issues);
   }
 
+  const first = results[0];
+  if (first === undefined) {
+    throw new Error("Case contains no Source verification.");
+  }
   return {
     status: "verified",
     caseDirectory: resolvedCaseDirectory,
-    sourceId: source.sourceId,
-    workingCopyPath,
-    evidenceSetDigest: source.evidenceSetDigest,
-    workingCopyDigest: source.workingCopyDigest,
-    verifiedFileCount: copiedEntries.length,
+    sourceId: first.sourceId,
+    sourceCount: results.length,
+    workingCopyPath: first.workingCopyPath,
+    evidenceSetDigest: first.evidenceSetDigest,
+    workingCopyDigest: first.workingCopyDigest,
+    verifiedFileCount: results.reduce(
+      (total, result) => total + result.verifiedFileCount,
+      0,
+    ),
+    sources: results,
   };
 }
 

--- a/core/test/manifest-contract.test.ts
+++ b/core/test/manifest-contract.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
+  SOURCE_KINDS,
   canonicalManifestLine,
   classifySourcePath,
   decodeManifestEntry,
@@ -104,6 +105,29 @@ describe("Manifest contract v1", () => {
     expect(() => decodeManifestEntry({ ...valid, extra: true })).toThrow(
       "missing or unknown fields",
     );
+  });
+
+  it("accepts every supported Source kind in a Manifest header", () => {
+    const digest = independentSha256("");
+    for (const sourceKind of SOURCE_KINDS) {
+      expect(
+        decodeManifestHeader({
+          manifest_schema: "forensix/manifest/1",
+          source_kind: sourceKind,
+          selection_policy: "chrome-userdata/1",
+          selection_policy_diff: [],
+          tier_2_included: false,
+          hash_algorithm: "sha-256",
+          evidence_set_digest: digest,
+          working_copy_digest: digest,
+          entry_count: 0,
+          copied_entry_count: 0,
+          profile_count: 0,
+          unavailable_count: 0,
+          unclassified_count: 0,
+        }).source_kind,
+      ).toBe(sourceKind);
+    }
   });
 
   it("hashes non-file representations without dereferencing them", () => {

--- a/e2e/ingest-cli.test.ts
+++ b/e2e/ingest-cli.test.ts
@@ -48,6 +48,7 @@ interface ManifestEntry {
 interface IngestOutput {
   readonly status: "ok";
   readonly caseDirectory: string;
+  readonly manifestPath: string;
   readonly workingCopyPath: string;
   readonly evidenceSetDigest: string;
   readonly workingCopyDigest: string;
@@ -526,6 +527,34 @@ describe("compiled analyzer CLI ingest", () => {
     );
 
     await writeFile(historyPath, "history-main\n");
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    const manifestBytesBeforeDamage = await readFile(output.manifestPath);
+    await rm(output.manifestPath);
+    const missingManifest = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--json",
+    ]);
+    expect(missingManifest.status).toBe(1);
+    expect(missingManifest.stderr).toContain("manifest_artifact_missing");
+    await writeFile(output.manifestPath, manifestBytesBeforeDamage);
+
+    const headerPath = join(caseDirectory, "manifest_header.json");
+    const headerBytesBeforeDamage = await readFile(headerPath);
+    await writeFile(headerPath, "{}\n");
+    const changedHeader = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--json",
+    ]);
+    expect(changedHeader.status).toBe(1);
+    expect(changedHeader.stderr).toContain("manifest_header_mismatch");
+    await writeFile(headerPath, headerBytesBeforeDamage);
     expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
       0,
     );

--- a/e2e/source-kinds-cli.test.ts
+++ b/e2e/source-kinds-cli.test.ts
@@ -1,0 +1,647 @@
+import { createHash } from "node:crypto";
+import {
+  cp,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  realpath,
+  rm,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { spawnSync } from "node:child_process";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface SourceOutput {
+  readonly sourceId: string;
+  readonly manifestId: string;
+  readonly sourceKind: string;
+  readonly sourcePath: string;
+  readonly sourceOriginPath: string | null;
+  readonly evidenceSetDigest: string;
+  readonly workingCopyDigest: string;
+  readonly manifestPath: string;
+  readonly workingCopyPath: string;
+  readonly copiedEntryCount: number;
+  readonly profiles: readonly {
+    readonly profileId: string;
+    readonly path: string;
+  }[];
+  readonly browserLevelEvidence: readonly {
+    readonly path: string;
+    readonly state: string;
+    readonly reason: string;
+  }[];
+}
+
+interface IngestOutput {
+  readonly status: "ok";
+  readonly sourceKind: string;
+  readonly sourceCount: number;
+  readonly profileCount: number;
+  readonly sources: readonly SourceOutput[];
+  readonly acquisitionBundleVerification?: {
+    readonly status: string;
+    readonly expectedBundleDigest: string;
+    readonly actualBundleDigest: string;
+    readonly counts: Readonly<Record<string, number>>;
+    readonly files: readonly {
+      readonly scope: string;
+      readonly sourceId: string | null;
+      readonly path: string;
+      readonly outcome: string;
+    }[];
+  };
+}
+
+function sha256(value: Buffer | string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function writeFixtureFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+async function createUserDataDir(path: string, marker: string): Promise<void> {
+  await writeFixtureFile(join(path, "Local State"), `{"marker":"${marker}"}\n`);
+  await writeFixtureFile(
+    join(path, "Default", "History"),
+    `history-${marker}\n`,
+  );
+  await writeFixtureFile(
+    join(path, "Default", "Preferences"),
+    `{"profile":"${marker}"}\n`,
+  );
+}
+
+async function treeSnapshot(root: string): Promise<readonly string[]> {
+  const records: string[] = [];
+  async function walk(
+    directory: string,
+    relativeDirectory: string,
+  ): Promise<void> {
+    const names = await readdir(directory);
+    names.sort((left, right) =>
+      Buffer.compare(Buffer.from(left), Buffer.from(right)),
+    );
+    for (const name of names) {
+      const relativePath = relativeDirectory
+        ? `${relativeDirectory}/${name}`
+        : name;
+      const absolutePath = join(directory, name);
+      const stats = await lstat(absolutePath);
+      if (stats.isDirectory()) {
+        records.push(`${relativePath}\0dir`);
+        await walk(absolutePath, relativePath);
+      } else if (stats.isFile()) {
+        records.push(
+          `${relativePath}\0file\0${sha256(await readFile(absolutePath))}`,
+        );
+      } else if (stats.isSymbolicLink()) {
+        records.push(`${relativePath}\0symlink`);
+      } else {
+        records.push(`${relativePath}\0other`);
+      }
+    }
+  }
+  await walk(root, "");
+  return records;
+}
+
+function ingest(
+  source: string,
+  sourceKind: string,
+  caseDirectory: string,
+): { readonly command: CliResult; readonly output: IngestOutput } {
+  const command = runCli([
+    "ingest",
+    source,
+    "--source-kind",
+    sourceKind,
+    "--case",
+    caseDirectory,
+    "--json",
+  ]);
+  expect(command.stderr).toBe("");
+  expect(command.status).toBe(0);
+  return { command, output: parseJson<IngestOutput>(command.stdout) };
+}
+
+async function regularFiles(root: string): Promise<readonly string[]> {
+  const files: string[] = [];
+  async function walk(
+    directory: string,
+    relativeDirectory: string,
+  ): Promise<void> {
+    const names = await readdir(directory);
+    names.sort((left, right) =>
+      Buffer.compare(Buffer.from(left), Buffer.from(right)),
+    );
+    for (const name of names) {
+      const path = relativeDirectory ? `${relativeDirectory}/${name}` : name;
+      const absolutePath = join(directory, name);
+      const stats = await lstat(absolutePath);
+      if (stats.isDirectory()) {
+        await walk(absolutePath, path);
+      } else if (stats.isFile()) {
+        files.push(path);
+      }
+    }
+  }
+  await walk(root, "");
+  return files;
+}
+
+async function createBundle(
+  root: string,
+  inputs: readonly {
+    readonly source: string;
+    readonly caseDirectory: string;
+    readonly account: string;
+    readonly index: number;
+  }[],
+): Promise<string> {
+  const bundle = join(root, "bundle");
+  await mkdir(bundle);
+  const userDataDirs = [];
+  for (const input of inputs) {
+    const bundlePath = `accounts/${input.account}/udd-${input.index}`;
+    const destination = join(bundle, ...bundlePath.split("/"));
+    await mkdir(destination, { recursive: true });
+    await cp(
+      join(input.caseDirectory, "manifest.jsonl"),
+      join(destination, "manifest.jsonl"),
+    );
+    await cp(
+      join(input.caseDirectory, "manifest_header.json"),
+      join(destination, "manifest_header.json"),
+    );
+    await cp(
+      join(input.caseDirectory, "working-copy"),
+      join(destination, "working_copy"),
+      { recursive: true },
+    );
+    userDataDirs.push({
+      account_id: input.account,
+      bundle_path: bundlePath,
+      source_path: input.source,
+      outcome: "collected",
+      chrome_running: false,
+      liveness_evidence: [],
+      liveness_explanation: "No supported Chrome Liveness Evidence was found.",
+    });
+  }
+  await writeFixtureFile(
+    join(bundle, "collector_record.json"),
+    '{"collector":"fixture"}\n',
+  );
+  await writeFixtureFile(join(bundle, "scan_record.json"), '{"attempts":[]}\n');
+
+  const files = [];
+  for (const path of await regularFiles(bundle)) {
+    const bytes = await readFile(join(bundle, ...path.split("/")));
+    files.push({ path, size: bytes.length, sha256: sha256(bytes) });
+  }
+  files.sort((left, right) =>
+    Buffer.compare(Buffer.from(left.path), Buffer.from(right.path)),
+  );
+  const bundleDigest = sha256(`${JSON.stringify(files)}\n`);
+  await writeFile(
+    join(bundle, "bundle_manifest.json"),
+    `${JSON.stringify(
+      {
+        schema_version: "forensix-acquisition-bundle-draft/1",
+        hash_algorithm: "sha-256",
+        key_material_captured: false,
+        user_data_dirs: userDataDirs,
+        files,
+        bundle_digest: bundleDigest,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  return bundle;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Source kinds", () => {
+  it("ingests a Profile Dir as a partial Source with explicit browser-level unavailability", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-profile-source-"));
+    temporaryRoots.push(root);
+    const profile = join(root, "partial-profile");
+    await writeFixtureFile(join(profile, "History"), "profile-history\n");
+    await writeFixtureFile(
+      join(profile, "Preferences"),
+      '{"profile":"partial"}\n',
+    );
+    const before = await treeSnapshot(profile);
+    const caseDirectory = join(root, "CASE-PROFILE");
+
+    const { output } = ingest(profile, "PROFILE_DIR", caseDirectory);
+    expect(output).toMatchObject({
+      sourceKind: "PROFILE_DIR",
+      sourceCount: 1,
+      profileCount: 1,
+    });
+    expect(output.sources[0]?.profiles).toEqual([
+      expect.objectContaining({ path: "." }),
+    ]);
+    expect(output.sources[0]?.browserLevelEvidence).toEqual(
+      expect.arrayContaining([
+        {
+          path: "Local State",
+          state: "unavailable",
+          reason: "outside_source",
+        },
+        {
+          path: "RunningChromeVersion",
+          state: "unavailable",
+          reason: "outside_source",
+        },
+      ]),
+    );
+    const manifestText = await readFile(
+      output.sources[0]?.manifestPath ?? "",
+      "utf8",
+    );
+    expect(manifestText).toContain('"path":"History"');
+    expect(manifestText).not.toContain('"path":"Default/History"');
+    const database = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readOnly: true,
+    });
+    try {
+      expect(
+        database
+          .prepare(
+            "SELECT state, reason FROM source_evidence_gaps WHERE path = 'Local State'",
+          )
+          .get(),
+      ).toEqual({ state: "unavailable", reason: "outside_source" });
+    } finally {
+      database.close();
+    }
+    expect(await treeSnapshot(profile)).toEqual(before);
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    await writeFile(
+      join(output.sources[0]?.workingCopyPath ?? "", "History"),
+      "damaged-profile-working-copy\n",
+    );
+    const damaged = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(damaged.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(damaged.stderr)).toMatchObject({
+      code: "WORKING_COPY_INTEGRITY_REFUSAL",
+    });
+  });
+
+  it("discovers every Chrome Source in a Filesystem Root without account or installation-path assumptions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-filesystem-source-"));
+    temporaryRoots.push(root);
+    const filesystemRoot = join(root, "filesystem");
+    const first = join(filesystemRoot, "tenant-a", "odd", "browser-data");
+    const second = join(
+      filesystemRoot,
+      "another-place",
+      "nested",
+      "installation",
+    );
+    await createUserDataDir(first, "one");
+    await createUserDataDir(second, "two");
+    const orphanProfile = join(filesystemRoot, "recovered", "Default");
+    await writeFixtureFile(join(orphanProfile, "History"), "orphan-history\n");
+    const before = await treeSnapshot(filesystemRoot);
+    const caseDirectory = join(root, "CASE-FILESYSTEM");
+
+    const { output } = ingest(filesystemRoot, "FILESYSTEM_ROOT", caseDirectory);
+    expect(output).toMatchObject({
+      sourceKind: "FILESYSTEM_ROOT",
+      sourceCount: 3,
+      profileCount: 3,
+    });
+    expect(new Set(output.sources.map((source) => source.sourcePath))).toEqual(
+      new Set(
+        await Promise.all([
+          realpath(first),
+          realpath(second),
+          realpath(orphanProfile),
+        ]),
+      ),
+    );
+    expect(
+      new Set(output.sources.map((source) => source.manifestId)).size,
+    ).toBe(3);
+    expect(
+      new Set(output.sources.map((source) => source.evidenceSetDigest)).size,
+    ).toBe(3);
+    expect(
+      new Set(
+        output.sources.flatMap((source) =>
+          source.profiles.map((profile) => profile.profileId),
+        ),
+      ).size,
+    ).toBe(3);
+    expect(await treeSnapshot(filesystemRoot)).toEqual(before);
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      sourceCount: 3,
+      history: {
+        profileCount: 3,
+        unavailableProfileCount: 3,
+      },
+    });
+    const caseDatabase = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readOnly: true,
+    });
+    try {
+      expect(
+        caseDatabase
+          .prepare("SELECT count(*) AS count FROM analysis_run_sources")
+          .get(),
+      ).toEqual({ count: 3 });
+      expect(
+        caseDatabase
+          .prepare("SELECT count(*) AS count FROM history_artifact_results")
+          .get(),
+      ).toEqual({ count: 3 });
+    } finally {
+      caseDatabase.close();
+    }
+
+    const physicalFirst = await realpath(first);
+    const firstCopied = output.sources.find(
+      (source) => source.sourcePath === physicalFirst,
+    )?.workingCopyPath;
+    expect(firstCopied).toBeDefined();
+    await unlink(join(firstCopied ?? "", "Default", "History"));
+    const damaged = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(damaged.status).toBe(1);
+    expect(damaged.stderr).toContain("entry_missing");
+    expect(await readFile(join(second, "Default", "History"), "utf8")).toBe(
+      "history-two\n",
+    );
+  });
+
+  it("reads a mounted Image Container offline and never writes to it", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-image-source-"));
+    temporaryRoots.push(root);
+    const imageRoot = join(root, "mounted-image");
+    const source = join(
+      imageRoot,
+      "Users",
+      "alice",
+      "unknown-layout",
+      "chrome",
+    );
+    await createUserDataDir(source, "image");
+    const before = await treeSnapshot(imageRoot);
+    const caseDirectory = join(root, "CASE-IMAGE");
+
+    const { output } = ingest(imageRoot, "IMAGE_CONTAINER", caseDirectory);
+    expect(output).toMatchObject({
+      sourceKind: "IMAGE_CONTAINER",
+      sourceCount: 1,
+      profileCount: 1,
+    });
+    expect(output.sources[0]).toMatchObject({
+      sourceKind: "IMAGE_CONTAINER",
+      sourcePath: await realpath(source),
+    });
+    expect(await treeSnapshot(imageRoot)).toEqual(before);
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    const opaqueContainer = join(root, "disk.E01");
+    await writeFile(opaqueContainer, "not-mounted\n");
+    const damaged = runCli([
+      "ingest",
+      opaqueContainer,
+      "--source-kind",
+      "IMAGE_CONTAINER",
+      "--case",
+      join(root, "CASE-OPAQUE"),
+      "--json",
+    ]);
+    expect(damaged.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(damaged.stderr)).toMatchObject({
+      code: "SOURCE_NOT_DIRECTORY",
+    });
+  });
+
+  it("verifies valid and damaged Acquisition Bundles per file while preserving unaffected evidence", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bundle-source-"));
+    temporaryRoots.push(root);
+    const sourceOne = join(root, "source-one");
+    const sourceTwo = join(root, "source-two");
+    await createUserDataDir(sourceOne, "bundle-one");
+    await createUserDataDir(sourceTwo, "bundle-two");
+    const seedCaseOne = join(root, "seed-case-one");
+    const seedCaseTwo = join(root, "seed-case-two");
+    ingest(sourceOne, "USER_DATA_DIR", seedCaseOne);
+    ingest(sourceTwo, "USER_DATA_DIR", seedCaseTwo);
+    const bundle = await createBundle(root, [
+      {
+        source: sourceOne,
+        caseDirectory: seedCaseOne,
+        account: "alpha",
+        index: 1,
+      },
+      {
+        source: sourceTwo,
+        caseDirectory: seedCaseTwo,
+        account: "beta",
+        index: 1,
+      },
+    ]);
+
+    const validCase = join(root, "CASE-BUNDLE-VALID");
+    const valid = ingest(bundle, "ACQUISITION_BUNDLE", validCase).output;
+    expect(valid).toMatchObject({
+      sourceKind: "ACQUISITION_BUNDLE",
+      sourceCount: 2,
+      profileCount: 2,
+      acquisitionBundleVerification: {
+        status: "verified",
+        counts: {
+          mismatch: 0,
+          missing_on_disk: 0,
+          missing_in_manifest: 0,
+        },
+      },
+    });
+    expect(valid.acquisitionBundleVerification?.expectedBundleDigest).toBe(
+      valid.acquisitionBundleVerification?.actualBundleDigest,
+    );
+    expect(new Set(valid.sources.map((source) => source.manifestId)).size).toBe(
+      2,
+    );
+    expect(runCli(["analyse", "--case", validCase, "--json"]).status).toBe(0);
+
+    const damagedBundle = join(root, "damaged-bundle");
+    await cp(bundle, damagedBundle, { recursive: true });
+    await writeFile(
+      join(
+        damagedBundle,
+        "accounts",
+        "alpha",
+        "udd-1",
+        "working_copy",
+        "Default",
+        "History",
+      ),
+      "changed-after-acquisition\n",
+    );
+    await unlink(
+      join(
+        damagedBundle,
+        "accounts",
+        "alpha",
+        "udd-1",
+        "working_copy",
+        "Default",
+        "Preferences",
+      ),
+    );
+    await writeFixtureFile(
+      join(
+        damagedBundle,
+        "accounts",
+        "alpha",
+        "udd-1",
+        "working_copy",
+        "unlisted.bin",
+      ),
+      "not-in-acquisition-manifest\n",
+    );
+    const damagedBefore = await treeSnapshot(damagedBundle);
+    const damagedCase = join(root, "CASE-BUNDLE-DAMAGED");
+    const damaged = ingest(
+      damagedBundle,
+      "ACQUISITION_BUNDLE",
+      damagedCase,
+    ).output;
+    expect(damaged.acquisitionBundleVerification).toMatchObject({
+      status: "verified_with_divergence",
+      counts: {
+        match: expect.any(Number),
+        mismatch: 2,
+        missing_on_disk: 2,
+        missing_in_manifest: 2,
+      },
+    });
+    expect(
+      damaged.acquisitionBundleVerification?.counts.match ?? 0,
+    ).toBeGreaterThan(0);
+    expect(damaged.acquisitionBundleVerification?.actualBundleDigest).not.toBe(
+      damaged.acquisitionBundleVerification?.expectedBundleDigest,
+    );
+    expect(
+      new Set(
+        damaged.acquisitionBundleVerification?.files.map(
+          (file) => file.outcome,
+        ),
+      ),
+    ).toEqual(
+      new Set(["match", "mismatch", "missing_on_disk", "missing_in_manifest"]),
+    );
+    const unaffected = damaged.sources.find(
+      (source) => source.sourceOriginPath === sourceTwo,
+    );
+    expect(unaffected?.copiedEntryCount).toBeGreaterThan(0);
+    expect(
+      await readFile(
+        join(unaffected?.workingCopyPath ?? "", "Default", "History"),
+        "utf8",
+      ),
+    ).toBe("history-bundle-two\n");
+    expect(await treeSnapshot(damagedBundle)).toEqual(damagedBefore);
+    expect(runCli(["analyse", "--case", damagedCase, "--json"]).status).toBe(0);
+
+    const database = new DatabaseSync(join(damagedCase, "case.fxdb"), {
+      readOnly: true,
+    });
+    try {
+      const outcomes = database
+        .prepare(
+          "SELECT outcome, COUNT(*) AS count FROM acquisition_bundle_files GROUP BY outcome ORDER BY outcome",
+        )
+        .all() as unknown as {
+        readonly outcome: string;
+        readonly count: number;
+      }[];
+      expect(new Set(outcomes.map((row) => row.outcome))).toEqual(
+        new Set([
+          "match",
+          "mismatch",
+          "missing_on_disk",
+          "missing_in_manifest",
+        ]),
+      );
+      expect(
+        database
+          .prepare("SELECT COUNT(*) AS count FROM acquisition_manifests")
+          .get(),
+      ).toEqual({ count: 2 });
+      const alphaSource = damaged.sources.find(
+        (source) => source.sourceOriginPath === sourceOne,
+      );
+      const hashes = database
+        .prepare(
+          `SELECT
+             (SELECT sha256 FROM acquisition_manifest_entries
+               WHERE source_id = ? AND path = 'Default/History') AS acquisition_hash,
+             (SELECT sha256 FROM manifest_entries
+               WHERE source_id = ? AND path = 'Default/History') AS ingest_hash`,
+        )
+        .get(alphaSource?.sourceId, alphaSource?.sourceId) as {
+        readonly acquisition_hash: string;
+        readonly ingest_hash: string;
+      };
+      expect(hashes.ingest_hash).not.toBe(hashes.acquisition_hash);
+    } finally {
+      database.close();
+    }
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     include: ["core/test/**/*.test.ts", "e2e/**/*.test.ts"],
+    testTimeout: 30_000,
   },
 });


### PR DESCRIPTION
Closes #173

## Scope

- Add `PROFILE_DIR`, `FILESYSTEM_ROOT`, `IMAGE_CONTAINER`, and `ACQUISITION_BUNDLE` Ingest paths.
- Preserve the canonical `USER_DATA_DIR` integrity model.
- Record Acquisition Bundle match, mismatch, missing-on-disk, and missing-in-manifest outcomes.
- Support multiple Sources and Profiles with independent Manifest identities and digests in one Case.

## Verification

- `corepack pnpm verify`
- `cd collector && go test ./...`
- Compiled-CLI coverage for valid and damaged examples of all five Source kinds

## Base

Started from `v2@ba690473dd65a24ddae9afbd0782329925e09d11` with no research ancestry.

## Integration note

This branch overlaps #168 in `README.md`, `cli/src/cli.ts`, `core/src/case.ts`, `core/src/errors.ts`, and `core/src/index.ts`. Merge #168 first, then rebase this branch onto the updated `v2` before merging.

## Residual risks

- Image Containers must currently be mounted or extracted read-only.
- Filesystem discovery time depends on accessible tree size.
- Acquisition Bundle decoding targets the current Collector schema.