### PR TITLE
feat(#177): Parse Login Data credential metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ A Filesystem Root, Image Container, or Acquisition Bundle stores each Source und
 The Case records all identities and paths.
 
 The compiled CLI checks every Working Copy before each analysis.
-It parses History from all Profiles and Sources, then writes Findings to the Case.
+It parses History and Login Data from all Profiles and Sources, then writes Findings to the Case.
 Committed and recovery content use separate passes.
 Recovered rows keep the `wal_resident` or `journal_resident` Commit State.
+
+Login Data yields credential metadata: origin, username, timestamps, and the encrypted-secret wrapper.
+The metadata is available independently of secret decryption.
+An encrypted secret without authorized key material is `unavailable` with a typed reason, never absent or blank.
 
 ## Requirements
 
@@ -150,6 +154,29 @@ You can repeat `--profile` to query at most 100 Profiles.
 Use `--commit-state` to keep committed and recovered rows separate.
 The `--from`, `--to`, and `--transition` filters apply only to `visits`.
 Timestamp bounds must include `Z` or a numeric offset.
+
+## Query Credential Metadata
+
+The `credentials` command returns Login Data Findings with the same bounded, multi-Profile query surface as History.
+Each query returns 50 rows by default; set `--limit` from 1 through 100 and use `nextCursor` as the next `--after` value.
+
+```sh
+node cli/dist/cli.js credentials \
+  --case "/path/to/CASE-001" \
+  --profile Default \
+  --search "example.com" \
+  --commit-state committed \
+  --sort created-time \
+  --direction desc \
+  --limit 50 \
+  --json
+```
+
+The sorts are `created-time`, `last-used-time`, `origin`, `username`, and `profile`.
+You can repeat `--profile` to query at most 100 Profiles.
+Use `--commit-state` to keep committed and recovered rows separate.
+Each credential Finding carries Provenance, the raw and UTC timestamps with their Epoch Family, and the secret's encryption prefix.
+The secret itself stays `unavailable` with the reason `encrypted_secret_without_key_material` until authorized key material is supplied.
 
 ## Export a canonical Extract
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,8 +9,11 @@ import {
   analyseCase,
   exportCase,
   ingestSource,
+  queryCredentials,
   queryHistory,
   type CommitState,
+  type CredentialDirection,
+  type CredentialSort,
   type DeclaredOriginOs,
   type ExtractCollection,
   type HistoryDirection,
@@ -29,6 +32,12 @@ const USAGE = `Usage:
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--transition <name>] [--from <instant>] [--to <instant>]
                    [--sort <field>] [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix credentials --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--sort <created-time|last-used-time|origin|username|profile>]
+                   [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix export --case <case-directory> --out <output-directory>
                    [--collection <findings|candidates>]... [--profile <profile>]...
@@ -369,6 +378,53 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as HistorySort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | HistoryDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "credentials") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The credentials command accepts no positional values.",
+      );
+    }
+    const result = queryCredentials({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      sort: enumOption(parsed, "--sort", [
+        "created-time",
+        "last-used-time",
+        "origin",
+        "username",
+        "profile",
+      ] as const) as CredentialSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | CredentialDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -40,6 +40,30 @@ export interface HistoryArtifactWrite {
   readonly recoveredVisitCount: number;
 }
 
+export interface PersistedLoginFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortCreated: string | null;
+  readonly sortLastUsed: string | null;
+  readonly sortOrigin: string | null;
+  readonly sortUsername: string | null;
+}
+
+export interface LoginDataArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedLoginFinding[];
+  readonly committedCredentialCount: number;
+  readonly recoveredCredentialCount: number;
+}
+
 export interface StoreHistoryAnalysisOptions {
   readonly caseDirectory: string;
   readonly sourceIds: readonly string[];
@@ -48,6 +72,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly invocation: readonly string[];
   readonly startedAt: string;
   readonly artifacts: readonly HistoryArtifactWrite[];
+  readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -163,6 +188,66 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       fields_json TEXT NOT NULL,
       search_text TEXT NOT NULL
     ) STRICT;
+
+    CREATE TABLE IF NOT EXISTS login_data_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Login Data'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS login_data_one_active_result
+      ON login_data_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS login_data_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES login_data_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_created TEXT,
+      sort_last_used TEXT,
+      sort_origin TEXT,
+      sort_username TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS login_data_findings_created_query
+      ON login_data_findings(finding_kind, COALESCE(sort_created, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS login_data_findings_last_used_query
+      ON login_data_findings(finding_kind, COALESCE(sort_last_used, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS login_data_findings_origin_query
+      ON login_data_findings(finding_kind, COALESCE(sort_origin, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS login_data_findings_username_query
+      ON login_data_findings(finding_kind, COALESCE(sort_username, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS login_data_findings_profile_query
+      ON login_data_findings(finding_kind, profile_path, finding_id);
   `);
 }
 
@@ -212,6 +297,32 @@ function insertCandidate(
     JSON.stringify(candidate.provenance),
     JSON.stringify(candidate.fields),
     row.searchText,
+  );
+}
+
+function insertLoginFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedLoginFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortCreated,
+    row.sortLastUsed,
+    row.sortOrigin,
+    row.sortUsername,
   );
 }
 
