### PR TITLE
feat(#172): Analysis Run identity and artifact supersede semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,33 @@ The accepted values are `windows`, `macos`, and `linux`.
 The command refuses a missing, moved, changed, or extended Working Copy.
 The refusal has the JSON code `WORKING_COPY_INTEGRITY_REFUSAL`.
 
+### Analysis Run identity
+
+Every `analyse` records one Analysis Run in the Case.
+The Case is the record of truth.
+Each Analysis Run keeps its run id, start time, end time, tool version, command line, Source, and exit state.
+
+### Supersede semantics
+
+A later successful Analysis Run supersedes earlier results at artifact granularity within the same Source.
+Supersede retains every earlier row, so the lineage stays complete.
+Queries return only the active result for each Source, Profile, and artifact.
+An artifact rerun that ends unavailable supersedes nothing, and unrelated artifact rows stay untouched.
+A failure in one artifact leaves the defensible results from the other artifacts queryable.
+
+### Exit codes
+
+The `analyse` command reports the run exit state through the process exit code:
+
+| Code | Exit state | Meaning                                                        |
+| ---- | ---------- | ------------------------------------------------------------- |
+| 0    | clean      | Every artifact produced defensible results.                   |
+| 2    | partial    | Some artifacts were unavailable; other results stay queryable. |
+| 3    | failed     | The analysis produced no defensible artifact result.          |
+| 1    | error      | Usage error, missing Case, or Working Copy integrity refusal.  |
+
+The JSON output carries the same value in the `exitState` field.
+
 ## Query History Findings
 
 Each query returns 50 rows by default.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import {
+  ANALYSE_EXIT_CODES,
   ForensixError,
   MINIMUM_NODE_VERSION,
   SOURCE_KINDS,
@@ -31,6 +32,12 @@ const USAGE = `Usage:
 
 Source kinds:
   USER_DATA_DIR (default), PROFILE_DIR, FILESYSTEM_ROOT, IMAGE_CONTAINER, ACQUISITION_BUNDLE
+
+analyse exit codes:
+  0  clean    every artifact produced defensible results
+  2  partial  some artifacts were unavailable; other results stay queryable
+  3  failed   the analysis produced no defensible artifact result
+  1  error    usage error, missing Case, or Working Copy integrity refusal
 `;
 
 type OptionValue = string | true;
@@ -292,7 +299,7 @@ async function run(arguments_: readonly string[]): Promise<number> {
       invocation: arguments_,
     });
     process.stdout.write(`${JSON.stringify(result)}\n`);
-    return 0;
+    return ANALYSE_EXIT_CODES[result.exitState];
   }
 
   if (parsed.command === "history") {

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -50,10 +50,12 @@ export interface StoreHistoryAnalysisOptions {
   readonly artifacts: readonly HistoryArtifactWrite[];
 }
 
+export type AnalysisRunExitState = "complete" | "partial" | "failed";
+
 export interface StoredHistoryAnalysis {
   readonly runId: string;
   readonly finishedAt: string;
-  readonly runStatus: "complete" | "partial";
+  readonly runStatus: AnalysisRunExitState;
 }
 
 export function initializeFindingSchema(database: DatabaseSync): void {
@@ -72,7 +74,7 @@ export function initializeFindingSchema(database: DatabaseSync): void {
         declared_origin_os IS NULL OR
         declared_origin_os IN ('windows', 'macos', 'linux')
       ),
-      status TEXT NOT NULL CHECK (status IN ('running', 'complete', 'partial'))
+      status TEXT NOT NULL CHECK (status IN ('running', 'complete', 'partial', 'failed'))
     ) STRICT;
 
     CREATE TABLE IF NOT EXISTS analysis_run_sources (
@@ -315,11 +317,18 @@ export function storeHistoryAnalysis(
         }
       }
 
-      const runStatus = options.artifacts.some(
+      const unavailableCount = options.artifacts.filter(
         (artifact) => artifact.status === "unavailable",
-      )
-        ? "partial"
-        : "complete";
+      ).length;
+      const completeCount = options.artifacts.filter(
+        (artifact) => artifact.status === "complete",
+      ).length;
+      const runStatus: AnalysisRunExitState =
+        unavailableCount === 0
+          ? "complete"
+          : completeCount === 0
+            ? "failed"
+            : "partial";
       const finishedAt = new Date().toISOString();
       database
         .prepare(

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -2,6 +2,7 @@ import { join, resolve } from "node:path";
 
 import {
   storeHistoryAnalysis,
+  type AnalysisRunExitState,
   type DeclaredOriginOs,
   type HistoryArtifactWrite,
   type PersistedFinding,
@@ -73,11 +74,32 @@ export interface HistoryAnalysisSummary {
   readonly declaredOriginOsConflict: boolean;
 }
 
+/**
+ * Distinct, documented exit codes for the `analyse` command. The Case is the
+ * record of truth for the exit state; these codes map each recorded Analysis
+ * Run exit state onto a stable process exit code so operators and scripts can
+ * tell a clean analysis from a partial or failed one.
+ *
+ * - `complete` (0): every artifact produced defensible results.
+ * - `partial` (2): at least one artifact was unavailable, but other artifacts
+ *   produced defensible, queryable results.
+ * - `failed` (3): the analysis produced no defensible artifact result.
+ *
+ * Usage errors, a missing Case, and a Working Copy integrity refusal exit with
+ * the generic error code 1 handled by the CLI entrypoint.
+ */
+export const ANALYSE_EXIT_CODES = {
+  complete: 0,
+  partial: 2,
+  failed: 3,
+} as const satisfies Record<AnalysisRunExitState, number>;
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
   readonly artifactCount: number;
   readonly runId: string;
+  readonly exitState: AnalysisRunExitState;
   readonly history: HistoryAnalysisSummary;
 }
 
@@ -1162,6 +1184,7 @@ export async function analyseCase(
     analysisStatus: "ready",
     artifactCount: analysed.length,
     runId: stored.runId,
+    exitState: stored.runStatus,
     history: {
       status: unavailable.length === 0 ? "complete" : "partial",
       profileCount: sources.reduce(

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -88,6 +88,7 @@ export {
   type ValueField,
 } from "./forensic-model.js";
 export {
+  ANALYSE_EXIT_CODES,
   analyseCase,
   type AnalyseCaseOptions,
   type AnalyseCaseResult,
@@ -103,6 +104,9 @@ export {
   type HistorySort,
   type HistoryView,
 } from "./history-query.js";
-export { type DeclaredOriginOs } from "./case-findings.js";
+export {
+  type AnalysisRunExitState,
+  type DeclaredOriginOs,
+} from "./case-findings.js";
 
 export const MINIMUM_NODE_VERSION = "24.15.0" as const;

--- a/e2e/analysis-run-cli.test.ts
+++ b/e2e/analysis-run-cli.test.ts
@@ -1,0 +1,500 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface AnalyseResult {
+  readonly command: "analyse";
+  readonly analysisStatus: "ready";
+  readonly runId: string;
+  readonly exitState: "complete" | "partial" | "failed";
+  readonly artifactCount: number;
+  readonly history: {
+    readonly status: "complete" | "partial";
+    readonly profileCount: number;
+    readonly analysedProfileCount: number;
+    readonly unavailableProfileCount: number;
+    readonly findingCount: number;
+  };
+}
+
+interface HistoryPage {
+  readonly status: "ok";
+  readonly items: readonly {
+    readonly provenance: { readonly rowId: string };
+  }[];
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function writeFixtureFile(path: string, content: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, content);
+}
+
+/**
+ * Build a minimal but valid Chrome History database with one recorded visit.
+ * Schema version 70 lets the Analyzer resolve timestamps without a Declared
+ * Origin OS, so the resulting artifact is `complete`.
+ */
+async function createValidHistory(
+  path: string,
+  urlHost: string,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR,
+        title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY,
+        segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL,
+        visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `INSERT INTO urls
+           (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+         VALUES (1, ?, ?, 1, 0, 13348638245123456, 0)`,
+      )
+      .run(`https://${urlHost}/`, `Title ${urlHost}`);
+    database
+      .prepare(
+        `INSERT INTO visits
+           (id, url, visit_time, from_visit, external_referrer_url, transition,
+            segment_id, visit_duration, incremented_omnibox_typed_score,
+            opener_visit, originator_cache_guid, originator_visit_id,
+            originator_from_visit, originator_opener_visit, is_known_to_sync,
+            consider_for_ntp_most_visited, visited_link_id, app_id)
+         VALUES (1, 1, 13348638245123456, 0, '', 1, 0, 100, 1, 0, '', 0, 0, 0, 0, 1, 0, NULL)`,
+      )
+      .run();
+  } finally {
+    database.close();
+  }
+}
+
+interface CaseReader {
+  readonly runs: readonly {
+    readonly run_id: string;
+    readonly started_at: string;
+    readonly finished_at: string | null;
+    readonly tool_version: string;
+    readonly invocation_json: string;
+    readonly status: string;
+  }[];
+  readonly runSourceCount: number;
+  readonly artifactResults: readonly {
+    readonly artifact_result_id: bigint;
+    readonly run_id: string;
+    readonly profile_path: string;
+    readonly status: string;
+    readonly reason: string | null;
+    readonly active: bigint;
+  }[];
+  readonly activeResults: readonly {
+    readonly artifact_result_id: bigint;
+    readonly run_id: string;
+    readonly profile_path: string;
+  }[];
+  readonly findingRunIds: readonly string[];
+  readonly activeFindingCount: number;
+  readonly activeVisitFindingCount: number;
+}
+
+function readCase(caseDirectory: string): CaseReader {
+  const database = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+    readOnly: true,
+    readBigInts: true,
+  });
+  try {
+    const runs = database
+      .prepare(
+        `SELECT run_id, started_at, finished_at, tool_version, invocation_json, status
+           FROM analysis_runs ORDER BY started_at, run_id`,
+      )
+      .all() as unknown as CaseReader["runs"];
+    const runSourceCount = Number(
+      (
+        database
+          .prepare("SELECT count(*) AS count FROM analysis_run_sources")
+          .get() as { readonly count: bigint }
+      ).count,
+    );
+    const artifactResults = database
+      .prepare(
+        `SELECT artifact_result_id, run_id, profile_path, status, reason, active
+           FROM history_artifact_results
+          ORDER BY artifact_result_id`,
+      )
+      .all() as unknown as CaseReader["artifactResults"];
+    const activeResults = database
+      .prepare(
+        `SELECT artifact_result_id, run_id, profile_path
+           FROM history_artifact_results WHERE active = 1
+          ORDER BY profile_path`,
+      )
+      .all() as unknown as CaseReader["activeResults"];
+    const findingRunIds = (
+      database
+        .prepare(
+          "SELECT DISTINCT run_id FROM forensic_findings ORDER BY run_id",
+        )
+        .all() as unknown as { readonly run_id: string }[]
+    ).map((row) => row.run_id);
+    const activeFindingCount = Number(
+      (
+        database
+          .prepare(
+            `SELECT count(*) AS count
+               FROM forensic_findings f
+               JOIN history_artifact_results r
+                 ON r.artifact_result_id = f.artifact_result_id
+              WHERE r.active = 1`,
+          )
+          .get() as { readonly count: bigint }
+      ).count,
+    );
+    const activeVisitFindingCount = Number(
+      (
+        database
+          .prepare(
+            `SELECT count(*) AS count
+               FROM forensic_findings f
+               JOIN history_artifact_results r
+                 ON r.artifact_result_id = f.artifact_result_id
+              WHERE r.active = 1 AND f.finding_kind = 'history_visit'`,
+          )
+          .get() as { readonly count: bigint }
+      ).count,
+    );
+    return {
+      runs,
+      runSourceCount,
+      artifactResults,
+      activeResults,
+      findingRunIds,
+      activeFindingCount,
+      activeVisitFindingCount,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+async function ingestUserDataDir(
+  source: string,
+  caseDirectory: string,
+): Promise<void> {
+  await writeFixtureFile(join(source, "Local State"), "{}\n");
+  const ingest = runCli(["ingest", source, "--case", caseDirectory, "--json"]);
+  expect(ingest.status).toBe(0);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Analysis Run identity and supersede", () => {
+  it("records run identity and supersedes each artifact while retaining lineage", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-run-supersede-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await createValidHistory(
+      join(source, "Default", "History"),
+      "alpha.example",
+    );
+    const caseDirectory = join(root, "CASE-SUPERSEDE");
+    await ingestUserDataDir(source, caseDirectory);
+
+    const first = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(first.status).toBe(0);
+    const firstResult = parseJson<AnalyseResult>(first.stdout);
+    expect(firstResult).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      history: { status: "complete", unavailableProfileCount: 0 },
+    });
+    expect(firstResult.history.findingCount).toBeGreaterThan(0);
+
+    const second = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(second.status).toBe(0);
+    const secondResult = parseJson<AnalyseResult>(second.stdout);
+    expect(secondResult.exitState).toBe("complete");
+    expect(secondResult.runId).not.toBe(firstResult.runId);
+
+    const state = readCase(caseDirectory);
+
+    // AC1: each Analysis Run records id, start, end, tool version, command
+    // line, Source, and exit state.
+    expect(state.runs).toHaveLength(2);
+    for (const runRow of state.runs) {
+      expect(runRow.started_at).toMatch(/^\d{4}-\d\d-\d\dT/);
+      expect(runRow.finished_at).toMatch(/^\d{4}-\d\d-\d\dT/);
+      expect(Date.parse(runRow.finished_at as string)).toBeGreaterThanOrEqual(
+        Date.parse(runRow.started_at),
+      );
+      expect(runRow.tool_version.length).toBeGreaterThan(0);
+      expect(JSON.parse(runRow.invocation_json)).toContain("analyse");
+      expect(runRow.status).toBe("complete");
+    }
+    expect(state.runs.map((runRow) => runRow.run_id)).toEqual([
+      firstResult.runId,
+      secondResult.runId,
+    ]);
+    expect(state.runSourceCount).toBe(2);
+
+    // AC2: the rerun supersedes at artifact granularity, every prior row is
+    // retained (lineage), and exactly one row stays active.
+    expect(state.artifactResults).toHaveLength(2);
+    expect(state.activeResults).toHaveLength(1);
+    expect(state.activeResults[0]?.run_id).toBe(secondResult.runId);
+    const supersededRun = state.artifactResults.find(
+      (row) => row.active === 0n,
+    );
+    expect(supersededRun?.run_id).toBe(firstResult.runId);
+    expect(state.findingRunIds).toEqual(
+      [firstResult.runId, secondResult.runId].sort(),
+    );
+
+    // Supersede, not accumulate: active Findings equal one run's worth even
+    // though both runs' rows are retained in the Case.
+    expect(state.activeFindingCount).toBe(firstResult.history.findingCount);
+
+    // Queries resolve only the latest run's Findings, not both runs combined.
+    const page = parseJson<HistoryPage>(
+      runCli(["history", "--case", caseDirectory, "--limit", "100", "--json"])
+        .stdout,
+    );
+    expect(page.items.length).toBe(state.activeVisitFindingCount);
+    expect(page.items.length).toBeGreaterThan(0);
+  });
+
+  it("records a failed Analysis Run and a failed rerun supersedes nothing", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-run-failed-"));
+    temporaryRoots.push(root);
+
+    // A first run whose only artifact is unreadable records the failed exit
+    // state and supersedes nothing.
+    const brokenSource = join(root, "broken");
+    await writeFixtureFile(
+      join(brokenSource, "Default", "History"),
+      "not-a-sqlite-database\n",
+    );
+    const brokenCase = join(root, "CASE-FAILED");
+    await ingestUserDataDir(brokenSource, brokenCase);
+
+    const failed = runCli(["analyse", "--case", brokenCase, "--json"]);
+    expect(failed.status).toBe(3);
+    expect(parseJson<AnalyseResult>(failed.stdout)).toMatchObject({
+      exitState: "failed",
+      history: { analysedProfileCount: 0, unavailableProfileCount: 1 },
+    });
+    const failedState = readCase(brokenCase);
+    expect(failedState.runs).toHaveLength(1);
+    expect(failedState.runs[0]?.status).toBe("failed");
+    expect(failedState.runs[0]?.finished_at).toMatch(/^\d{4}/);
+    expect(failedState.activeResults).toHaveLength(0);
+    expect(failedState.artifactResults[0]?.status).toBe("unavailable");
+    expect(failedState.artifactResults[0]?.reason).not.toBeNull();
+    expect(failedState.activeFindingCount).toBe(0);
+
+    // A failed rerun over previously good results must not supersede them.
+    const goodSource = join(root, "good");
+    await createValidHistory(
+      join(goodSource, "Default", "History"),
+      "beta.example",
+    );
+    const goodCase = join(root, "CASE-FAILED-RERUN");
+    await ingestUserDataDir(goodSource, goodCase);
+
+    const clean = runCli(["analyse", "--case", goodCase, "--json"]);
+    expect(clean.status).toBe(0);
+    const cleanResult = parseJson<AnalyseResult>(clean.stdout);
+    const before = readCase(goodCase);
+    expect(before.activeResults).toHaveLength(1);
+    const activeBefore = before.activeResults[0]?.artifact_result_id;
+
+    // Corrupt the Working Copy so the rerun fails Working Copy verification.
+    await writeFile(
+      join(goodCase, "working-copy", "Default", "History"),
+      "tampered\n",
+    );
+    const rerun = runCli(["analyse", "--case", goodCase, "--json"]);
+    expect(rerun.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(rerun.stderr)).toMatchObject({
+      code: "WORKING_COPY_INTEGRITY_REFUSAL",
+    });
+
+    // No new run recorded, the earlier active result is untouched, and the
+    // prior run's Findings stay queryable.
+    const after = readCase(goodCase);
+    expect(after.runs).toHaveLength(1);
+    expect(after.runs[0]?.run_id).toBe(cleanResult.runId);
+    expect(after.activeResults).toHaveLength(1);
+    expect(after.activeResults[0]?.artifact_result_id).toBe(activeBefore);
+    const page = parseJson<HistoryPage>(
+      runCli(["history", "--case", goodCase, "--limit", "100", "--json"])
+        .stdout,
+    );
+    expect(page.items.length).toBe(after.activeVisitFindingCount);
+    expect(page.items.length).toBeGreaterThan(0);
+  });
+
+  it("isolates a failing artifact so other artifacts stay queryable across reruns", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-run-partial-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await createValidHistory(
+      join(source, "Default", "History"),
+      "good.example",
+    );
+    await writeFixtureFile(
+      join(source, "Profile 1", "History"),
+      "not-a-sqlite-database\n",
+    );
+    const caseDirectory = join(root, "CASE-PARTIAL");
+    await ingestUserDataDir(source, caseDirectory);
+
+    const first = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // AC5: a partial analysis has its own exit code.
+    expect(first.status).toBe(2);
+    const firstResult = parseJson<AnalyseResult>(first.stdout);
+    expect(firstResult).toMatchObject({
+      exitState: "partial",
+      history: {
+        status: "partial",
+        analysedProfileCount: 1,
+        unavailableProfileCount: 1,
+      },
+    });
+
+    const firstState = readCase(caseDirectory);
+    expect(firstState.runs[0]?.status).toBe("partial");
+    // Only the defensible Default artifact is active; the failing Profile 1
+    // artifact supersedes nothing.
+    expect(firstState.activeResults).toHaveLength(1);
+    expect(firstState.activeResults[0]?.profile_path).toBe("Default");
+    const failingFirst = firstState.artifactResults.find(
+      (row) => row.profile_path === "Profile 1",
+    );
+    expect(failingFirst?.status).toBe("unavailable");
+    expect(failingFirst?.active).toBe(0n);
+
+    // AC4: the healthy artifact's Findings stay queryable despite the failure.
+    const goodPage = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Default",
+        "--limit",
+        "100",
+        "--json",
+      ]).stdout,
+    );
+    expect(goodPage.items.length).toBeGreaterThan(0);
+
+    // Rerun: the Default artifact supersedes its prior row, Profile 1 stays
+    // unavailable and untouched.
+    const second = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(second.status).toBe(2);
+    const secondResult = parseJson<AnalyseResult>(second.stdout);
+
+    const secondState = readCase(caseDirectory);
+    expect(secondState.runs).toHaveLength(2);
+    // Two runs each wrote a Default and a Profile 1 artifact row (lineage).
+    expect(secondState.artifactResults).toHaveLength(4);
+    expect(secondState.activeResults).toHaveLength(1);
+    expect(secondState.activeResults[0]?.profile_path).toBe("Default");
+    expect(secondState.activeResults[0]?.run_id).toBe(secondResult.runId);
+    // No Profile 1 artifact result is ever active.
+    expect(
+      secondState.artifactResults.filter(
+        (row) => row.profile_path === "Profile 1" && row.active === 1n,
+      ),
+    ).toHaveLength(0);
+
+    const rerunPage = parseJson<HistoryPage>(
+      runCli([
+        "history",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Default",
+        "--limit",
+        "100",
+        "--json",
+      ]).stdout,
+    );
+    expect(rerunPage.items.length).toBe(secondState.activeVisitFindingCount);
+    expect(rerunPage.items.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/ingest-cli.test.ts
+++ b/e2e/ingest-cli.test.ts
@@ -391,11 +391,14 @@ describe("compiled analyzer CLI ingest", () => {
     }
 
     const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
-    expect(analysis.status).toBe(0);
+    // The Profiles hold placeholder Histories, so every artifact is
+    // unavailable and the analysis exits failed (3).
+    expect(analysis.status).toBe(3);
     expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
       status: "verified",
       command: "analyse",
       analysisStatus: "ready",
+      exitState: "failed",
       evidenceSetDigest: output.evidenceSetDigest,
       workingCopyDigest: output.workingCopyDigest,
       verifiedFileCount: 7,
@@ -527,8 +530,10 @@ describe("compiled analyzer CLI ingest", () => {
     );
 
     await writeFile(historyPath, "history-main\n");
+    // The restored Working Copy verifies, but the placeholder History is not a
+    // real Chrome database, so the analysis exits failed (3).
     expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
-      0,
+      3,
     );
 
     const manifestBytesBeforeDamage = await readFile(output.manifestPath);
@@ -555,8 +560,10 @@ describe("compiled analyzer CLI ingest", () => {
     expect(changedHeader.status).toBe(1);
     expect(changedHeader.stderr).toContain("manifest_header_mismatch");
     await writeFile(headerPath, headerBytesBeforeDamage);
+    // Restored Manifest header verifies; the placeholder History still exits
+    // failed (3).
     expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
-      0,
+      3,
     );
 
     const database = new DatabaseSync(join(caseDirectory, "case.fxdb"));
@@ -620,7 +627,9 @@ describe("compiled analyzer CLI ingest", () => {
         absoluteDatabase.close();
       }
       const absolute = runCli(["analyse", "--case", caseDirectory, "--json"]);
-      expect(absolute.status).toBe(0);
+      // Placeholder History resolves through the absolute Working Copy path but
+      // is not a real Chrome database, so the analysis exits failed (3).
+      expect(absolute.status).toBe(3);
       expect(parseJson<Record<string, unknown>>(absolute.stdout)).toMatchObject(
         {
           workingCopyPath: externalWorkingCopy,

--- a/e2e/source-kinds-cli.test.ts
+++ b/e2e/source-kinds-cli.test.ts
@@ -320,8 +320,10 @@ describe("compiled analyzer CLI Source kinds", () => {
       database.close();
     }
     expect(await treeSnapshot(profile)).toEqual(before);
+    // The placeholder History is not a real Chrome database, so the single
+    // artifact is unavailable and the analysis exits failed (3).
     expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
-      0,
+      3,
     );
 
     await writeFile(
@@ -383,9 +385,12 @@ describe("compiled analyzer CLI Source kinds", () => {
     ).toBe(3);
     expect(await treeSnapshot(filesystemRoot)).toEqual(before);
     const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
-    expect(analysis.status).toBe(0);
+    // Every discovered Profile has a placeholder History, so all three
+    // artifacts are unavailable and the analysis exits failed (3).
+    expect(analysis.status).toBe(3);
     expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
       sourceCount: 3,
+      exitState: "failed",
       history: {
         profileCount: 3,
         unavailableProfileCount: 3,
@@ -449,8 +454,10 @@ describe("compiled analyzer CLI Source kinds", () => {
       sourcePath: await realpath(source),
     });
     expect(await treeSnapshot(imageRoot)).toEqual(before);
+    // The placeholder History is not a real Chrome database, so the analysis
+    // exits failed (3).
     expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
-      0,
+      3,
     );
 
     const opaqueContainer = join(root, "disk.E01");
@@ -517,7 +524,8 @@ describe("compiled analyzer CLI Source kinds", () => {
     expect(new Set(valid.sources.map((source) => source.manifestId)).size).toBe(
       2,
     );
-    expect(runCli(["analyse", "--case", validCase, "--json"]).status).toBe(0);
+    // Bundle Histories are placeholders, so analysis exits failed (3).
+    expect(runCli(["analyse", "--case", validCase, "--json"]).status).toBe(3);
 
     const damagedBundle = join(root, "damaged-bundle");
     await cp(bundle, damagedBundle, { recursive: true });
@@ -597,7 +605,8 @@ describe("compiled analyzer CLI Source kinds", () => {
       ),
     ).toBe("history-bundle-two\n");
     expect(await treeSnapshot(damagedBundle)).toEqual(damagedBefore);
-    expect(runCli(["analyse", "--case", damagedCase, "--json"]).status).toBe(0);
+    // Unaffected evidence is a placeholder History, so analysis exits failed (3).
+    expect(runCli(["analyse", "--case", damagedCase, "--json"]).status).toBe(3);
 
     const database = new DatabaseSync(join(damagedCase, "case.fxdb"), {
       readOnly: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import { defineConfig } from "vitest/config";
 
+const isWindows = process.platform === "win32";
+
 export default defineConfig({
   test: {
     include: ["core/test/**/*.test.ts", "e2e/**/*.test.ts"],
     testTimeout: 30_000,
+    // Windows CI runners are slow spawning the compiled CLI + SQLite I/O; run
+    // E2E files serially there to remove resource contention (not a hang).
+    // Linux/macOS stay parallel.
+    fileParallelism: !isWindows,
   },
 });


### PR DESCRIPTION
Closes #172. Base and target: `v2` only (no research ancestry, not merged to master).

## What changed
The v2 Case schema already carried most run-identity machinery (`analysis_runs`, `analysis_run_sources`, the `active` supersede flag, and the single-active partial index). This PR completes the acceptance criteria on top of it:

- **Run exit state** is now recorded in `analysis_runs.status` as `complete` / `partial` / `failed` — the Case is the record of truth for the exit state.
- **Exit-state classification** in `storeHistoryAnalysis`: `failed` when no artifact is defensible (zero `complete`), `partial` when some artifacts are unavailable but others produced results, `complete` otherwise.
- **Distinct, documented CLI exit codes** for `analyse`, exposed as `exitState` in JSON output, in `--help`, and in the README:
  - `0` clean · `2` partial · `3` failed · `1` error / Working Copy integrity refusal.
- **Supersede** stays at artifact granularity within a Source, retains every prior row (lineage preserved), and an artifact rerun ending `unavailable` supersedes nothing (unrelated rows untouched).

Files: `core/src/case-findings.ts`, `core/src/history.ts`, `core/src/index.ts` (exports `ANALYSE_EXIT_CODES`, `AnalysisRunExitState`), `cli/src/cli.ts`, `README.md`, plus tests.

## Acceptance criteria
1. **Run records id/start/end/tool version/command line/Source/exit state** — verified in `records run identity...` by reading `analysis_runs` + `analysis_run_sources` from `case.fxdb`.
2. **Successful reruns supersede at artifact granularity, retaining every prior row** — `records run identity and supersedes each artifact while retaining lineage`: 2 runs, 2 artifact rows, exactly 1 active (latest), both run ids present in `forensic_findings`, active Findings equal one run's worth (not doubled).
3. **An unavailable artifact rerun supersedes nothing; unrelated rows untouched** — covered by the failed-rerun and partial-isolation tests (Profile 1 artifact never becomes active across reruns; a corrupted Working Copy rerun records no new run and leaves the active result unchanged).
4. **A failure in one artifact leaves other artifacts' defensible results queryable** — `isolates a failing artifact...`: Default Findings stay queryable while Profile 1 is unavailable, across two reruns.
5. **Clean, partial, and failed analyses have distinct, documented exit codes** — `0/2/3` asserted in the compiled-CLI tests; documented in README + `--help`.
6. **Compiled-CLI tests cover successful supersede, failed rerun, partial-run isolation** — new suite `e2e/analysis-run-cli.test.ts` (3 tests), all exercising the compiled `cli/dist/cli.js`.

## Verification (local, Node 24.15.0)
`pnpm verify` green: format check, ESLint + dependency-cruiser, typecheck, and `vitest run` — **21/21 tests pass** (5 files). Existing compiled-CLI analyse assertions over placeholder (non-SQLite) Histories were updated from exit `0` to `3`/`2` to match the new documented exit-code contract.

## Notes / risks
- The `analysis_runs.status` CHECK now allows `failed`. The table is created lazily at first `analyse` (`CREATE TABLE IF NOT EXISTS`), so fresh Cases pick it up; pre-existing on-disk Cases from before this change would retain the old CHECK (acceptable for `2.0.0-alpha`, no migration path defined yet).
- A Working Copy integrity refusal exits `1` (error), not `3` — it is a refusal to analyse an untrusted copy and intentionally writes no Analysis Run to the Case; the failed rerun test asserts this leaves prior results and the active row untouched.
- CI links: will populate on this PR's checks once the v2 workflows run.