### PR TITLE
feat(#169): export canonical JSONL and lossy CSV Extracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,10 +118,10 @@ A failure in one artifact leaves the defensible results from the other artifacts
 The `analyse` command reports the run exit state through the process exit code:
 
 | Code | Exit state | Meaning                                                        |
-| ---- | ---------- | ------------------------------------------------------------- |
-| 0    | clean      | Every artifact produced defensible results.                   |
+| ---- | ---------- | -------------------------------------------------------------- |
+| 0    | clean      | Every artifact produced defensible results.                    |
 | 2    | partial    | Some artifacts were unavailable; other results stay queryable. |
-| 3    | failed     | The analysis produced no defensible artifact result.          |
+| 3    | failed     | The analysis produced no defensible artifact result.           |
 | 1    | error      | Usage error, missing Case, or Working Copy integrity refusal.  |
 
 The JSON output carries the same value in the `exitState` field.
@@ -150,6 +150,40 @@ You can repeat `--profile` to query at most 100 Profiles.
 Use `--commit-state` to keep committed and recovered rows separate.
 The `--from`, `--to`, and `--transition` filters apply only to `visits`.
 Timestamp bounds must include `Z` or a numeric offset.
+
+## Export a canonical Extract
+
+An Extract is a scoped, deterministic, citable read over the Case.
+It never becomes a second record of truth: every row is copied from Findings and Candidates that an Analysis Run already recorded.
+
+```sh
+node cli/dist/cli.js export \
+  --case "/path/to/CASE-001" \
+  --out "/path/to/EXTRACT-001" \
+  --examiner "Jane Doe" \
+  --csv \
+  --json
+```
+
+The output directory must be outside the Case Directory and empty.
+The command writes these files:
+
+- `export_header.json`: a versioned header with the Case, Source, tool, examiner, Declared Timezone, scope, Redaction State, and the Completeness Statement.
+- `findings.jsonl` and `candidates.jsonl`: canonical JSONL rows, one per line, with Findings and Candidates in separate collections.
+- `findings.lossy.csv` and `candidates.lossy.csv` (only with `--csv`): a lossy CSV profile whose first column is `record_type`.
+- `export_manifest.json`: the Export Manifest listing each file digest and a derived digest over them.
+- `export_generation.json`: the single quarantined generation instant.
+
+Each row keeps its Provenance, Field State, Commit State, and timestamp semantics.
+The Completeness Statement records attempted, produced, absent, and unavailable artifacts before any result row is interpreted.
+
+Plaintext secrets are redacted by default; each withheld value keeps a hash so it stays citable.
+Add `--include-secrets` to disclose them.
+Binary payloads are separately hashed files, never base64 cells.
+
+The Export Manifest and its derived digest are independently reproducible.
+Two exports of the same Case are byte-identical except for the quarantined generation instant.
+Use `--collection`, `--profile`, and `--commit-state` to scope the Extract.
 
 ## Verify the implementation
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -7,10 +7,12 @@ import {
   SOURCE_KINDS,
   TOOL_VERSION,
   analyseCase,
+  exportCase,
   ingestSource,
   queryHistory,
   type CommitState,
   type DeclaredOriginOs,
+  type ExtractCollection,
   type HistoryDirection,
   type HistorySort,
   type HistoryView,
@@ -28,6 +30,10 @@ const USAGE = `Usage:
                    [--transition <name>] [--from <instant>] [--to <instant>]
                    [--sort <field>] [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
+  forensix export --case <case-directory> --out <output-directory>
+                   [--collection <findings|candidates>]... [--profile <profile>]...
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--examiner <name>] [--csv] [--include-secrets] [--json]
   forensix --version
 
 Source kinds:
@@ -48,7 +54,12 @@ interface ParsedArguments {
   readonly options: ReadonlyMap<string, readonly OptionValue[]>;
 }
 
-const FLAG_OPTIONS = new Set(["--json", "--include-tier-2"]);
+const FLAG_OPTIONS = new Set([
+  "--json",
+  "--include-tier-2",
+  "--csv",
+  "--include-secrets",
+]);
 const VALUE_OPTIONS = new Set([
   "--case",
   "--source-kind",
@@ -65,8 +76,11 @@ const VALUE_OPTIONS = new Set([
   "--direction",
   "--limit",
   "--after",
+  "--out",
+  "--collection",
+  "--examiner",
 ]);
-const REPEATABLE_OPTIONS = new Set(["--profile"]);
+const REPEATABLE_OPTIONS = new Set(["--profile", "--collection"]);
 
 function parseArguments(arguments_: readonly string[]): ParsedArguments {
   const [command, ...remaining] = arguments_;
@@ -358,6 +372,62 @@ async function run(arguments_: readonly string[]): Promise<number> {
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "export") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--out",
+        "--collection",
+        "--profile",
+        "--commit-state",
+        "--examiner",
+        "--csv",
+        "--include-secrets",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The export command accepts no positional values.",
+      );
+    }
+    const outDirectory = optionValue(parsed, "--out");
+    if (outDirectory === undefined) {
+      throw new ForensixError("INVALID_ARGUMENT", "Option --out is required.");
+    }
+    const collections = optionValues(parsed, "--collection");
+    for (const collection of collections) {
+      if (collection !== "findings" && collection !== "candidates") {
+        throw new ForensixError(
+          "INVALID_ARGUMENT",
+          `Option --collection has an unsupported value: ${collection}`,
+          { option: "--collection", value: collection },
+        );
+      }
+    }
+    const result = await exportCase({
+      caseDirectory: requiredCasePath(parsed),
+      outDirectory,
+      examiner: optionValue(parsed, "--examiner"),
+      profiles: optionValues(parsed, "--profile"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      collections:
+        collections.length === 0
+          ? undefined
+          : (collections as ExtractCollection[]),
+      csv: hasOption(parsed, "--csv"),
+      includeSecrets: hasOption(parsed, "--include-secrets"),
     });
     process.stdout.write(`${JSON.stringify(result)}\n`);
     return 0;

--- a/core/src/export.ts
+++ b/core/src/export.ts
@@ -1,0 +1,881 @@
+import { createHash } from "node:crypto";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
+import { isAbsolute, join, relative, resolve, sep } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import {
+  CASE_FILENAME,
+  TOOL_VERSION,
+  loadCaseSources,
+  type CaseSourceRecord,
+} from "./case.js";
+import { ForensixError } from "./errors.js";
+import type {
+  CommitState,
+  FieldState,
+  ForensicFields,
+  Provenance,
+} from "./forensic-model.js";
+
+/**
+ * The Extract is a scoped, deterministic, citable read over the Case. It never
+ * becomes a second record of truth: every row is copied from Findings and
+ * Candidates already recorded by an Analysis Run, and the Export Manifest binds
+ * the emitted files to an independently reproducible digest.
+ */
+export const EXTRACT_SCHEMA = "forensix/extract/1" as const;
+export const REDACTION_POLICY = "forensix/redaction/1" as const;
+
+export type ExtractCollection = "findings" | "candidates";
+
+/**
+ * Field names whose value is treated as a plaintext secret. Such values are
+ * withheld by default and only disclosed with an explicit opt-in. The match is
+ * a case-insensitive substring so `password_value`, `encrypted_value`, and
+ * similar names are covered without an exhaustive list.
+ */
+const SECRET_FIELD_PATTERNS = [
+  "password",
+  "passphrase",
+  "secret",
+  "token",
+  "credential",
+  "cookie_value",
+  "encrypted_value",
+  "private_key",
+] as const;
+
+export interface ExportCaseOptions {
+  readonly caseDirectory: string;
+  readonly outDirectory: string;
+  readonly examiner?: string;
+  readonly profiles?: readonly string[];
+  readonly commitState?: CommitState;
+  readonly collections?: readonly ExtractCollection[];
+  readonly csv?: boolean;
+  readonly includeSecrets?: boolean;
+  /**
+   * The single quarantined generation instant. It is injectable so tests can
+   * assert byte-identical exports; it defaults to the current time.
+   */
+  readonly generatedAt?: string;
+}
+
+export interface ExtractRedactionState {
+  readonly policy: typeof REDACTION_POLICY;
+  readonly state: "redacted" | "disclosed";
+  readonly plaintextSecretsIncluded: boolean;
+  readonly redactedFieldCount: number;
+  readonly binaryPayloadCount: number;
+}
+
+export interface ExtractCompletenessArtifact {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly artifact: "History";
+  readonly databasePath: string;
+  readonly outcome: "produced" | "absent" | "unavailable";
+  readonly reason: string | null;
+  readonly runId: string;
+}
+
+export interface ExtractCompletenessStatement {
+  readonly attempted: number;
+  readonly produced: number;
+  readonly absent: number;
+  readonly unavailable: number;
+  readonly artifacts: readonly ExtractCompletenessArtifact[];
+}
+
+export interface ExtractManifestFile {
+  readonly path: string;
+  readonly sha256: string;
+  readonly size: number;
+}
+
+export interface ExtractManifest {
+  readonly extract_schema: typeof EXTRACT_SCHEMA;
+  readonly files: readonly ExtractManifestFile[];
+  readonly quarantinedGenerationFile: string;
+  readonly derivedDigest: string;
+}
+
+export interface ExportCaseResult {
+  readonly status: "ok";
+  readonly command: "export";
+  readonly extractKind: "history";
+  readonly outDirectory: string;
+  readonly findingCount: number;
+  readonly candidateCount: number;
+  readonly csv: boolean;
+  readonly redaction: ExtractRedactionState;
+  readonly completeness: ExtractCompletenessStatement;
+  readonly derivedDigest: string;
+  readonly generatedAt: string;
+  readonly files: readonly string[];
+}
+
+const HEADER_FILE = "export_header.json";
+const FINDINGS_JSONL = "findings.jsonl";
+const CANDIDATES_JSONL = "candidates.jsonl";
+const FINDINGS_CSV = "findings.lossy.csv";
+const CANDIDATES_CSV = "candidates.lossy.csv";
+const MANIFEST_FILE = "export_manifest.json";
+const GENERATION_FILE = "export_generation.json";
+
+interface FindingRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly source_id: string;
+  readonly run_id: string;
+  readonly artifact_result_id: bigint;
+}
+
+interface CandidateRow {
+  readonly candidate_id: bigint;
+  readonly candidate_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly rank: bigint;
+  readonly supporting_count: bigint;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly source_id: string;
+  readonly run_id: string;
+  readonly artifact_result_id: bigint;
+}
+
+interface ArtifactResultRow {
+  readonly source_id: string;
+  readonly profile_path: string;
+  readonly database_path: string;
+  readonly status: string;
+  readonly reason: string | null;
+  readonly run_id: string;
+  readonly artifact_result_id: bigint;
+  readonly started_at: string;
+}
+
+interface RunRow {
+  readonly run_id: string;
+  readonly started_at: string;
+  readonly finished_at: string | null;
+  readonly tool_version: string;
+  readonly invocation_json: string;
+  readonly declared_timezone: string;
+  readonly declared_origin_os: string | null;
+  readonly status: string;
+}
+
+type CanonicalValue =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly CanonicalValue[]
+  | { readonly [key: string]: CanonicalValue };
+
+/**
+ * Order object keys so repeated exports of the same Case are byte-identical.
+ * Every emitted JSON document flows through this function.
+ */
+function canonicalize(value: unknown): CanonicalValue {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+  if (value !== null && typeof value === "object") {
+    const source = value as Record<string, unknown>;
+    const result: Record<string, CanonicalValue> = {};
+    for (const key of Object.keys(source).sort()) {
+      result[key] = canonicalize(source[key]);
+    }
+    return result;
+  }
+  return value as CanonicalValue;
+}
+
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+export function isSecretFieldName(name: string): boolean {
+  const lower = name.toLowerCase();
+  return SECRET_FIELD_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+export interface RedactedField {
+  readonly state: "redacted";
+  readonly reason: "plaintext_secret_withheld";
+  readonly sha256: string;
+}
+
+/**
+ * Replace every plaintext-secret value with a typed, hashed marker unless
+ * secrets were explicitly opted in. The hash keeps the withheld value citable
+ * without disclosing it, and non-secret Field State is preserved unchanged.
+ */
+export function redactFields(
+  fields: ForensicFields,
+  includeSecrets: boolean,
+): {
+  readonly fields: Readonly<
+    Record<string, FieldState<unknown> | RedactedField>
+  >;
+  readonly redactedCount: number;
+} {
+  if (includeSecrets) {
+    return { fields, redactedCount: 0 };
+  }
+  let redactedCount = 0;
+  const result: Record<string, FieldState<unknown> | RedactedField> = {};
+  for (const [name, state] of Object.entries(fields)) {
+    if (isSecretFieldName(name) && state.state === "value") {
+      result[name] = {
+        state: "redacted",
+        reason: "plaintext_secret_withheld",
+        sha256: sha256(Buffer.from(canonicalJson(state.value), "utf8")),
+      };
+      redactedCount += 1;
+    } else {
+      result[name] = state;
+    }
+  }
+  return { fields: result, redactedCount };
+}
+
+function parseJsonColumn<T>(value: string, findingId: string): T {
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Extract row JSON.",
+      { record_id: findingId },
+      { cause: error },
+    );
+  }
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function findingSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'forensic_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function profileFilter(
+  profiles: readonly string[],
+  parameters: string[],
+): string {
+  if (profiles.length === 0) {
+    return "";
+  }
+  parameters.push(...profiles);
+  return ` AND f.profile_path IN (${profiles.map(() => "?").join(", ")})`;
+}
+
+function resolveOutDirectory(
+  caseDirectory: string,
+  outDirectory: string,
+): string {
+  const resolvedCase = resolve(caseDirectory);
+  const resolvedOut = resolve(outDirectory);
+  const difference = relative(resolvedCase, resolvedOut);
+  if (
+    difference === "" ||
+    (difference !== ".." &&
+      !difference.startsWith(`..${sep}`) &&
+      !isAbsolute(difference))
+  ) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "The Extract output directory must be outside the Case Directory.",
+      { out_directory: resolvedOut, case_directory: resolvedCase },
+    );
+  }
+  return resolvedOut;
+}
+
+async function assertEmptyOutDirectory(outDirectory: string): Promise<void> {
+  await mkdir(outDirectory, { recursive: true });
+  const existing = await readdir(outDirectory);
+  if (existing.length > 0) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "The Extract output directory is not empty.",
+      { out_directory: outDirectory },
+    );
+  }
+}
+
+function loadCaseInfo(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly schemaVersion: number;
+  readonly createdAt: string;
+  readonly toolVersion: string;
+} {
+  const row = database
+    .prepare(
+      "SELECT case_id, schema_version, created_at, tool_version FROM case_info LIMIT 1",
+    )
+    .get() as
+    | {
+        readonly case_id: string;
+        readonly schema_version: bigint;
+        readonly created_at: string;
+        readonly tool_version: string;
+      }
+    | undefined;
+  if (row === undefined) {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  return {
+    caseId: row.case_id,
+    schemaVersion: Number(row.schema_version),
+    createdAt: row.created_at,
+    toolVersion: row.tool_version,
+  };
+}
+
+/**
+ * Reduce the retained artifact-result lineage to the current outcome per
+ * (Source, Profile, artifact) by keeping the most recent Analysis Run. This is
+ * what the Completeness Statement reports before any result row is read.
+ */
+function buildCompleteness(
+  database: DatabaseSync,
+): ExtractCompletenessStatement {
+  const rows = database
+    .prepare(
+      `SELECT r.source_id, r.profile_path, r.database_path, r.status,
+              r.reason, r.run_id, r.artifact_result_id, a.started_at
+         FROM history_artifact_results r
+         JOIN analysis_runs a ON a.run_id = r.run_id
+        ORDER BY r.source_id, r.profile_path`,
+    )
+    .all() as unknown as ArtifactResultRow[];
+  const latest = new Map<string, ArtifactResultRow>();
+  for (const row of rows) {
+    const key = `${row.source_id}\u0000${row.profile_path}`;
+    const current = latest.get(key);
+    if (
+      current === undefined ||
+      row.started_at > current.started_at ||
+      (row.started_at === current.started_at &&
+        row.artifact_result_id > current.artifact_result_id)
+    ) {
+      latest.set(key, row);
+    }
+  }
+  const artifacts = [...latest.values()]
+    .map((row): ExtractCompletenessArtifact => {
+      const outcome =
+        row.status === "complete"
+          ? "produced"
+          : row.status === "absent"
+            ? "absent"
+            : "unavailable";
+      return {
+        sourceId: row.source_id,
+        profile: row.profile_path,
+        artifact: "History",
+        databasePath: row.database_path,
+        outcome,
+        reason: row.reason,
+        runId: row.run_id,
+      };
+    })
+    .sort((left, right) =>
+      left.sourceId === right.sourceId
+        ? left.profile.localeCompare(right.profile)
+        : left.sourceId.localeCompare(right.sourceId),
+    );
+  return {
+    attempted: artifacts.length,
+    produced: artifacts.filter((row) => row.outcome === "produced").length,
+    absent: artifacts.filter((row) => row.outcome === "absent").length,
+    unavailable: artifacts.filter((row) => row.outcome === "unavailable")
+      .length,
+    artifacts,
+  };
+}
+
+function loadActiveRuns(database: DatabaseSync): readonly RunRow[] {
+  return database
+    .prepare(
+      `SELECT DISTINCT a.run_id, a.started_at, a.finished_at, a.tool_version,
+              a.invocation_json, a.declared_timezone, a.declared_origin_os,
+              a.status
+         FROM analysis_runs a
+         JOIN history_artifact_results r ON r.run_id = a.run_id
+        WHERE r.active = 1
+        ORDER BY a.started_at, a.run_id`,
+    )
+    .all() as unknown as RunRow[];
+}
+
+function commonField<T>(
+  values: readonly T[],
+  emptyReason: string,
+  conflictReason: string,
+): { readonly state: "value"; readonly value: T } | UnavailableStatement {
+  const distinct = [...new Set(values.map((value) => JSON.stringify(value)))];
+  if (values.length === 0) {
+    return { state: "unavailable", reason: emptyReason };
+  }
+  if (distinct.length > 1) {
+    return { state: "unavailable", reason: conflictReason };
+  }
+  return { state: "value", value: values[0] as T };
+}
+
+interface UnavailableStatement {
+  readonly state: "unavailable";
+  readonly reason: string;
+}
+
+function sourceHeader(source: CaseSourceRecord): CanonicalValue {
+  return {
+    sourceId: source.sourceId,
+    sourceKind: source.sourceKind,
+    sourcePath: source.sourcePath,
+    sourceOriginPath: source.sourceOriginPath,
+    manifestId: source.manifestId,
+    manifestPath: source.manifestPath,
+    evidenceSetDigest: source.evidenceSetDigest,
+    workingCopyDigest: source.workingCopyDigest,
+  };
+}
+
+function runHeader(run: RunRow): CanonicalValue {
+  return {
+    runId: run.run_id,
+    startedAt: run.started_at,
+    finishedAt: run.finished_at,
+    status: run.status,
+    toolVersion: run.tool_version,
+    declaredTimezone: run.declared_timezone,
+    declaredOriginOs: run.declared_origin_os,
+    invocation: parseJsonColumn<readonly string[]>(
+      run.invocation_json,
+      run.run_id,
+    ),
+  };
+}
+
+function csvCell(value: string): string {
+  if (/[",\r\n]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+/**
+ * Render a Field State as a single lossy CSV cell. Structure, provenance, and
+ * non-value Field State collapse to typed markers, which is why the CSV profile
+ * is explicitly lossy and never authoritative.
+ */
+function csvFieldCell(state: FieldState<unknown> | RedactedField): string {
+  if (state.state === "absent") {
+    return "[absent]";
+  }
+  if (state.state === "unavailable") {
+    return `[unavailable:${state.reason}]`;
+  }
+  if (state.state === "redacted") {
+    return `[redacted:${state.reason}]`;
+  }
+  const value = state.value;
+  if (value === null) {
+    return "[absent]";
+  }
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    return `[array:${value.length}]`;
+  }
+  if (typeof value === "object" && "utc" in value) {
+    return String((value as { readonly utc: unknown }).utc);
+  }
+  return "[object]";
+}
+
+interface ExtractRow {
+  readonly recordType: "finding" | "candidate";
+  readonly collection: ExtractCollection;
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly commitState: string;
+  readonly kind: string;
+  readonly id: string;
+  readonly runId: string;
+  readonly artifactResultId: string;
+  readonly provenance: Provenance;
+  readonly fields: Readonly<
+    Record<string, FieldState<unknown> | RedactedField>
+  >;
+  readonly extra: CanonicalValue;
+}
+
+function jsonlBytes(rows: readonly ExtractRow[]): Buffer {
+  if (rows.length === 0) {
+    return Buffer.alloc(0);
+  }
+  const lines = rows.map((row) =>
+    canonicalJson({
+      record_type: row.recordType,
+      collection: row.collection,
+      source_id: row.sourceId,
+      profile: row.profile,
+      commit_state: row.commitState,
+      kind: row.kind,
+      id: row.id,
+      run_id: row.runId,
+      artifact_result_id: row.artifactResultId,
+      provenance: row.provenance,
+      fields: row.fields,
+      ...(row.extra as Record<string, CanonicalValue>),
+    }),
+  );
+  return Buffer.from(`${lines.join("\n")}\n`, "utf8");
+}
+
+function csvBytes(rows: readonly ExtractRow[]): Buffer {
+  const fieldNames = [
+    ...new Set(rows.flatMap((row) => Object.keys(row.fields))),
+  ].sort();
+  const header = [
+    "record_type",
+    "collection",
+    "source_id",
+    "profile",
+    "commit_state",
+    "kind",
+    "id",
+    "provenance",
+    ...fieldNames.map((name) => `field.${name}`),
+  ];
+  const lines = [header.map(csvCell).join(",")];
+  for (const row of rows) {
+    const provenance = `${row.provenance.manifestPath}#${row.provenance.table}:${row.provenance.rowId}`;
+    const cells = [
+      row.recordType,
+      row.collection,
+      row.sourceId,
+      row.profile,
+      row.commitState,
+      row.kind,
+      row.id,
+      provenance,
+      ...fieldNames.map((name) => {
+        const field = row.fields[name];
+        return field === undefined ? "[absent]" : csvFieldCell(field);
+      }),
+    ];
+    lines.push(cells.map(csvCell).join(","));
+  }
+  return Buffer.from(`${lines.join("\n")}\n`, "utf8");
+}
+
+function loadFindingRows(
+  database: DatabaseSync,
+  profiles: readonly string[],
+  commitState: CommitState | undefined,
+  includeSecrets: boolean,
+): { readonly rows: ExtractRow[]; readonly redactedCount: number } {
+  const parameters: string[] = [];
+  const filter = profileFilter(profiles, parameters);
+  let commitFilter = "";
+  if (commitState !== undefined) {
+    commitFilter = " AND f.commit_state = ?";
+    parameters.push(commitState);
+  }
+  const findingRows = database
+    .prepare(
+      `SELECT f.finding_id, f.finding_kind, f.profile_path, f.commit_state,
+              f.provenance_json, f.fields_json, f.source_id, f.run_id,
+              f.artifact_result_id
+         FROM forensic_findings f
+         JOIN history_artifact_results r
+           ON r.artifact_result_id = f.artifact_result_id
+        WHERE r.active = 1 AND f.record_type = 'finding'${filter}${commitFilter}
+        ORDER BY f.source_id, f.profile_path, f.finding_kind, f.finding_id`,
+    )
+    .all(...parameters) as unknown as FindingRow[];
+  let redactedCount = 0;
+  const rows = findingRows.map((row): ExtractRow => {
+    const id = row.finding_id.toString();
+    const provenance = parseJsonColumn<Provenance>(row.provenance_json, id);
+    const rawFields = parseJsonColumn<ForensicFields>(row.fields_json, id);
+    const redacted = redactFields(rawFields, includeSecrets);
+    redactedCount += redacted.redactedCount;
+    return {
+      recordType: "finding",
+      collection: "findings",
+      sourceId: row.source_id,
+      profile: row.profile_path,
+      commitState: row.commit_state,
+      kind: row.finding_kind,
+      id,
+      runId: row.run_id,
+      artifactResultId: row.artifact_result_id.toString(),
+      provenance,
+      fields: redacted.fields,
+      extra: {},
+    };
+  });
+  return { rows, redactedCount };
+}
+
+function loadCandidateRows(
+  database: DatabaseSync,
+  profiles: readonly string[],
+  commitState: CommitState | undefined,
+  includeSecrets: boolean,
+): { readonly rows: ExtractRow[]; readonly redactedCount: number } {
+  const parameters: string[] = [];
+  const filter = profileFilter(profiles, parameters);
+  let commitFilter = "";
+  if (commitState !== undefined) {
+    commitFilter = " AND f.commit_state = ?";
+    parameters.push(commitState);
+  }
+  const candidateRows = database
+    .prepare(
+      `SELECT f.candidate_id, f.candidate_kind, f.profile_path, f.commit_state,
+              f.rank, f.supporting_count, f.provenance_json, f.fields_json,
+              r.source_id, f.run_id, f.artifact_result_id
+         FROM forensic_candidates f
+         JOIN history_artifact_results r
+           ON r.artifact_result_id = f.artifact_result_id
+        WHERE r.active = 1 AND f.record_type = 'candidate'${filter}${commitFilter}
+        ORDER BY r.source_id, f.profile_path, f.candidate_kind, f.rank,
+                 f.candidate_id`,
+    )
+    .all(...parameters) as unknown as CandidateRow[];
+  let redactedCount = 0;
+  const rows = candidateRows.map((row): ExtractRow => {
+    const id = row.candidate_id.toString();
+    const provenance = parseJsonColumn<Provenance>(row.provenance_json, id);
+    const rawFields = parseJsonColumn<ForensicFields>(row.fields_json, id);
+    const redacted = redactFields(rawFields, includeSecrets);
+    redactedCount += redacted.redactedCount;
+    return {
+      recordType: "candidate",
+      collection: "candidates",
+      sourceId: row.source_id,
+      profile: row.profile_path,
+      commitState: row.commit_state,
+      kind: row.candidate_kind,
+      id,
+      runId: row.run_id,
+      artifactResultId: row.artifact_result_id.toString(),
+      provenance,
+      fields: redacted.fields,
+      extra: {
+        rank: Number(row.rank),
+        supporting_count: Number(row.supporting_count),
+      },
+    };
+  });
+  return { rows, redactedCount };
+}
+
+export async function exportCase(
+  options: ExportCaseOptions,
+): Promise<ExportCaseResult> {
+  const caseDirectory = resolve(options.caseDirectory);
+  const outDirectory = resolveOutDirectory(caseDirectory, options.outDirectory);
+  const collections = options.collections ?? ["findings", "candidates"];
+  const includeSecrets = options.includeSecrets ?? false;
+  const csv = options.csv ?? false;
+  const generatedAt = options.generatedAt ?? new Date().toISOString();
+  const profiles = [...new Set(options.profiles ?? [])].sort();
+
+  await assertEmptyOutDirectory(outDirectory);
+
+  const sources = loadCaseSources(caseDirectory);
+  const database = openCase(caseDirectory);
+  let caseInfo: ReturnType<typeof loadCaseInfo>;
+  let completeness: ExtractCompletenessStatement;
+  let activeRuns: readonly RunRow[];
+  let findingResult: { rows: ExtractRow[]; redactedCount: number };
+  let candidateResult: { rows: ExtractRow[]; redactedCount: number };
+  try {
+    if (!findingSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no analysis to export. Run analyse first.",
+      );
+    }
+    caseInfo = loadCaseInfo(database);
+    completeness = buildCompleteness(database);
+    activeRuns = loadActiveRuns(database);
+    findingResult = collections.includes("findings")
+      ? loadFindingRows(database, profiles, options.commitState, includeSecrets)
+      : { rows: [], redactedCount: 0 };
+    candidateResult = collections.includes("candidates")
+      ? loadCandidateRows(
+          database,
+          profiles,
+          options.commitState,
+          includeSecrets,
+        )
+      : { rows: [], redactedCount: 0 };
+  } finally {
+    database.close();
+  }
+
+  const redaction: ExtractRedactionState = {
+    policy: REDACTION_POLICY,
+    state: includeSecrets ? "disclosed" : "redacted",
+    plaintextSecretsIncluded: includeSecrets,
+    redactedFieldCount:
+      findingResult.redactedCount + candidateResult.redactedCount,
+    binaryPayloadCount: 0,
+  };
+
+  const examiner: CanonicalValue =
+    options.examiner === undefined
+      ? { state: "unavailable", reason: "examiner_not_declared" }
+      : { state: "value", value: options.examiner };
+
+  const header = {
+    extract_schema: EXTRACT_SCHEMA,
+    extractKind: "history",
+    case: {
+      caseId: caseInfo.caseId,
+      schemaVersion: caseInfo.schemaVersion,
+      createdAt: caseInfo.createdAt,
+      toolVersion: caseInfo.toolVersion,
+    },
+    tool: { name: "forensix", version: TOOL_VERSION },
+    examiner,
+    declaredTimezone: commonField(
+      activeRuns.map((run) => run.declared_timezone),
+      "no_active_analysis_run",
+      "multiple_declared_timezones",
+    ),
+    declaredOriginOs: commonField(
+      activeRuns.map((run) => run.declared_origin_os),
+      "no_active_analysis_run",
+      "multiple_declared_origin_os",
+    ),
+    sources: sources.map(sourceHeader),
+    analysisRuns: activeRuns.map(runHeader),
+    scope: {
+      collections: [...collections].sort(),
+      profiles: profiles.length === 0 ? "all" : profiles,
+      commitState: options.commitState ?? "all",
+      activeResultsOnly: true,
+      csv: { enabled: csv, lossy: true },
+    },
+    redaction,
+    completeness,
+  };
+
+  const emitted: { readonly path: string; readonly bytes: Buffer }[] = [
+    {
+      path: HEADER_FILE,
+      bytes: Buffer.from(`${canonicalJson(header)}\n`, "utf8"),
+    },
+  ];
+  if (collections.includes("findings")) {
+    emitted.push({
+      path: FINDINGS_JSONL,
+      bytes: jsonlBytes(findingResult.rows),
+    });
+    if (csv) {
+      emitted.push({ path: FINDINGS_CSV, bytes: csvBytes(findingResult.rows) });
+    }
+  }
+  if (collections.includes("candidates")) {
+    emitted.push({
+      path: CANDIDATES_JSONL,
+      bytes: jsonlBytes(candidateResult.rows),
+    });
+    if (csv) {
+      emitted.push({
+        path: CANDIDATES_CSV,
+        bytes: csvBytes(candidateResult.rows),
+      });
+    }
+  }
+
+  const manifestFiles: ExtractManifestFile[] = [...emitted]
+    .sort((left, right) => left.path.localeCompare(right.path))
+    .map((file) => ({
+      path: file.path,
+      sha256: sha256(file.bytes),
+      size: file.bytes.byteLength,
+    }));
+  const derivedDigest = sha256(
+    Buffer.from(canonicalJson(manifestFiles), "utf8"),
+  );
+  const manifest: ExtractManifest = {
+    extract_schema: EXTRACT_SCHEMA,
+    files: manifestFiles,
+    quarantinedGenerationFile: GENERATION_FILE,
+    derivedDigest,
+  };
+  emitted.push({
+    path: MANIFEST_FILE,
+    bytes: Buffer.from(`${canonicalJson(manifest)}\n`, "utf8"),
+  });
+  emitted.push({
+    path: GENERATION_FILE,
+    bytes: Buffer.from(
+      `${canonicalJson({
+        extract_schema: EXTRACT_SCHEMA,
+        generatedAt,
+        derivedDigest,
+      })}\n`,
+      "utf8",
+    ),
+  });
+
+  for (const file of emitted) {
+    await writeFile(join(outDirectory, file.path), file.bytes);
+  }
+
+  return {
+    status: "ok",
+    command: "export",
+    extractKind: "history",
+    outDirectory,
+    findingCount: findingResult.rows.length,
+    candidateCount: candidateResult.rows.length,
+    csv,
+    redaction,
+    completeness,
+    derivedDigest,
+    generatedAt,
+    files: emitted.map((file) => file.path).sort(),
+  };
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -105,6 +105,22 @@ export {
   type HistoryView,
 } from "./history-query.js";
 export {
+  EXTRACT_SCHEMA,
+  REDACTION_POLICY,
+  exportCase,
+  isSecretFieldName,
+  redactFields,
+  type ExportCaseOptions,
+  type ExportCaseResult,
+  type ExtractCollection,
+  type ExtractCompletenessArtifact,
+  type ExtractCompletenessStatement,
+  type ExtractManifest,
+  type ExtractManifestFile,
+  type ExtractRedactionState,
+  type RedactedField,
+} from "./export.js";
+export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,
 } from "./case-findings.js";