@@ -280,6 +391,30 @@ export function storeHistoryAnalysis(
       const activateCurrent = database.prepare(
         "UPDATE history_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertLoginArtifact = database.prepare(
+        `INSERT INTO login_data_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Login Data', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertLoginFindingStatement = database.prepare(
+        `INSERT INTO login_data_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_created,
+            sort_last_used, sort_origin, sort_username)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousLogin = database.prepare(
+        `UPDATE login_data_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Login Data'
+            AND active = 1`,
+      );
+      const activateCurrentLogin = database.prepare(
+        "UPDATE login_data_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
 
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
@@ -317,10 +452,42 @@ export function storeHistoryAnalysis(
         }
       }
 
-      const unavailableCount = options.artifacts.filter(
+      for (const artifact of options.loginDataArtifacts ?? []) {
+        const insertion = insertLoginArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertLoginFinding(
+            insertLoginFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousLogin.run(artifact.sourceId, artifact.profile);
+          activateCurrentLogin.run(artifactResultId);
+        }
+      }
+
+      const combinedArtifacts = [
+        ...options.artifacts,
+        ...(options.loginDataArtifacts ?? []),
+      ];
+      const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",
       ).length;
-      const completeCount = options.artifacts.filter(
+      const completeCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "complete",
       ).length;
       const runStatus: AnalysisRunExitState =

--- a/core/src/forensic-model.ts
+++ b/core/src/forensic-model.ts
@@ -7,7 +7,8 @@ export type FieldUnavailableReason =
   | "related_row_missing"
   | "epoch_requires_declared_origin_os"
   | "timestamp_out_of_range"
-  | "unsupported_value";
+  | "unsupported_value"
+  | "encrypted_secret_without_key_material";
 
 export interface ValueField<T> {
   readonly state: "value";

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -5,8 +5,10 @@ import {
   type AnalysisRunExitState,
   type DeclaredOriginOs,
   type HistoryArtifactWrite,
+  type LoginDataArtifactWrite,
   type PersistedFinding,
 } from "./case-findings.js";
+import { analyseLoginDataProfile } from "./login-data.js";
 import {
   loadCaseSources,
   workingCopyAbsolutePath,
@@ -94,6 +96,17 @@ export const ANALYSE_EXIT_CODES = {
   failed: 3,
 } as const satisfies Record<AnalysisRunExitState, number>;
 
+export interface LoginDataAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly committedCredentialCount: number;
+  readonly recoveredCredentialCount: number;
+  readonly findingCount: number;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -101,6 +114,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly runId: string;
   readonly exitState: AnalysisRunExitState;
   readonly history: HistoryAnalysisSummary;
+  readonly loginData: LoginDataAnalysisSummary;
 }
 
 interface ManifestIdentity {
@@ -1138,6 +1152,7 @@ export async function analyseCase(
   const verification = await verifyWorkingCopy(caseDirectory);
   const sources = loadCaseSources(caseDirectory);
   const artifacts: HistoryArtifactWrite[] = [];
+  const loginDataArtifacts: LoginDataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1148,6 +1163,14 @@ export async function analyseCase(
           workingCopyPath,
           declaredTimezone,
           declaredOriginOs,
+        }),
+      );
+      loginDataArtifacts.push(
+        await analyseLoginDataProfile({
+          source,
+          profile: profile.path,
+          workingCopyPath,
+          declaredTimezone,
         }),
       );
     }
@@ -1162,6 +1185,7 @@ export async function analyseCase(
     invocation: options.invocation ?? ["analyse", "--case", caseDirectory],
     startedAt,
     artifacts,
+    loginDataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1176,6 +1200,15 @@ export async function analyseCase(
   );
   const absent = artifacts.filter((artifact) => artifact.status === "absent");
   const unavailable = artifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
+  const loginAnalysed = loginDataArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const loginAbsent = loginDataArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const loginUnavailable = loginDataArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
   return {
@@ -1214,6 +1247,28 @@ export async function analyseCase(
       declaredOriginOs,
       declaredOriginOsConflict:
         declaredOriginOs === "windows" && singletonLockPresent,
+    },
+    loginData: {
+      status: loginUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: loginAnalysed.length,
+      absentProfileCount: loginAbsent.length,
+      unavailableProfileCount: loginUnavailable.length,
+      committedCredentialCount: loginAnalysed.reduce(
+        (count, artifact) => count + artifact.committedCredentialCount,
+        0,
+      ),
+      recoveredCredentialCount: loginAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredCredentialCount,
+        0,
+      ),
+      findingCount: loginAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
     },
   };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -95,6 +95,7 @@ export {
   type EpochFamily,
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
+  type LoginDataAnalysisSummary,
 } from "./history.js";
 export {
   queryHistory,
@@ -120,6 +121,13 @@ export {
   type ExtractRedactionState,
   type RedactedField,
 } from "./export.js";
+export {
+  queryCredentials,
+  type CredentialDirection,
+  type CredentialPage,
+  type CredentialQuery,
+  type CredentialSort,
+} from "./login-data-query.js";
 export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,

--- a/core/src/login-data-query.ts
+++ b/core/src/login-data-query.ts
@@ -1,0 +1,368 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type CredentialSort =
+  | "created-time"
+  | "last-used-time"
+  | "origin"
+  | "username"
+  | "profile";
+export type CredentialDirection = "asc" | "desc";
+
+export interface CredentialQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly sort?: CredentialSort;
+  readonly direction?: CredentialDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface CredentialPage {
+  readonly status: "ok";
+  readonly command: "credentials";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const CREDENTIAL_SORTS = [
+  "created-time",
+  "last-used-time",
+  "origin",
+  "username",
+  "profile",
+] as const;
+const CREDENTIAL_DIRECTIONS = ["asc", "desc"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const CREDENTIAL_KIND = "login_credential";
+
+const SORT_EXPRESSIONS: Readonly<Record<CredentialSort, string>> = {
+  "created-time": "COALESCE(f.sort_created, '')",
+  "last-used-time": "COALESCE(f.sort_last_used, '')",
+  origin: "COALESCE(f.sort_origin, '')",
+  username: "COALESCE(f.sort_username, '')",
+  profile: "f.profile_path",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly sort: CredentialSort;
+  readonly direction: CredentialDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Credential cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Credential cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Credential --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Credential ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM login_data_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function findingSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'login_data_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryCredentials(input: CredentialQuery): CredentialPage {
+  const direction = enumValue(
+    input.direction,
+    "desc",
+    CREDENTIAL_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(
+    input.sort,
+    "created-time",
+    CREDENTIAL_SORTS,
+    "--sort",
+  );
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Credential queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!findingSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Login Data analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [CREDENTIAL_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      if (findingId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Credential cursor contains an invalid sort key.",
+        );
+      }
+      parameters.push(cursor.key, cursor.key, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM login_data_findings f
+           JOIN login_data_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "credentials",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/login-data-sqlite.ts
+++ b/core/src/login-data-sqlite.ts
@@ -1,0 +1,405 @@
+import { lstat, mkdtemp, open, rm } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import type { CommitState } from "./forensic-model.js";
+import { readStableRegularFile } from "./stable-file.js";
+
+export type RawLoginValue = null | string | bigint | Uint8Array;
+
+/**
+ * One row of the Chrome `logins` table, preserved column-by-column exactly as
+ * stored. Values keep their raw SQLite type so the Finding layer can classify
+ * each Field State (value, absent, or unavailable) without lossy coercion.
+ */
+export interface RawLoginRow {
+  readonly values: ReadonlyMap<string, RawLoginValue>;
+  readonly id: bigint | null;
+}
+
+export interface LoginSchema {
+  readonly version: number;
+  readonly columns: ReadonlySet<string>;
+}
+
+export interface LoginPass {
+  readonly schema: LoginSchema;
+  readonly rows: readonly RawLoginRow[];
+  readonly integrity: string;
+}
+
+export interface RecoveredLoginPass extends LoginPass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface LoginPasses {
+  readonly committed: LoginPass;
+  readonly recovered: RecoveredLoginPass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+export interface VerifiedLoginFile {
+  readonly path: string;
+  readonly manifestPath: string;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+/**
+ * Columns the metadata pipeline preserves when present. `password_value` is the
+ * encrypted secret blob; it is retained here only so its wrapper prefix and byte
+ * length can be described. The plaintext secret is never derived.
+ */
+export const SUPPORTED_LOGIN_COLUMNS = [
+  "id",
+  "origin_url",
+  "action_url",
+  "signon_realm",
+  "username_element",
+  "username_value",
+  "password_element",
+  "password_value",
+  "date_created",
+  "date_last_used",
+  "date_password_modified",
+  "blacklisted_by_user",
+  "scheme",
+  "password_type",
+  "times_used",
+  "display_name",
+  "icon_url",
+  "federation_url",
+  "skip_zero_click",
+  "generation_upload_status",
+] as const;
+
+const REQUIRED_LOGIN_COLUMNS = [
+  "id",
+  "origin_url",
+  "signon_realm",
+  "username_value",
+  "password_value",
+  "date_created",
+] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): LoginSchema {
+  for (const table of ["meta", "logins"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `Login Data database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "Login Data meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const columns = tableColumns(database, "logins");
+  const missing = REQUIRED_LOGIN_COLUMNS.filter(
+    (column) => !columns.has(column),
+  );
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Login Data schema version ${version} is missing required logins columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return { version, columns };
+}
+
+function normalizeValue(value: unknown): RawLoginValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Login Data contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): LoginPass {
+  const schema = readSchema(database);
+  const selected = SUPPORTED_LOGIN_COLUMNS.filter((column) =>
+    schema.columns.has(column),
+  );
+  const projection = selected
+    .map((column) => `l."${column}" AS "${column}"`)
+    .join(",\n      ");
+  const statement = database.prepare(`
+    SELECT
+      ${projection}
+    FROM logins l
+    ORDER BY l."id"
+  `);
+  const rows: RawLoginRow[] = [];
+  for (const row of statement.iterate()) {
+    const values = new Map<string, RawLoginValue>();
+    for (const column of selected) {
+      values.set(column, normalizeValue(row[column]));
+    }
+    const idValue = values.get("id");
+    rows.push({
+      values,
+      id: typeof idValue === "bigint" ? idValue : null,
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function immutableDatabase(path: string): DatabaseSync {
+  const url = pathToFileURL(path);
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, {
+    readOnly: true,
+    readBigInts: true,
+  });
+}
+
+function fingerprint(row: RawLoginRow): string {
+  return JSON.stringify(
+    [...row.values.entries()].sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    ),
+    (_key, value: unknown) => {
+      if (typeof value === "bigint") {
+        return `${value.toString()}n`;
+      }
+      if (value instanceof Uint8Array) {
+        return `blob:${Buffer.from(value).toString("base64")}`;
+      }
+      return value;
+    },
+  );
+}
+
+/**
+ * Return only rows that a WAL or rollback journal adds or changes relative to
+ * the committed database, keyed by `logins.id`. This keeps recovered evidence
+ * separate from committed evidence, mirroring the History recovery contract.
+ */
+function recoveredOnlyRows(
+  committed: readonly RawLoginRow[],
+  recovered: readonly RawLoginRow[],
+): RawLoginRow[] {
+  const committedById = new Map(
+    committed.flatMap((row) =>
+      row.id === null ? [] : [[row.id.toString(), fingerprint(row)] as const],
+    ),
+  );
+  const rows: RawLoginRow[] = [];
+  for (const row of recovered) {
+    const id = row.id === null ? null : row.id.toString();
+    const committedFingerprint =
+      id === null ? undefined : committedById.get(id);
+    if (
+      committedFingerprint === undefined ||
+      committedFingerprint !== fingerprint(row)
+    ) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+async function writeAll(destination: FileHandle, chunk: Buffer): Promise<void> {
+  let written = 0;
+  while (written < chunk.length) {
+    const result = await destination.write(
+      chunk,
+      written,
+      chunk.length - written,
+    );
+    written += result.bytesWritten;
+  }
+}
+
+async function snapshotVerifiedFile(
+  source: VerifiedLoginFile,
+  destinationPath: string,
+): Promise<void> {
+  let stats;
+  try {
+    stats = await lstat(source.path, { bigint: true });
+  } catch {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_missing" },
+    ]);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_not_regular_file" },
+    ]);
+  }
+
+  const destination = await open(destinationPath, "wx", 0o600);
+  let result;
+  try {
+    result = await readStableRegularFile(source.path, stats, async (chunk) =>
+      writeAll(destination, chunk),
+    );
+    await destination.sync();
+  } finally {
+    await destination.close();
+  }
+  if (result.status !== "stable") {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_unreadable" },
+    ]);
+  }
+  const issues = [];
+  if (result.size !== source.size) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_size_mismatch" as const,
+      expected: source.size,
+      actual: result.size,
+    });
+  }
+  if (result.sha256 !== source.sha256) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_hash_mismatch" as const,
+      expected: source.sha256,
+      actual: result.sha256,
+    });
+  }
+  if (issues.length > 0) {
+    throw new WorkingCopyIntegrityRefusal(issues);
+  }
+}
+
+export async function readLoginPasses(options: {
+  readonly database: VerifiedLoginFile;
+  readonly sidecars: readonly VerifiedLoginFile[];
+}): Promise<LoginPasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-login-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: LoginPass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyRows(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/login-data.ts
+++ b/core/src/login-data.ts
@@ -1,0 +1,502 @@
+import { join } from "node:path";
+
+import type {
+  LoginDataArtifactWrite,
+  PersistedLoginFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import {
+  readLoginPasses,
+  type LoginSchema,
+  type RawLoginRow,
+  type RawLoginValue,
+  type VerifiedLoginFile,
+} from "./login-data-sqlite.js";
+
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+/**
+ * Chrome stores password-store timestamps as `base::Time` internal values, i.e.
+ * microseconds since 1601-01-01 UTC, on every platform. Unlike History, the
+ * epoch does not depend on the origin OS, so no Declared Origin OS is required.
+ */
+const LOGIN_EPOCH_FAMILY = "1601-us" as const;
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface BuiltCredential {
+  readonly persisted: PersistedLoginFinding;
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+function preservedString(value: RawLoginValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(value: RawLoginValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function preservedBoolean(value: RawLoginValue): FieldState<boolean> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  if (value === 0n) {
+    return valueField(false);
+  }
+  if (value === 1n) {
+    return valueField(true);
+  }
+  return unavailableField("unsupported_value");
+}
+
+function timestampField(
+  raw: RawLoginValue,
+  columnPresent: boolean,
+  schemaVersion: number,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (!columnPresent || raw === undefined || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const utc = utcFromUnixMicros(raw - WINDOWS_EPOCH_OFFSET_MICROS);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: LOGIN_EPOCH_FAMILY,
+      utc,
+      declaredTimezone,
+      resolution: `verified_login_data_schema_version_${schemaVersion}`,
+    },
+    { synthetic: false },
+  );
+}
+
+interface SecretDescription {
+  readonly secret: FieldState<string>;
+  readonly scheme: FieldState<string>;
+  readonly prefix: FieldState<string>;
+  readonly byteLength: FieldState<string>;
+}
+
+/**
+ * Describe the encrypted secret wrapper without ever attempting to read the
+ * plaintext. A stored secret is always reported `unavailable` with the typed
+ * reason `encrypted_secret_without_key_material`; an empty or missing blob is
+ * `absent`. The wrapper prefix (for example `v10`, `v11`, `v20`) and byte
+ * length are retained as metadata so an investigator can classify the scheme.
+ */
+function describeSecret(
+  value: RawLoginValue,
+  columnPresent: boolean,
+): SecretDescription {
+  if (!columnPresent || value === undefined || value === null) {
+    return {
+      secret: absentField(),
+      scheme: absentField(),
+      prefix: absentField(),
+      byteLength: absentField(),
+    };
+  }
+  if (!(value instanceof Uint8Array)) {
+    return {
+      secret: unavailableField("unsupported_value"),
+      scheme: unavailableField("unsupported_value"),
+      prefix: unavailableField("unsupported_value"),
+      byteLength: unavailableField("unsupported_value"),
+    };
+  }
+  if (value.length === 0) {
+    return {
+      secret: absentField(),
+      scheme: absentField(),
+      prefix: absentField(),
+      byteLength: valueField("0"),
+    };
+  }
+  const head = value.subarray(0, 3);
+  const ascii = Buffer.from(head).toString("latin1");
+  const recognizedScheme = /^v\d\d$/.test(ascii);
+  return {
+    secret: unavailableField("encrypted_secret_without_key_material"),
+    scheme: recognizedScheme
+      ? valueField(ascii)
+      : unavailableField("unsupported_value"),
+    prefix: recognizedScheme
+      ? valueField(ascii)
+      : valueField(Buffer.from(head).toString("hex")),
+    byteLength: valueField(value.length.toString()),
+  };
+}
+
+function sourceRowProvenance(
+  manifest: ManifestIdentity,
+  rowId: string,
+): SourceRowProvenance {
+  return {
+    manifestEntryId: `${manifest.sourceId}:${manifest.ordinal}`,
+    sourceId: manifest.sourceId,
+    manifestEntryOrdinal: manifest.ordinal,
+    manifestPath: manifest.path,
+    database: manifest.databasePath,
+    table: "logins",
+    rowId,
+  };
+}
+
+function textValue(field: FieldState<string>): string {
+  return field.state === "value" ? field.value : "";
+}
+
+function timeValue(field: FieldState<ForensicTimestamp>): string | null {
+  return field.state === "value" ? field.value.utc : null;
+}
+
+function buildCredentials(options: {
+  readonly rows: readonly RawLoginRow[];
+  readonly schema: LoginSchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+}): BuiltCredential[] {
+  return options.rows.map((row) => {
+    if (row.id === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Login Data logins.id is not an exact integer.",
+      );
+    }
+    const rowId = row.id.toString();
+    const has = (column: string): boolean => options.schema.columns.has(column);
+    const get = (column: string): RawLoginValue =>
+      row.values.get(column) ?? null;
+    const secret = describeSecret(get("password_value"), has("password_value"));
+    const originUrl = preservedString(get("origin_url"));
+    const signonRealm = preservedString(get("signon_realm"));
+    const usernameValue = preservedString(get("username_value"));
+    const actionUrl = preservedString(get("action_url"));
+    const dateCreated = timestampField(
+      get("date_created"),
+      has("date_created"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const dateLastUsed = timestampField(
+      get("date_last_used"),
+      has("date_last_used"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const fields = {
+      credentialId: valueField(rowId),
+      originUrl,
+      actionUrl,
+      signonRealm,
+      usernameElement: preservedString(get("username_element")),
+      usernameValue,
+      passwordElement: preservedString(get("password_element")),
+      secret: secret.secret,
+      secretEncryptionScheme: secret.scheme,
+      secretEncryptionPrefix: secret.prefix,
+      secretByteLength: secret.byteLength,
+      dateCreated,
+      dateLastUsed,
+      datePasswordModified: timestampField(
+        get("date_password_modified"),
+        has("date_password_modified"),
+        options.schema.version,
+        options.declaredTimezone,
+      ),
+      timesUsed: preservedInteger(get("times_used")),
+      blacklistedByUser: preservedBoolean(get("blacklisted_by_user")),
+      scheme: preservedInteger(get("scheme")),
+      passwordType: preservedInteger(get("password_type")),
+      displayName: preservedString(get("display_name")),
+      iconUrl: preservedString(get("icon_url")),
+      federationUrl: preservedString(get("federation_url")),
+      skipZeroClick: preservedBoolean(get("skip_zero_click")),
+      generationUploadStatus: preservedInteger(get("generation_upload_status")),
+    };
+    const finding: Finding = createFinding({
+      findingKind: "login_credential",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance: sourceRowProvenance(options.manifest, rowId),
+      fields,
+    });
+    return {
+      persisted: {
+        finding,
+        searchText: [
+          options.profile,
+          textValue(originUrl),
+          textValue(actionUrl),
+          textValue(signonRealm),
+          textValue(usernameValue),
+        ]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortCreated: timeValue(dateCreated),
+        sortLastUsed: timeValue(dateLastUsed),
+        sortOrigin: textValue(originUrl) || null,
+        sortUsername: textValue(usernameValue) || null,
+      },
+    };
+  });
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): LoginDataArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedCredentialCount: 0,
+    recoveredCredentialCount: 0,
+  };
+}
+
+export async function analyseLoginDataProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+}): Promise<LoginDataArtifactWrite> {
+  const databasePath =
+    options.profile === "." ? "Login Data" : `${options.profile}/Login Data`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      null,
+      "absent",
+      "login_data_manifest_entry_missing",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "login_data_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `login_data_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "login_data_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "login_data_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedLoginFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedLoginFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readLoginPasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Login Data recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const committed = buildCredentials({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      declaredTimezone: options.declaredTimezone,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildCredentials({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            declaredTimezone: options.declaredTimezone,
+          });
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [
+        ...committed.map((credential) => credential.persisted),
+        ...recovered.map((credential) => credential.persisted),
+      ],
+      committedCredentialCount: committed.length,
+      recoveredCredentialCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `login_data_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}

--- a/e2e/login-data-cli.test.ts
+++ b/e2e/login-data-cli.test.ts
@@ -1,0 +1,542 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface CredentialFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "login_credential";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: {
+    readonly credentialId: Field<string>;
+    readonly originUrl: Field<string>;
+    readonly signonRealm: Field<string>;
+    readonly usernameValue: Field<string>;
+    readonly secret: Field<string>;
+    readonly secretEncryptionScheme: Field<string>;
+    readonly secretEncryptionPrefix: Field<string>;
+    readonly secretByteLength: Field<string>;
+    readonly dateCreated: Field<{
+      readonly raw: string;
+      readonly epochFamily: string;
+      readonly utc: string;
+      readonly declaredTimezone: string;
+      readonly resolution: string;
+    }>;
+    readonly dateLastUsed: Field<unknown>;
+    readonly timesUsed: Field<string>;
+    readonly federationUrl: Field<string>;
+  };
+}
+
+interface CredentialPage {
+  readonly status: "ok";
+  readonly command: "credentials";
+  readonly items: readonly CredentialFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+interface LoginRow {
+  readonly id: bigint;
+  readonly originUrl: string;
+  readonly signonRealm: string;
+  readonly usernameValue: string;
+  readonly passwordValue: Uint8Array | null;
+  readonly dateCreated: bigint;
+  readonly dateLastUsed: bigint;
+  readonly scheme: bigint;
+  readonly timesUsed: bigint;
+  readonly federationUrl: string;
+}
+
+function createLoginsSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+    INSERT INTO meta (key, value) VALUES ('version', '43'), ('last_compatible_version', '1');
+
+    CREATE TABLE logins (
+      origin_url VARCHAR NOT NULL,
+      action_url VARCHAR,
+      username_element VARCHAR,
+      username_value VARCHAR,
+      password_element VARCHAR,
+      password_value BLOB,
+      signon_realm VARCHAR NOT NULL,
+      date_created INTEGER NOT NULL,
+      blacklisted_by_user INTEGER NOT NULL,
+      scheme INTEGER NOT NULL,
+      password_type INTEGER,
+      times_used INTEGER,
+      form_data BLOB,
+      display_name VARCHAR,
+      icon_url VARCHAR,
+      federation_url VARCHAR,
+      skip_zero_click INTEGER,
+      generation_upload_status INTEGER,
+      possible_username_pairs BLOB,
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      date_last_used INTEGER NOT NULL DEFAULT 0,
+      moving_blocked_for BLOB,
+      date_password_modified INTEGER NOT NULL DEFAULT 0,
+      keychain_identifier BLOB
+    );
+  `);
+}
+
+function insertLogin(database: DatabaseSync, row: LoginRow): void {
+  database
+    .prepare(
+      `INSERT INTO logins
+         (id, origin_url, action_url, username_element, username_value,
+          password_element, password_value, signon_realm, date_created,
+          blacklisted_by_user, scheme, password_type, times_used, display_name,
+          icon_url, federation_url, skip_zero_click, generation_upload_status,
+          date_last_used, date_password_modified)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 0, ?, ?, ?, ?, 0, 0, ?, ?)`,
+    )
+    .run(
+      row.id,
+      row.originUrl,
+      `${row.originUrl}login`,
+      "username",
+      row.usernameValue,
+      "password",
+      row.passwordValue,
+      row.signonRealm,
+      row.dateCreated,
+      row.scheme,
+      row.timesUsed,
+      `Account ${row.id}`,
+      `${row.originUrl}favicon.ico`,
+      row.federationUrl,
+      row.dateLastUsed,
+      row.dateCreated,
+    );
+}
+
+async function createLoginData(
+  path: string,
+  rows: readonly LoginRow[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    createLoginsSchema(database);
+    for (const row of rows) {
+      insertLogin(database, row);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+const V10_SECRET = new Uint8Array([
+  0x76, 0x31, 0x30, 0xde, 0xad, 0xbe, 0xef, 0x00, 0x11,
+]);
+const V20_SECRET = new Uint8Array([
+  0x76, 0x32, 0x30, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06,
+]);
+const DPAPI_SECRET = new Uint8Array([0x01, 0x00, 0x00, 0x00, 0xaa, 0xbb]);
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createLoginData(join(source, "Default", "Login Data"), [
+    {
+      id: 1n,
+      originUrl: "https://alpha.example/",
+      signonRealm: "https://alpha.example/",
+      usernameValue: "alice@alpha.example",
+      passwordValue: V10_SECRET,
+      dateCreated: 13_348_638_245_123_456n,
+      dateLastUsed: 13_348_638_305_456_000n,
+      scheme: 0n,
+      timesUsed: 4n,
+      federationUrl: "",
+    },
+    {
+      id: 2n,
+      originUrl: "https://bank.example/",
+      signonRealm: "https://bank.example/",
+      usernameValue: "bob@bank.example",
+      passwordValue: V20_SECRET,
+      dateCreated: 13_348_638_400_000_000n,
+      dateLastUsed: 13_348_638_500_000_000n,
+      scheme: 0n,
+      timesUsed: 9n,
+      federationUrl: "",
+    },
+    {
+      id: 3n,
+      originUrl: "https://federated.example/",
+      signonRealm: "federation://federated.example/accounts.google.com",
+      usernameValue: "carol@federated.example",
+      passwordValue: new Uint8Array(0),
+      dateCreated: 13_348_638_600_000_000n,
+      dateLastUsed: 0n,
+      scheme: 0n,
+      timesUsed: 0n,
+      federationUrl: "https://accounts.google.com/",
+    },
+  ]);
+  await createLoginData(join(source, "Profile 1", "Login Data"), [
+    {
+      id: 5n,
+      originUrl: "https://gamma.example/",
+      signonRealm: "https://gamma.example/",
+      usernameValue: "dave@gamma.example",
+      passwordValue: DPAPI_SECRET,
+      dateCreated: 13_361_718_600_000_000n,
+      dateLastUsed: 13_361_718_700_000_000n,
+      scheme: 0n,
+      timesUsed: 1n,
+      federationUrl: "",
+    },
+  ]);
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Login Data credential metadata", () => {
+  it("parses credential metadata across Profiles without decrypting secrets", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-login-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const defaultBytes = await readFile(join(source, "Default", "Login Data"));
+    const caseDirectory = join(root, "CASE-LOGIN");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      loginData: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        unavailableProfileCount: 0,
+        committedCredentialCount: 4,
+        recoveredCredentialCount: 0,
+      },
+    });
+
+    // AC5: bounded, multi-Profile keyset pagination ordered by creation time.
+    const firstPage = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "created-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage).toMatchObject({ command: "credentials", limit: 2 });
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const [alpha] = firstPage.items;
+    expect(alpha).toBeDefined();
+    // AC1 + AC2 + AC5: origin, username, timestamp, and Provenance are present
+    // and available independently of any secret decryption.
+    expect(alpha).toMatchObject({
+      recordType: "finding",
+      findingKind: "login_credential",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Login Data",
+        database: "Default/Login Data",
+        table: "logins",
+        rowId: "1",
+      },
+      fields: {
+        credentialId: { state: "value", value: "1" },
+        originUrl: { state: "value", value: "https://alpha.example/" },
+        signonRealm: { state: "value", value: "https://alpha.example/" },
+        usernameValue: { state: "value", value: "alice@alpha.example" },
+        timesUsed: { state: "value", value: "4" },
+      },
+    });
+    // AC4: timestamp keeps raw value, Epoch Family, and UTC instant.
+    expect(alpha?.fields.dateCreated).toEqual({
+      state: "value",
+      synthetic: false,
+      value: {
+        raw: "13348638245123456",
+        epochFamily: "1601-us",
+        utc: "2024-01-02T03:04:05.123456Z",
+        declaredTimezone: "America/New_York",
+        resolution: "verified_login_data_schema_version_43",
+      },
+    });
+    // AC3: an encrypted secret is unavailable with a typed reason, never blank.
+    expect(alpha?.fields.secret).toEqual({
+      state: "unavailable",
+      reason: "encrypted_secret_without_key_material",
+    });
+    expect(alpha?.fields.secretEncryptionScheme).toEqual({
+      state: "value",
+      value: "v10",
+    });
+    expect(alpha?.fields.secretEncryptionPrefix).toEqual({
+      state: "value",
+      value: "v10",
+    });
+    expect(alpha?.fields.secretByteLength).toEqual({
+      state: "value",
+      value: "9",
+    });
+
+    const secondPage = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "created-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const allIds = [...firstPage.items, ...secondPage.items].map(
+      (item) => item.provenance.rowId,
+    );
+    expect(new Set(allIds).size).toBe(4);
+    expect(
+      [...firstPage.items, ...secondPage.items].map((item) => item.profile),
+    ).toContain("Profile 1");
+
+    // v20 App-Bound wrapper is recognised; secret still unavailable.
+    const bank = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--search",
+        "bank.example",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(bank).toHaveLength(1);
+    expect(bank[0]?.fields.secretEncryptionScheme).toEqual({
+      state: "value",
+      value: "v20",
+    });
+    expect(bank[0]?.fields.secret.state).toBe("unavailable");
+
+    // A federated credential stores no secret: absent, not unavailable/blank.
+    const federated = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--search",
+        "federated.example",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(federated).toHaveLength(1);
+    expect(federated[0]?.fields.secret).toEqual({ state: "absent" });
+    expect(federated[0]?.fields.federationUrl).toEqual({
+      state: "value",
+      value: "https://accounts.google.com/",
+    });
+    expect(federated[0]?.fields.dateLastUsed).toEqual({ state: "absent" });
+
+    // An unrecognised wrapper keeps the raw prefix bytes as retained metadata.
+    const gamma = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Profile 1",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(gamma).toHaveLength(1);
+    expect(gamma[0]?.fields.secret).toEqual({
+      state: "unavailable",
+      reason: "encrypted_secret_without_key_material",
+    });
+    expect(gamma[0]?.fields.secretEncryptionScheme).toEqual({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    expect(gamma[0]?.fields.secretEncryptionPrefix).toEqual({
+      state: "value",
+      value: "010000",
+    });
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(source, "Default", "Login Data"))).toEqual(
+      defaultBytes,
+    );
+  });
+
+  it("keeps committed and WAL-resident credentials separate with Provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-login-wal-"));
+    temporaryRoots.push(root);
+    const source = join(root, "wal-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const loginPath = join(source, "Default", "Login Data");
+    await createLoginData(loginPath, [
+      {
+        id: 1n,
+        originUrl: "https://committed.example/",
+        signonRealm: "https://committed.example/",
+        usernameValue: "committed@example",
+        passwordValue: V10_SECRET,
+        dateCreated: 13_348_638_245_123_456n,
+        dateLastUsed: 13_348_638_245_123_456n,
+        scheme: 0n,
+        timesUsed: 1n,
+        federationUrl: "",
+      },
+    ]);
+
+    const writer = new DatabaseSync(loginPath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    insertLogin(writer, {
+      id: 2n,
+      originUrl: "https://wal.example/",
+      signonRealm: "https://wal.example/",
+      usernameValue: "wal@example",
+      passwordValue: V20_SECRET,
+      dateCreated: 13_348_638_400_000_000n,
+      dateLastUsed: 13_348_638_400_000_000n,
+      scheme: 0n,
+      timesUsed: 2n,
+      federationUrl: "",
+    });
+
+    const caseDirectory = join(root, "CASE-LOGIN-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      loginData: { committedCredentialCount: 1, recoveredCredentialCount: 1 },
+    });
+
+    const committed = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/Login Data", rowId: "1" },
+    });
+
+    const recovered = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/Login Data-wal",
+        database: "Default/Login Data",
+        table: "logins",
+        rowId: "2",
+      },
+      fields: {
+        originUrl: { state: "value", value: "https://wal.example/" },
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #177. Base and target: `v2` only.

Adds a Login Data pipeline parallel to the History Finding pipeline (#168) and folds it into the existing Analysis Run / supersede model (#172). Lets an investigator review saved credential evidence even when encrypted secrets cannot be decrypted.

## Acceptance criteria → where met

| # | Criterion | Where |
| - | --------- | ----- |
| 1 | Current Login Data schemas parsed across all Profiles for origin, username, timestamps, encryption prefix, and other supported external fields | `core/src/login-data-sqlite.ts` (`readPass`, `SUPPORTED_LOGIN_COLUMNS`, per-column presence detection); `core/src/login-data.ts` (`buildCredentials` emits `originUrl`, `usernameValue`, `signonRealm`, `dateCreated/dateLastUsed/datePasswordModified`, `secretEncryptionPrefix`, `timesUsed`, `scheme`, `federationUrl`, …). `analyseCase` loops every Source × Profile. E2E: “parses credential metadata across Profiles …” |
| 2 | Credential metadata available independently of secret decryption | Metadata fields are built from plaintext columns; no decryption path exists. `usernameValue`/`originUrl`/timestamps resolve regardless of the secret. E2E asserts full metadata while `secret` is unavailable. |
| 3 | Encrypted secrets without authorized key material are unavailable with a typed reason — not absent or blank | `describeSecret` returns `unavailable("encrypted_secret_without_key_material")` for any non-empty wrapper (new typed reason added to `FieldUnavailableReason`); empty/missing blob → `absent`. Wrapper prefix (`v10`/`v11`/`v20`) and byte length retained as metadata. E2E asserts v10, v20, unrecognised DPAPI, and federated (absent) cases. |
| 4 | Timestamp conversion uses verified database metadata; retain raw value, Epoch Family, and UTC instant | `timestampField` resolves `1601-us` from the verified `meta.version`; emits `ForensicTimestamp { raw, epochFamily, utc, declaredTimezone, resolution: verified_login_data_schema_version_N }`. E2E asserts exact raw/epochFamily/UTC. |
| 5 | Committed and sidecar rows separate; each Finding has Provenance; CLI query surface bounded and multi-Profile (History contract) | `login-data-sqlite.ts` runs separate committed and recovered (WAL/journal) passes; recovered-only rows carry the sidecar manifest path and `wal_resident`/`journal_resident` Commit State. Every Finding carries `logins` row Provenance. `login-data-query.ts` + the `credentials` CLI command mirror History’s fingerprinted keyset pagination, `--profile` (≤100), `--search`, `--commit-state`, `--sort`, `--direction`, `--limit` (1–100). E2E: committed vs WAL-resident separation with Provenance. |

## Design notes

- One Analysis Run per `analyse`: Login Data results are written to new `login_data_artifact_results` / `login_data_findings` tables under the **same** run as History, with independent per-artifact supersede and `active` tracking. Existing `analysis_runs`, `history_artifact_results`, `forensic_findings`, and `forensic_candidates` are structurally untouched, so all prior E2E invariants hold.
- Overall run exit state (0/2/3) now aggregates History + Login Data artifacts; absent Login Data (no file) is `absent`, so it never flips a clean run to partial.
- Scope: primary `Login Data` DB per Profile. `Login Data For Account` is a documented follow-up (would need an artifact-name distinction to avoid the per-Profile unique constraint).

## Verification

`pnpm verify` green locally on Node 24.15.0: format, lint, typecheck, and **23 tests pass** (2 new Login Data E2E cases + all pre-existing suites). New compiled-CLI E2E: `e2e/login-data-cli.test.ts`. The serial-on-Windows E2E config was left intact.

## Risks

- Login Data schema variance across Chrome versions: required columns are enforced and unknown columns are ignored; a missing required column yields an `unavailable` artifact with a typed reason rather than a crash.
- Encryption-prefix heuristic recognises `v\d\d` tags; anything else keeps the raw prefix bytes (hex) and still reports the secret unavailable — no misclassification of the secret state.
- No fixture exercises `Login Data For Account`; out of scope by design.