--- a/core/test/export-redaction.test.ts
+++ b/core/test/export-redaction.test.ts
@@ -1,0 +1,68 @@
+import { createHash } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isSecretFieldName,
+  redactFields,
+  type FieldState,
+} from "../src/index.js";
+
+function sha256(value: string): string {
+  return createHash("sha256").update(Buffer.from(value, "utf8")).digest("hex");
+}
+
+describe("Extract redaction primitive", () => {
+  it("classifies plaintext-secret field names case-insensitively", () => {
+    expect(isSecretFieldName("password_value")).toBe(true);
+    expect(isSecretFieldName("Encrypted_Value")).toBe(true);
+    expect(isSecretFieldName("cookie_value")).toBe(true);
+    expect(isSecretFieldName("token")).toBe(true);
+    expect(isSecretFieldName("url")).toBe(false);
+    expect(isSecretFieldName("visitTime")).toBe(false);
+  });
+
+  it("withholds secret values by default while keeping them citable by hash", () => {
+    const fields: Readonly<Record<string, FieldState<unknown>>> = {
+      password_value: { state: "value", value: "hunter2" },
+      url: { state: "value", value: "https://example.test/" },
+      missing: { state: "absent" },
+    };
+    const redacted = redactFields(fields, false);
+    expect(redacted.redactedCount).toBe(1);
+    expect(redacted.fields.password_value).toEqual({
+      state: "redacted",
+      reason: "plaintext_secret_withheld",
+      sha256: sha256(JSON.stringify("hunter2")),
+    });
+    // Non-secret Field State is preserved unchanged.
+    expect(redacted.fields.url).toBe(fields.url);
+    expect(redacted.fields.missing).toBe(fields.missing);
+  });
+
+  it("discloses secret values when explicitly opted in", () => {
+    const fields: Readonly<Record<string, FieldState<unknown>>> = {
+      password_value: { state: "value", value: "hunter2" },
+    };
+    const disclosed = redactFields(fields, true);
+    expect(disclosed.redactedCount).toBe(0);
+    expect(disclosed.fields.password_value).toEqual({
+      state: "value",
+      value: "hunter2",
+    });
+  });
+
+  it("does not redact secret-named fields that are already absent or unavailable", () => {
+    const fields: Readonly<Record<string, FieldState<unknown>>> = {
+      token: { state: "unavailable", reason: "missing_column" },
+      secret_note: { state: "absent" },
+    };
+    const redacted = redactFields(fields, false);
+    expect(redacted.redactedCount).toBe(0);
+    expect(redacted.fields.token).toEqual({
+      state: "unavailable",
+      reason: "missing_column",
+    });
+    expect(redacted.fields.secret_note).toEqual({ state: "absent" });
+  });
+});

--- a/e2e/export-cli.test.ts
+++ b/e2e/export-cli.test.ts
@@ -1,0 +1,521 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+function sha256(data: Buffer): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+async function createHistory(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR,
+        title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      INSERT INTO urls
+        (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+      VALUES (1, 'https://alpha.example/', 'Alpha', 1, 0, 13348638245123456, 0);
+      INSERT INTO visits
+        (id, url, visit_time, from_visit, external_referrer_url, transition,
+         segment_id, visit_duration, incremented_omnibox_typed_score,
+         opener_visit, originator_cache_guid, originator_visit_id,
+         originator_from_visit, originator_opener_visit, is_known_to_sync,
+         consider_for_ntp_most_visited, visited_link_id, app_id)
+      VALUES (1, 1, 13348638245123456, 0, '', 1, 0, 100, 1, 0, '', 0, 0, 0, 0, 1, 0, NULL);
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+async function ingestAndAnalyse(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"));
+  const caseDirectory = join(root, "CASE-EXPORT");
+  expect(
+    runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+  ).toBe(0);
+  expect(
+    runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]).status,
+  ).toBe(0);
+  return caseDirectory;
+}
+
+interface ExportSummary {
+  readonly status: "ok";
+  readonly command: "export";
+  readonly extractKind: "history";
+  readonly outDirectory: string;
+  readonly findingCount: number;
+  readonly candidateCount: number;
+  readonly csv: boolean;
+  readonly redaction: {
+    readonly policy: string;
+    readonly state: "redacted" | "disclosed";
+    readonly plaintextSecretsIncluded: boolean;
+    readonly redactedFieldCount: number;
+    readonly binaryPayloadCount: number;
+  };
+  readonly completeness: {
+    readonly attempted: number;
+    readonly produced: number;
+    readonly absent: number;
+    readonly unavailable: number;
+  };
+  readonly derivedDigest: string;
+  readonly generatedAt: string;
+  readonly files: readonly string[];
+}
+
+async function readOut(outDirectory: string): Promise<Record<string, Buffer>> {
+  const names = await readdir(outDirectory);
+  const files: Record<string, Buffer> = {};
+  for (const name of names) {
+    files[name] = await readFile(join(outDirectory, name));
+  }
+  return files;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI canonical Extract export", () => {
+  it("emits a versioned header, separate collections, and a reproducible Manifest", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-export-"));
+    temporaryRoots.push(root);
+    const caseDirectory = await ingestAndAnalyse(root);
+
+    const outDirectory = join(root, "extract");
+    const command = runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      outDirectory,
+      "--examiner",
+      "Jane Doe",
+      "--csv",
+      "--json",
+    ]);
+    expect(command.status).toBe(0);
+    const summary = parseJson<ExportSummary>(command.stdout);
+
+    // AC3: Findings and Candidates are separate collections.
+    expect(summary.findingCount).toBeGreaterThan(0);
+    expect(summary.candidateCount).toBe(0);
+    expect(summary.files).toEqual(
+      [
+        "candidates.jsonl",
+        "candidates.lossy.csv",
+        "export_generation.json",
+        "export_header.json",
+        "export_manifest.json",
+        "findings.jsonl",
+        "findings.lossy.csv",
+      ].sort(),
+    );
+
+    const files = await readOut(outDirectory);
+
+    // AC1: versioned JSON header with mandatory Case, Source, tool, examiner,
+    // timezone, scope, and Redaction State data.
+    const header = JSON.parse(String(files["export_header.json"])) as Record<
+      string,
+      unknown
+    >;
+    expect(header).toMatchObject({
+      extract_schema: "forensix/extract/1",
+      extractKind: "history",
+      case: { schemaVersion: 2, toolVersion: expect.any(String) },
+      tool: { name: "forensix", version: expect.any(String) },
+      examiner: { state: "value", value: "Jane Doe" },
+      declaredTimezone: { state: "value", value: "America/New_York" },
+      scope: {
+        collections: ["candidates", "findings"],
+        profiles: "all",
+        commitState: "all",
+        activeResultsOnly: true,
+        csv: { enabled: true, lossy: true },
+      },
+      redaction: {
+        policy: "forensix/redaction/1",
+        state: "redacted",
+        plaintextSecretsIncluded: false,
+        binaryPayloadCount: 0,
+      },
+    });
+    expect(String((header.case as Record<string, unknown>).caseId)).toMatch(
+      /[0-9a-f-]{36}/,
+    );
+    expect(Array.isArray(header.sources)).toBe(true);
+    expect((header.sources as unknown[]).length).toBe(1);
+    expect(Array.isArray(header.analysisRuns)).toBe(true);
+    expect((header.analysisRuns as unknown[]).length).toBe(1);
+
+    // AC4: the Completeness Statement records attempted, produced, absent, and
+    // unavailable artifacts and lives in the header, before any result row.
+    expect(header.completeness).toMatchObject({
+      attempted: 1,
+      produced: 1,
+      absent: 0,
+      unavailable: 0,
+    });
+    const completenessArtifact = (
+      (header.completeness as Record<string, unknown>).artifacts as Record<
+        string,
+        unknown
+      >[]
+    )[0];
+    expect(completenessArtifact).toMatchObject({
+      artifact: "History",
+      profile: "Default",
+      outcome: "produced",
+    });
+
+    // AC3: each JSONL Finding row preserves Provenance, Field State, Commit
+    // State, and timestamp semantics.
+    const findingLines = String(files["findings.jsonl"])
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+    expect(findingLines.length).toBe(summary.findingCount);
+    const visit = findingLines.find(
+      (row) => row.kind === "history_visit",
+    ) as Record<string, unknown>;
+    expect(visit).toMatchObject({
+      record_type: "finding",
+      collection: "findings",
+      commit_state: "committed",
+      provenance: { table: "visits", rowId: "1" },
+    });
+    const visitFields = visit.fields as Record<string, Record<string, unknown>>;
+    expect(visitFields.url).toMatchObject({
+      state: "value",
+      value: "https://alpha.example/",
+    });
+    expect(visitFields.visitTime).toMatchObject({
+      state: "value",
+      value: { epochFamily: "1601-us", declaredTimezone: "America/New_York" },
+    });
+    expect(visitFields.appId).toMatchObject({ state: "absent" });
+
+    // AC5: no result cell carries a base64 binary payload; binaries would be
+    // separate hashed files instead.
+    expect(String(files["findings.jsonl"])).not.toContain('"base64"');
+    expect(summary.redaction.binaryPayloadCount).toBe(0);
+
+    // AC2: the CSV profile is explicitly lossy and uses record_type first.
+    const csvHeaderLine = String(files["findings.lossy.csv"])
+      .split("\n")[0]
+      ?.split(",");
+    expect(csvHeaderLine?.[0]).toBe("record_type");
+    expect(header.scope).toMatchObject({ csv: { lossy: true } });
+
+    // AC6: the Export Manifest digest is independently reproducible from the
+    // emitted file bytes.
+    const manifest = JSON.parse(String(files["export_manifest.json"])) as {
+      readonly files: readonly {
+        readonly path: string;
+        readonly sha256: string;
+        readonly size: number;
+      }[];
+      readonly derivedDigest: string;
+      readonly quarantinedGenerationFile: string;
+    };
+    expect(manifest.quarantinedGenerationFile).toBe("export_generation.json");
+    for (const entry of manifest.files) {
+      const bytes = files[entry.path];
+      expect(bytes).toBeDefined();
+      expect(sha256(bytes as Buffer)).toBe(entry.sha256);
+      expect((bytes as Buffer).byteLength).toBe(entry.size);
+    }
+    expect(manifest.files.map((entry) => entry.path)).not.toContain(
+      "export_manifest.json",
+    );
+    expect(manifest.files.map((entry) => entry.path)).not.toContain(
+      "export_generation.json",
+    );
+    const independentDigest = sha256(
+      Buffer.from(JSON.stringify(manifest.files), "utf8"),
+    );
+    expect(independentDigest).toBe(manifest.derivedDigest);
+    expect(summary.derivedDigest).toBe(manifest.derivedDigest);
+
+    // The quarantined generation instant is isolated in one file.
+    const generation = JSON.parse(
+      String(files["export_generation.json"]),
+    ) as Record<string, unknown>;
+    expect(generation.generatedAt).toBe(summary.generatedAt);
+    expect(generation.derivedDigest).toBe(manifest.derivedDigest);
+  });
+
+  it("produces byte-identical exports except for the quarantined generation instant", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-export-repro-"));
+    temporaryRoots.push(root);
+    const caseDirectory = await ingestAndAnalyse(root);
+
+    const outOne = join(root, "extract-1");
+    const outTwo = join(root, "extract-2");
+    expect(
+      runCli(["export", "--case", caseDirectory, "--out", outOne, "--json"])
+        .status,
+    ).toBe(0);
+    expect(
+      runCli(["export", "--case", caseDirectory, "--out", outTwo, "--json"])
+        .status,
+    ).toBe(0);
+
+    const first = await readOut(outOne);
+    const second = await readOut(outTwo);
+    expect(Object.keys(first).sort()).toEqual(Object.keys(second).sort());
+    for (const name of Object.keys(first)) {
+      if (name === "export_generation.json") {
+        expect((first[name] as Buffer).equals(second[name] as Buffer)).toBe(
+          false,
+        );
+      } else {
+        expect((first[name] as Buffer).equals(second[name] as Buffer)).toBe(
+          true,
+        );
+      }
+    }
+  });
+
+  it("redacts plaintext secrets by default and discloses them only on opt-in", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-export-secret-"));
+    temporaryRoots.push(root);
+    const caseDirectory = await ingestAndAnalyse(root);
+
+    // Inject a synthetic Finding that carries a plaintext-secret field so the
+    // redaction policy has something to act on. This exercises the export
+    // redaction path end to end without a second record of truth of its own.
+    const database = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readBigInts: true,
+    });
+    try {
+      const template = database
+        .prepare(
+          `SELECT f.artifact_result_id, f.run_id, f.source_id,
+                  f.manifest_entry_ordinal, f.profile_path, f.commit_state,
+                  f.provenance_json
+             FROM forensic_findings f
+             JOIN history_artifact_results r
+               ON r.artifact_result_id = f.artifact_result_id
+            WHERE r.active = 1 AND f.finding_kind = 'history_visit'
+            LIMIT 1`,
+        )
+        .get() as Record<string, unknown>;
+      database
+        .prepare(
+          `INSERT INTO forensic_findings
+             (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+              record_type, finding_kind, profile_path, commit_state,
+              provenance_json, fields_json, search_text, sort_time, sort_url,
+              sort_duration, sort_count, transition_core)
+           VALUES (?, ?, ?, ?, 'finding', 'history_secret', ?, ?, ?, ?, '', NULL, NULL, NULL, NULL, NULL)`,
+        )
+        .run(
+          template.artifact_result_id as bigint,
+          template.run_id as string,
+          template.source_id as string,
+          template.manifest_entry_ordinal as bigint,
+          template.profile_path as string,
+          template.commit_state as string,
+          template.provenance_json as string,
+          JSON.stringify({
+            password_value: { state: "value", value: "hunter2" },
+            note: { state: "value", value: "not a secret" },
+          }),
+        );
+    } finally {
+      database.close();
+    }
+
+    const redactedOut = join(root, "redacted");
+    const redacted = parseJson<ExportSummary>(
+      runCli([
+        "export",
+        "--case",
+        caseDirectory,
+        "--out",
+        redactedOut,
+        "--json",
+      ]).stdout,
+    );
+    expect(redacted.redaction.plaintextSecretsIncluded).toBe(false);
+    expect(redacted.redaction.redactedFieldCount).toBe(1);
+    const redactedBytes = String(
+      await readFile(join(redactedOut, "findings.jsonl")),
+    );
+    expect(redactedBytes).not.toContain("hunter2");
+    expect(redactedBytes).toContain("plaintext_secret_withheld");
+    // The withheld value stays citable through its hash.
+    expect(redactedBytes).toContain(
+      sha256(Buffer.from(JSON.stringify("hunter2"), "utf8")),
+    );
+
+    const disclosedOut = join(root, "disclosed");
+    const disclosed = parseJson<ExportSummary>(
+      runCli([
+        "export",
+        "--case",
+        caseDirectory,
+        "--out",
+        disclosedOut,
+        "--include-secrets",
+        "--json",
+      ]).stdout,
+    );
+    expect(disclosed.redaction.plaintextSecretsIncluded).toBe(true);
+    expect(disclosed.redaction.state).toBe("disclosed");
+    expect(disclosed.redaction.redactedFieldCount).toBe(0);
+    expect(
+      String(await readFile(join(disclosedOut, "findings.jsonl"))),
+    ).toContain("hunter2");
+  });
+
+  it("keeps the Extract out of the Case and refuses a non-empty target", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-export-guard-"));
+    temporaryRoots.push(root);
+    const caseDirectory = await ingestAndAnalyse(root);
+
+    const insideCase = runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      join(caseDirectory, "extract"),
+      "--json",
+    ]);
+    expect(insideCase.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(insideCase.stderr)).toMatchObject(
+      { code: "INVALID_ARGUMENT" },
+    );
+
+    const outDirectory = join(root, "used");
+    await mkdir(outDirectory, { recursive: true });
+    await writeFile(join(outDirectory, "keep.txt"), "existing\n");
+    const nonEmpty = runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      outDirectory,
+      "--json",
+    ]);
+    expect(nonEmpty.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(nonEmpty.stderr)).toMatchObject({
+      code: "INVALID_ARGUMENT",
+    });
+  });
+
+  it("refuses to export a Case without analysis", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-export-noanalysis-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    await createHistory(join(source, "Default", "History"));
+    const caseDirectory = join(root, "CASE-NO-ANALYSIS");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const command = runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      join(root, "extract"),
+      "--json",
+    ]);
+    expect(command.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(command.stderr)).toMatchObject({
+      code: "ANALYSIS_NOT_FOUND",
+    });
+  });
+});


### PR DESCRIPTION
Closes #169.

Adds an offline `forensix export` command that produces a scoped, deterministic, citable **Extract** over the Case. The Extract is a read over Findings and Candidates already recorded by an Analysis Run — it never becomes a second record of truth.

Built on `v2` (includes #172 Analysis Run identity/supersede and the #168 History Finding pipeline). Mirrors the History query surface: active-result resolution, `--profile` / `--commit-state` scoping, keyset-free full extract ordering, multi-Profile and Commit State handling.

## Acceptance criteria → where met

1. **Canonical JSONL rows + versioned JSON header with all mandatory Case, Source, tool, examiner, timezone, scope, Redaction State data.**
   - `core/src/export.ts` builds `export_header.json` (`extract_schema: forensix/extract/1`) with `case`, `sources`, `tool`, `examiner` (typed FieldState — `unavailable(examiner_not_declared)` when absent, never blank), `declaredTimezone`/`declaredOriginOs`, `analysisRuns` (reuses **#172** run identity), `scope`, `redaction`, `completeness`. Rows in `findings.jsonl` / `candidates.jsonl`.
   - E2E: `e2e/export-cli.test.ts` → "emits a versioned header, separate collections, and a reproducible Manifest".
2. **Optional CSV profile explicitly lossy, `record_type` first column.**
   - Files named `findings.lossy.csv` / `candidates.lossy.csv`; header `scope.csv.lossy = true`; first column `record_type` (`csvBytes`).
   - E2E: same test asserts `csvHeaderLine[0] === "record_type"` and `scope.csv.lossy`.
3. **Findings and Candidates separate collections; each row preserves Provenance, Field State, Commit State, timestamp semantics.**
   - Separate query paths (`loadFindingRows` / `loadCandidateRows`) and separate files (always emitted, even when empty). Rows carry `provenance`, `fields` (Field State intact), `commit_state`, and timestamp field objects unchanged.
   - E2E: same test asserts visit row provenance/commit_state, `visitTime` epoch/timezone semantics, and `appId` absent Field State.
4. **Completeness Statement records attempted, produced, absent, unavailable before result rows.**
   - `buildCompleteness` reduces retained artifact-result lineage to the latest run per (Source, Profile, artifact); statement lives in the header (read before any row).
   - E2E: same test asserts `completeness` counts + per-artifact outcome.
5. **Plaintext secrets redacted by default, explicit opt-in; binary payloads separately hashed, not base64 cells.**
   - `redactFields` withholds secret-named values as `redacted(plaintext_secret_withheld)` with a citable SHA-256; `--include-secrets` discloses. `binaryPayloadCount: 0`; no base64 cells.
   - E2E: "redacts plaintext secrets by default and discloses them only on opt-in"; unit: `core/test/export-redaction.test.ts`.
6. **Export Manifest + derived digest independently reproducible; repeated exports byte-identical except one quarantined generation instant.**
   - `export_manifest.json` lists per-file `sha256`/`size` + `derivedDigest = sha256(canonicalJson(files))`; the single generation instant is isolated in `export_generation.json` (excluded from the digest). All JSON canonicalised (sorted keys).
   - E2E: manifest digest recomputed independently; "produces byte-identical exports except for the quarantined generation instant".

## Guards
- Output directory must be **outside** the Case Directory and empty (no second record of truth).
- `ANALYSIS_NOT_FOUND` when the Case has no analysis.

## Tests
`pnpm verify` green locally on Node 24.15.0 (format + lint + typecheck + **30 tests** across 7 files). New: 5 compiled-CLI E2E cases + 4 core unit cases. Did not touch `vitest.config.ts` `fileParallelism` (Windows serial E2E preserved).

## Notes / risks
- Candidates are currently always empty for History; the empty `candidates.jsonl` still documents the separate collection (AC3).
- CSV renders timestamp objects to their `utc` string and collapses arrays/objects/non-value Field State to typed markers — intentional, hence "lossy".
- JSONL uses canonical sorted keys for reproducibility (data preserved; only key order differs from the `history` query output).
- Base/target is **v2 only**; not for master.