### PR TITLE
feat(#174): Parse Cookies as forensic Findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,35 @@ Use `--commit-state` to keep committed and recovered rows separate.
 The `--from`, `--to`, and `--transition` filters apply only to `visits`.
 Timestamp bounds must include `Z` or a numeric offset.
 
+## Query Cookie Findings
+
+The `analyse` command parses each Profile's Cookie store in the same Analysis
+Run as History, without decrypting any value. Query the Cookie Findings with:
+
+```sh
+node cli/dist/cli.js cookies \
+  --case "/path/to/CASE-001" \
+  --profile Default \
+  --search "example.com" \
+  --commit-state committed \
+  --host ".example.com" \
+  --same-site lax \
+  --sort host \
+  --direction asc \
+  --limit 50 \
+  --json
+```
+
+Each Cookie Finding records host, name, path, flags, and the exact SameSite,
+priority, source scheme, source type, and port. Cookie timestamps use the
+1601 Epoch Family; a legacy schema needs `--origin-os` before the analyzer
+asserts the UTC instant. An encrypted cookie value stays `unavailable` with the
+typed reason `encrypted_secret_without_key_material`, and the Finding still
+reports the encryption scheme (`v10`, `v11`, `v20`) and the ciphertext byte
+length. Use `--commit-state` to keep committed and sidecar-resident cookies
+separate. Repeat `--profile` to query at most 100 Profiles, and use `nextCursor`
+as the next `--after` value.
+
 ## Query Credential Metadata
 
 The `credentials` command returns Login Data Findings with the same bounded, multi-Profile query surface as History.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,9 +9,12 @@ import {
   analyseCase,
   exportCase,
   ingestSource,
+  queryCookies,
   queryCredentials,
   queryHistory,
   type CommitState,
+  type CookieDirection,
+  type CookieSort,
   type CredentialDirection,
   type CredentialSort,
   type DeclaredOriginOs,
@@ -32,6 +35,13 @@ const USAGE = `Usage:
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--transition <name>] [--from <instant>] [--to <instant>]
                    [--sort <field>] [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix cookies --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--host <host-key>] [--same-site <name>]
+                   [--sort <host|name|creation-time|expires-time|last-access-time|profile>]
+                   [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix credentials --case <case-directory>
                    [--profile <profile>]... [--search <text>]
@@ -81,6 +91,8 @@ const VALUE_OPTIONS = new Set([
   "--transition",
   "--from",
   "--to",
+  "--host",
+  "--same-site",
   "--sort",
   "--direction",
   "--limit",
@@ -378,6 +390,58 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as HistorySort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | HistoryDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "cookies") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--host",
+        "--same-site",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The cookies command accepts no positional values.",
+      );
+    }
+    const result = queryCookies({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      host: optionValue(parsed, "--host"),
+      sameSite: optionValue(parsed, "--same-site"),
+      sort: enumOption(parsed, "--sort", [
+        "host",
+        "name",
+        "creation-time",
+        "expires-time",
+        "last-access-time",
+        "profile",
+      ] as const) as CookieSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | CookieDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -64,6 +64,33 @@ export interface LoginDataArtifactWrite {
   readonly recoveredCredentialCount: number;
 }
 
+export interface PersistedCookieFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortHost: string | null;
+  readonly sortName: string | null;
+  readonly sortCreation: string | null;
+  readonly sortExpires: string | null;
+  readonly sortLastAccess: string | null;
+  readonly hostKey: string | null;
+  readonly sameSite: string | null;
+}
+
+export interface CookieArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedCookieFinding[];
+  readonly committedCookieCount: number;
+  readonly recoveredCookieCount: number;
+}
+
 export interface StoreHistoryAnalysisOptions {
   readonly caseDirectory: string;
   readonly sourceIds: readonly string[];
@@ -72,6 +99,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly invocation: readonly string[];
   readonly startedAt: string;
   readonly artifacts: readonly HistoryArtifactWrite[];
+  readonly cookieArtifacts?: readonly CookieArtifactWrite[];
   readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
 }
 
@@ -248,6 +276,71 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON login_data_findings(finding_kind, COALESCE(sort_username, ''), finding_id);
     CREATE INDEX IF NOT EXISTS login_data_findings_profile_query
       ON login_data_findings(finding_kind, profile_path, finding_id);
+
+    CREATE TABLE IF NOT EXISTS cookie_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Cookies'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS cookie_one_active_result
+      ON cookie_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS cookie_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES cookie_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_host TEXT,
+      sort_name TEXT,
+      sort_creation TEXT,
+      sort_expires TEXT,
+      sort_last_access TEXT,
+      host_key TEXT,
+      same_site TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS cookie_findings_host_query
+      ON cookie_findings(finding_kind, COALESCE(sort_host, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cookie_findings_name_query
+      ON cookie_findings(finding_kind, COALESCE(sort_name, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cookie_findings_creation_query
+      ON cookie_findings(finding_kind, COALESCE(sort_creation, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cookie_findings_expires_query
+      ON cookie_findings(finding_kind, COALESCE(sort_expires, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cookie_findings_last_access_query
+      ON cookie_findings(finding_kind, COALESCE(sort_last_access, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cookie_findings_profile_query
+      ON cookie_findings(finding_kind, profile_path, commit_state, finding_id);
   `);
 }
 
@@ -326,9 +419,39 @@ function insertLoginFinding(
   );
 }
 
+function insertCookieFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedCookieFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortHost,
+    row.sortName,
+    row.sortCreation,
+    row.sortExpires,
+    row.sortLastAccess,
+    row.hostKey,
+    row.sameSite,
+  );
+}
+
 export function storeHistoryAnalysis(
   options: StoreHistoryAnalysisOptions,
 ): StoredHistoryAnalysis {
+  const cookieArtifacts = options.cookieArtifacts ?? [];
   const runId = randomUUID();
   const database = new DatabaseSync(
     join(resolve(options.caseDirectory), CASE_FILENAME),
@@ -415,6 +538,30 @@ export function storeHistoryAnalysis(
       const activateCurrentLogin = database.prepare(
         "UPDATE login_data_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertCookieArtifact = database.prepare(
+        `INSERT INTO cookie_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Cookies', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertCookieFindingStatement = database.prepare(
+        `INSERT INTO cookie_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_host, sort_name,
+            sort_creation, sort_expires, sort_last_access, host_key, same_site)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousCookie = database.prepare(
+        `UPDATE cookie_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Cookies'
+            AND active = 1`,
+      );
+      const activateCurrentCookie = database.prepare(
+        "UPDATE cookie_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
 
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
@@ -452,6 +599,34 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of cookieArtifacts) {
+        const insertion = insertCookieArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertCookieFinding(
+            insertCookieFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousCookie.run(artifact.sourceId, artifact.profile);
+          activateCurrentCookie.run(artifactResultId);
+        }
+      }
+
       for (const artifact of options.loginDataArtifacts ?? []) {
         const insertion = insertLoginArtifact.run(
           runId,
@@ -482,6 +657,7 @@ export function storeHistoryAnalysis(
 
       const combinedArtifacts = [
         ...options.artifacts,
+        ...cookieArtifacts,
         ...(options.loginDataArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(

--- a/core/src/cookies-query.ts
+++ b/core/src/cookies-query.ts
@@ -1,0 +1,381 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type CookieDirection = "asc" | "desc";
+export type CookieSort =
+  | "host"
+  | "name"
+  | "creation-time"
+  | "expires-time"
+  | "last-access-time"
+  | "profile";
+
+export interface CookieQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly host?: string;
+  readonly sameSite?: string;
+  readonly sort?: CookieSort;
+  readonly direction?: CookieDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface CookiePage {
+  readonly status: "ok";
+  readonly command: "cookies";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string;
+}
+
+const COOKIE_DIRECTIONS = ["asc", "desc"] as const;
+const COOKIE_SORTS = [
+  "host",
+  "name",
+  "creation-time",
+  "expires-time",
+  "last-access-time",
+  "profile",
+] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+
+const SORT_EXPRESSIONS: Readonly<Record<CookieSort, string>> = {
+  host: "COALESCE(f.sort_host, '')",
+  name: "COALESCE(f.sort_name, '')",
+  "creation-time": "COALESCE(f.sort_creation, '')",
+  "expires-time": "COALESCE(f.sort_expires, '')",
+  "last-access-time": "COALESCE(f.sort_last_access, '')",
+  profile: "f.profile_path",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly host: string | null;
+  readonly sameSite: string | null;
+  readonly sort: CookieSort;
+  readonly direction: CookieDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Cookies cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Cookies cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Cookies --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Cookies ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM cookie_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function cookieSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'cookie_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Cookie Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryCookies(input: CookieQuery): CookiePage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    COOKIE_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "host", COOKIE_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Cookies queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+  const host = input.host ?? null;
+  const sameSite = input.sameSite?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!cookieSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Cookies analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      host,
+      sameSite,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = 'cookie'",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (host !== null) {
+      conditions.push("f.host_key = ?");
+      parameters.push(host);
+    }
+    if (sameSite !== null) {
+      conditions.push("f.same_site = ?");
+      parameters.push(sameSite);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      if (findingId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Cookies cursor contains an invalid sort key.",
+        );
+      }
+      parameters.push(cursor.key, cursor.key, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM cookie_findings f
+           JOIN cookie_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "cookies",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/cookies-sqlite.ts
+++ b/core/src/cookies-sqlite.ts
@@ -1,0 +1,386 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { CommitState } from "./forensic-model.js";
+import { ForensixError } from "./errors.js";
+import {
+  immutableDatabase,
+  snapshotVerifiedFile,
+  type RawHistoryValue,
+  type VerifiedHistoryFile,
+} from "./history-sqlite.js";
+
+export type RawCookieValue = RawHistoryValue;
+export type VerifiedCookieFile = VerifiedHistoryFile;
+
+export interface RawCookie {
+  readonly rowId: RawCookieValue;
+  readonly creationUtc: RawCookieValue;
+  readonly hostKey: RawCookieValue;
+  readonly topFrameSiteKey: RawCookieValue;
+  readonly name: RawCookieValue;
+  readonly value: RawCookieValue;
+  readonly encryptedValue: RawCookieValue;
+  readonly path: RawCookieValue;
+  readonly expiresUtc: RawCookieValue;
+  readonly isSecure: RawCookieValue;
+  readonly isHttpOnly: RawCookieValue;
+  readonly lastAccessUtc: RawCookieValue;
+  readonly hasExpires: RawCookieValue;
+  readonly isPersistent: RawCookieValue;
+  readonly priority: RawCookieValue;
+  readonly samesite: RawCookieValue;
+  readonly sourceScheme: RawCookieValue;
+  readonly sourcePort: RawCookieValue;
+  readonly lastUpdateUtc: RawCookieValue;
+  readonly sourceType: RawCookieValue;
+  readonly hasCrossSiteAncestor: RawCookieValue;
+}
+
+export interface CookieSchema {
+  readonly version: number;
+  readonly cookieColumns: ReadonlySet<string>;
+}
+
+export interface CookiePass {
+  readonly schema: CookieSchema;
+  readonly rows: readonly RawCookie[];
+  readonly integrity: string;
+}
+
+export interface RecoveredCookiePass extends CookiePass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface CookiePasses {
+  readonly committed: CookiePass;
+  readonly recovered: RecoveredCookiePass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+/**
+ * Columns every supported Chromium `cookies` schema must expose. The remaining
+ * columns are read when present and recorded as an absent Field State when the
+ * schema predates them, so a Finding never fabricates a value.
+ */
+const REQUIRED_COOKIE_COLUMNS = [
+  "creation_utc",
+  "host_key",
+  "name",
+  "value",
+  "encrypted_value",
+  "path",
+  "expires_utc",
+  "is_secure",
+  "is_httponly",
+  "last_access_utc",
+] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): CookieSchema {
+  for (const table of ["meta", "cookies"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `Cookies database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "Cookies meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const cookieColumns = tableColumns(database, "cookies");
+  const missing = REQUIRED_COOKIE_COLUMNS.filter(
+    (column) => !cookieColumns.has(column),
+  );
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Cookies schema version ${version} is missing required columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return { version, cookieColumns };
+}
+
+function optionalColumn(
+  columns: ReadonlySet<string>,
+  column: string,
+  alias: string,
+): string {
+  return columns.has(column)
+    ? `c."${column}" AS "${alias}"`
+    : `NULL AS "${alias}"`;
+}
+
+function normalizeValue(value: unknown): RawCookieValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Cookies contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): CookiePass {
+  const schema = readSchema(database);
+  const column = (name: string, alias: string): string =>
+    optionalColumn(schema.cookieColumns, name, alias);
+  const statement = database.prepare(`
+    SELECT
+      c.rowid AS "rowId",
+      ${column("creation_utc", "creationUtc")},
+      ${column("host_key", "hostKey")},
+      ${column("top_frame_site_key", "topFrameSiteKey")},
+      ${column("name", "name")},
+      ${column("value", "value")},
+      ${column("encrypted_value", "encryptedValue")},
+      ${column("path", "path")},
+      ${column("expires_utc", "expiresUtc")},
+      ${column("is_secure", "isSecure")},
+      ${column("is_httponly", "isHttpOnly")},
+      ${column("last_access_utc", "lastAccessUtc")},
+      ${column("has_expires", "hasExpires")},
+      ${column("is_persistent", "isPersistent")},
+      ${column("priority", "priority")},
+      ${column("samesite", "samesite")},
+      ${column("source_scheme", "sourceScheme")},
+      ${column("source_port", "sourcePort")},
+      ${column("last_update_utc", "lastUpdateUtc")},
+      ${column("source_type", "sourceType")},
+      ${column("has_cross_site_ancestor", "hasCrossSiteAncestor")}
+    FROM cookies c
+    ORDER BY c.rowid
+  `);
+  const rows: RawCookie[] = [];
+  for (const row of statement.iterate()) {
+    rows.push({
+      rowId: normalizeValue(row.rowId),
+      creationUtc: normalizeValue(row.creationUtc),
+      hostKey: normalizeValue(row.hostKey),
+      topFrameSiteKey: normalizeValue(row.topFrameSiteKey),
+      name: normalizeValue(row.name),
+      value: normalizeValue(row.value),
+      encryptedValue: normalizeValue(row.encryptedValue),
+      path: normalizeValue(row.path),
+      expiresUtc: normalizeValue(row.expiresUtc),
+      isSecure: normalizeValue(row.isSecure),
+      isHttpOnly: normalizeValue(row.isHttpOnly),
+      lastAccessUtc: normalizeValue(row.lastAccessUtc),
+      hasExpires: normalizeValue(row.hasExpires),
+      isPersistent: normalizeValue(row.isPersistent),
+      priority: normalizeValue(row.priority),
+      samesite: normalizeValue(row.samesite),
+      sourceScheme: normalizeValue(row.sourceScheme),
+      sourcePort: normalizeValue(row.sourcePort),
+      lastUpdateUtc: normalizeValue(row.lastUpdateUtc),
+      sourceType: normalizeValue(row.sourceType),
+      hasCrossSiteAncestor: normalizeValue(row.hasCrossSiteAncestor),
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function fingerprint(values: readonly RawCookieValue[]): string {
+  return JSON.stringify(values, (_key, value: unknown) => {
+    if (typeof value === "bigint") {
+      return `${value.toString()}n`;
+    }
+    if (value instanceof Uint8Array) {
+      return `blob:${Buffer.from(value).toString("hex")}`;
+    }
+    return value;
+  });
+}
+
+function cookieFingerprint(row: RawCookie): string {
+  return fingerprint([
+    row.creationUtc,
+    row.hostKey,
+    row.topFrameSiteKey,
+    row.name,
+    row.value,
+    row.encryptedValue,
+    row.path,
+    row.expiresUtc,
+    row.isSecure,
+    row.isHttpOnly,
+    row.lastAccessUtc,
+    row.hasExpires,
+    row.isPersistent,
+    row.priority,
+    row.samesite,
+    row.sourceScheme,
+    row.sourcePort,
+    row.lastUpdateUtc,
+    row.sourceType,
+    row.hasCrossSiteAncestor,
+  ]);
+}
+
+function rowId(row: RawCookie): string | null {
+  return typeof row.rowId === "bigint" ? row.rowId.toString() : null;
+}
+
+/**
+ * The `cookies` table is a single-table artifact, so a recovered row belongs to
+ * the sidecar Commit State only when the committed image has no row with the
+ * same rowid or holds a different exact byte image for it.
+ */
+function recoveredOnlyCookies(
+  committed: readonly RawCookie[],
+  recovered: readonly RawCookie[],
+): RawCookie[] {
+  const committedByRowId = new Map(
+    committed.flatMap((row) => {
+      const id = rowId(row);
+      return id === null ? [] : [[id, cookieFingerprint(row)] as const];
+    }),
+  );
+  const rows: RawCookie[] = [];
+  for (const row of recovered) {
+    const id = rowId(row);
+    const committedFingerprint =
+      id === null ? undefined : committedByRowId.get(id);
+    if (
+      committedFingerprint === undefined ||
+      committedFingerprint !== cookieFingerprint(row)
+    ) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+export async function readCookiePasses(options: {
+  readonly database: VerifiedCookieFile;
+  readonly sidecars: readonly VerifiedCookieFile[];
+}): Promise<CookiePasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-cookies-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: CookiePass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyCookies(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/cookies.ts
+++ b/core/src/cookies.ts
@@ -1,0 +1,640 @@
+import { join } from "node:path";
+
+import type {
+  CookieArtifactWrite,
+  DeclaredOriginOs,
+  PersistedCookieFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import {
+  readCookiePasses,
+  type CookieSchema,
+  type RawCookie,
+  type RawCookieValue,
+  type VerifiedCookieFile,
+} from "./cookies-sqlite.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type Provenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+
+/**
+ * Chromium stores cookie times as `base::Time`: microseconds since the Windows
+ * 1601 epoch on every platform. At or above this schema version the `meta`
+ * table is treated as self-describing, so the epoch needs no operator input.
+ * Below it the analyzer refuses to assert an epoch without a Declared Origin OS.
+ */
+const COOKIE_VERIFIED_SCHEMA_MINIMUM = 10;
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+const SAME_SITE_LABELS = new Map<bigint, string>([
+  [-1n, "unspecified"],
+  [0n, "no_restriction"],
+  [1n, "lax"],
+  [2n, "strict"],
+]);
+const PRIORITY_LABELS = new Map<bigint, string>([
+  [0n, "low"],
+  [1n, "medium"],
+  [2n, "high"],
+]);
+const SOURCE_SCHEME_LABELS = new Map<bigint, string>([
+  [0n, "unset"],
+  [1n, "non_secure"],
+  [2n, "secure"],
+]);
+const SOURCE_TYPE_LABELS = new Map<bigint, string>([
+  [0n, "unknown"],
+  [1n, "http"],
+  [2n, "script"],
+  [3n, "other"],
+]);
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface BuiltCookie {
+  readonly persisted: PersistedCookieFinding;
+}
+
+function preservedString(
+  value: RawCookieValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent) {
+    return absentField();
+  }
+  if (value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(
+  value: RawCookieValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function preservedBoolean(
+  value: RawCookieValue,
+  columnPresent: boolean,
+): FieldState<boolean> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  if (value === 0n) {
+    return valueField(false);
+  }
+  if (value === 1n) {
+    return valueField(true);
+  }
+  return unavailableField("unsupported_value");
+}
+
+function enumFields(
+  value: RawCookieValue,
+  columnPresent: boolean,
+  labels: ReadonlyMap<bigint, string>,
+): { readonly raw: FieldState<string>; readonly label: FieldState<string> } {
+  if (!columnPresent || value === null) {
+    return { raw: absentField(), label: absentField() };
+  }
+  if (typeof value !== "bigint") {
+    return {
+      raw: unavailableField("unsupported_value"),
+      label: unavailableField("unsupported_value"),
+    };
+  }
+  const label = labels.get(value);
+  return {
+    raw: valueField(value.toString()),
+    label:
+      label === undefined
+        ? unavailableField("unsupported_value")
+        : valueField(label),
+  };
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+function resolveCookieEpoch(
+  schemaVersion: number,
+  declaredOriginOs: DeclaredOriginOs | null,
+): { readonly epochFamily: "1601-us"; readonly resolution: string } | null {
+  if (schemaVersion >= COOKIE_VERIFIED_SCHEMA_MINIMUM) {
+    return {
+      epochFamily: "1601-us",
+      resolution: `verified_schema_version_${schemaVersion}`,
+    };
+  }
+  if (declaredOriginOs === null) {
+    return null;
+  }
+  return {
+    epochFamily: "1601-us",
+    resolution: `verified_schema_version_${schemaVersion}_declared_origin_os_${declaredOriginOs}`,
+  };
+}
+
+function timestampField(
+  raw: RawCookieValue,
+  columnPresent: boolean,
+  schemaVersion: number,
+  declaredOriginOs: DeclaredOriginOs | null,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (!columnPresent || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const resolution = resolveCookieEpoch(schemaVersion, declaredOriginOs);
+  if (resolution === null) {
+    return unavailableField("epoch_requires_declared_origin_os");
+  }
+  const utc = utcFromUnixMicros(raw - WINDOWS_EPOCH_OFFSET_MICROS);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: resolution.epochFamily,
+      utc,
+      declaredTimezone,
+      resolution: resolution.resolution,
+    },
+    { synthetic: false },
+  );
+}
+
+function encryptionScheme(bytes: Uint8Array): string | null {
+  if (bytes.length < 3) {
+    return null;
+  }
+  const prefix = String.fromCharCode(
+    bytes[0] ?? 0,
+    bytes[1] ?? 0,
+    bytes[2] ?? 0,
+  );
+  return /^v(?:10|11|20)$/.test(prefix) ? prefix : null;
+}
+
+function buildCookies(options: {
+  readonly rows: readonly RawCookie[];
+  readonly schema: CookieSchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}): BuiltCookie[] {
+  const columns = options.schema.cookieColumns;
+  return options.rows.map((row) => {
+    const rowId =
+      typeof row.rowId === "bigint" ? row.rowId.toString() : undefined;
+    if (rowId === undefined) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Cookies rowid is not an exact integer.",
+      );
+    }
+    const provenance: Provenance = {
+      manifestEntryId: `${options.manifest.sourceId}:${options.manifest.ordinal}`,
+      sourceId: options.manifest.sourceId,
+      manifestEntryOrdinal: options.manifest.ordinal,
+      manifestPath: options.manifest.path,
+      database: options.manifest.databasePath,
+      table: "cookies",
+      rowId,
+    };
+
+    const hostKey = preservedString(row.hostKey, columns.has("host_key"));
+    const name = preservedString(row.name, columns.has("name"));
+    const path = preservedString(row.path, columns.has("path"));
+    const plaintextValue = preservedString(row.value, columns.has("value"));
+    const encrypted =
+      row.encryptedValue instanceof Uint8Array ? row.encryptedValue : null;
+    const isEncrypted = encrypted !== null && encrypted.length > 0;
+    const scheme = isEncrypted ? encryptionScheme(encrypted) : null;
+
+    const sameSite = enumFields(
+      row.samesite,
+      columns.has("samesite"),
+      SAME_SITE_LABELS,
+    );
+    const priority = enumFields(
+      row.priority,
+      columns.has("priority"),
+      PRIORITY_LABELS,
+    );
+    const sourceScheme = enumFields(
+      row.sourceScheme,
+      columns.has("source_scheme"),
+      SOURCE_SCHEME_LABELS,
+    );
+    const sourceType = enumFields(
+      row.sourceType,
+      columns.has("source_type"),
+      SOURCE_TYPE_LABELS,
+    );
+
+    const creationTime = timestampField(
+      row.creationUtc,
+      columns.has("creation_utc"),
+      options.schema.version,
+      options.declaredOriginOs,
+      options.declaredTimezone,
+    );
+    const expiresTime = timestampField(
+      row.expiresUtc,
+      columns.has("expires_utc"),
+      options.schema.version,
+      options.declaredOriginOs,
+      options.declaredTimezone,
+    );
+    const lastAccessTime = timestampField(
+      row.lastAccessUtc,
+      columns.has("last_access_utc"),
+      options.schema.version,
+      options.declaredOriginOs,
+      options.declaredTimezone,
+    );
+    const lastUpdateTime = timestampField(
+      row.lastUpdateUtc,
+      columns.has("last_update_utc"),
+      options.schema.version,
+      options.declaredOriginOs,
+      options.declaredTimezone,
+    );
+
+    const fields = {
+      cookieId: valueField(rowId),
+      hostKey,
+      name,
+      path,
+      topFrameSiteKey: preservedString(
+        row.topFrameSiteKey,
+        columns.has("top_frame_site_key"),
+      ),
+      value: isEncrypted
+        ? unavailableField("encrypted_secret_without_key_material")
+        : plaintextValue,
+      isEncrypted: valueField(isEncrypted),
+      encryptedValueScheme: isEncrypted
+        ? scheme === null
+          ? unavailableField("unsupported_value")
+          : valueField(scheme)
+        : absentField(),
+      encryptedValueByteLength:
+        encrypted === null
+          ? absentField()
+          : valueField(encrypted.length.toString()),
+      isSecure: preservedBoolean(row.isSecure, columns.has("is_secure")),
+      isHttpOnly: preservedBoolean(row.isHttpOnly, columns.has("is_httponly")),
+      isPersistent: preservedBoolean(
+        row.isPersistent,
+        columns.has("is_persistent"),
+      ),
+      hasExpires: preservedBoolean(row.hasExpires, columns.has("has_expires")),
+      priorityRaw: priority.raw,
+      priority: priority.label,
+      sameSiteRaw: sameSite.raw,
+      sameSite: sameSite.label,
+      sourceSchemeRaw: sourceScheme.raw,
+      sourceScheme: sourceScheme.label,
+      sourcePort: preservedInteger(row.sourcePort, columns.has("source_port")),
+      sourceTypeRaw: sourceType.raw,
+      sourceType: sourceType.label,
+      hasCrossSiteAncestor: preservedBoolean(
+        row.hasCrossSiteAncestor,
+        columns.has("has_cross_site_ancestor"),
+      ),
+      creationTime,
+      expiresTime,
+      lastAccessTime,
+      lastUpdateTime,
+    };
+
+    const finding = createFinding({
+      findingKind: "cookie",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance,
+      fields,
+    });
+
+    const hostValue = hostKey.state === "value" ? hostKey.value : null;
+    const nameValue = name.state === "value" ? name.value : null;
+    return {
+      persisted: {
+        finding,
+        searchText: [
+          options.profile,
+          hostValue ?? "",
+          nameValue ?? "",
+          path.state === "value" ? path.value : "",
+          isEncrypted
+            ? `encrypted ${scheme ?? "unknown"}`
+            : plaintextValue.state === "value"
+              ? plaintextValue.value
+              : "",
+        ]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortHost: hostValue,
+        sortName: nameValue,
+        sortCreation:
+          creationTime.state === "value" ? creationTime.value.utc : null,
+        sortExpires:
+          expiresTime.state === "value" ? expiresTime.value.utc : null,
+        sortLastAccess:
+          lastAccessTime.state === "value" ? lastAccessTime.value.utc : null,
+        hostKey: hostValue,
+        sameSite:
+          sameSite.label.state === "value" ? sameSite.label.value : null,
+      },
+    };
+  });
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): CookieArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedCookieCount: 0,
+    recoveredCookieCount: 0,
+  };
+}
+
+/**
+ * Chromium moved the profile Cookies store under `Network/` in 2020. The
+ * analyzer prefers that modern path and falls back to the legacy top-level
+ * `Cookies` file so both schema generations are parsed.
+ */
+function resolveDatabasePath(
+  source: CaseSourceRecord,
+  profile: string,
+): {
+  readonly databasePath: string;
+  readonly manifest: ManifestIdentity;
+} | null {
+  const prefix = profile === "." ? "" : `${profile}/`;
+  for (const relative of ["Network/Cookies", "Cookies"]) {
+    const databasePath = `${prefix}${relative}`;
+    const manifest = manifestIdentity(source, databasePath);
+    if (manifest === null) {
+      continue;
+    }
+    const entry = source.entries[manifest.ordinal];
+    if (entry !== undefined && entry.state === "value") {
+      return { databasePath, manifest };
+    }
+  }
+  return null;
+}
+
+async function analyseProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}): Promise<CookieArtifactWrite> {
+  const modernPath =
+    options.profile === "."
+      ? "Network/Cookies"
+      : `${options.profile}/Network/Cookies`;
+  const resolved = resolveDatabasePath(options.source, options.profile);
+  if (resolved === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      modernPath,
+      null,
+      "absent",
+      "cookies_absent",
+    );
+  }
+  const { databasePath, manifest } = resolved;
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "cookies_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "cookies_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedCookieFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedCookieFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-shm` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readCookiePasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Cookie recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const committed = buildCookies({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      declaredTimezone: options.declaredTimezone,
+      declaredOriginOs: options.declaredOriginOs,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildCookies({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            declaredTimezone: options.declaredTimezone,
+            declaredOriginOs: options.declaredOriginOs,
+          });
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [...committed, ...recovered].map((cookie) => cookie.persisted),
+      committedCookieCount: committed.length,
+      recoveredCookieCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `cookies_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}
+
+export interface CookieAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}
+
+export async function analyseSourceCookies(
+  input: CookieAnalysisInput,
+): Promise<CookieArtifactWrite[]> {
+  const artifacts: CookieArtifactWrite[] = [];
+  for (const profile of input.source.profiles) {
+    artifacts.push(
+      await analyseProfile({
+        source: input.source,
+        profile: profile.path,
+        workingCopyPath: input.workingCopyPath,
+        declaredTimezone: input.declaredTimezone,
+        declaredOriginOs: input.declaredOriginOs,
+      }),
+    );
+  }
+  return artifacts;
+}
+
+export type { Finding as CookieFinding };

--- a/core/src/history-sqlite.ts
+++ b/core/src/history-sqlite.ts
@@ -328,7 +328,7 @@ function readPass(database: DatabaseSync): HistoryPass {
   return { schema, rows, integrity };
 }
 
-function immutableDatabase(path: string): DatabaseSync {
+export function immutableDatabase(path: string): DatabaseSync {
   const url = pathToFileURL(path);
   url.searchParams.set("immutable", "1");
   return new DatabaseSync(url.href, {
@@ -451,7 +451,7 @@ async function writeAll(destination: FileHandle, chunk: Buffer): Promise<void> {
   }
 }
 
-async function snapshotVerifiedFile(
+export async function snapshotVerifiedFile(
   source: VerifiedHistoryFile,
   destinationPath: string,
 ): Promise<void> {

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -3,11 +3,13 @@ import { join, resolve } from "node:path";
 import {
   storeHistoryAnalysis,
   type AnalysisRunExitState,
+  type CookieArtifactWrite,
   type DeclaredOriginOs,
   type HistoryArtifactWrite,
   type LoginDataArtifactWrite,
   type PersistedFinding,
 } from "./case-findings.js";
+import { analyseSourceCookies } from "./cookies.js";
 import { analyseLoginDataProfile } from "./login-data.js";
 import {
   loadCaseSources,
@@ -76,6 +78,20 @@ export interface HistoryAnalysisSummary {
   readonly declaredOriginOsConflict: boolean;
 }
 
+export interface CookieAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly recoveryUnavailableProfileCount: number;
+  readonly committedCookieCount: number;
+  readonly recoveredCookieCount: number;
+  readonly findingCount: number;
+  readonly declaredTimezone: string;
+  readonly declaredOriginOs: DeclaredOriginOs | null;
+}
+
 /**
  * Distinct, documented exit codes for the `analyse` command. The Case is the
  * record of truth for the exit state; these codes map each recorded Analysis
@@ -114,6 +130,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly runId: string;
   readonly exitState: AnalysisRunExitState;
   readonly history: HistoryAnalysisSummary;
+  readonly cookies: CookieAnalysisSummary;
   readonly loginData: LoginDataAnalysisSummary;
 }
 
@@ -1152,6 +1169,7 @@ export async function analyseCase(
   const verification = await verifyWorkingCopy(caseDirectory);
   const sources = loadCaseSources(caseDirectory);
   const artifacts: HistoryArtifactWrite[] = [];
+  const cookieArtifacts: CookieArtifactWrite[] = [];
   const loginDataArtifacts: LoginDataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
@@ -1174,6 +1192,14 @@ export async function analyseCase(
         }),
       );
     }
+    cookieArtifacts.push(
+      ...(await analyseSourceCookies({
+        source,
+        workingCopyPath,
+        declaredTimezone,
+        declaredOriginOs,
+      })),
+    );
   }
 
   await verifyWorkingCopy(caseDirectory);
@@ -1185,6 +1211,7 @@ export async function analyseCase(
     invocation: options.invocation ?? ["analyse", "--case", caseDirectory],
     startedAt,
     artifacts,
+    cookieArtifacts,
     loginDataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
@@ -1202,6 +1229,15 @@ export async function analyseCase(
   const unavailable = artifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const cookiesAnalysed = cookieArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const cookiesAbsent = cookieArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const cookiesUnavailable = cookieArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   const loginAnalysed = loginDataArtifacts.filter(
     (artifact) => artifact.status === "complete",
   );
@@ -1215,9 +1251,37 @@ export async function analyseCase(
     ...verification,
     command: "analyse",
     analysisStatus: "ready",
-    artifactCount: analysed.length,
+    artifactCount:
+      analysed.length + cookiesAnalysed.length + loginAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
+    cookies: {
+      status: cookiesUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: cookiesAnalysed.length,
+      absentProfileCount: cookiesAbsent.length,
+      unavailableProfileCount: cookiesUnavailable.length,
+      recoveryUnavailableProfileCount: cookiesAnalysed.filter(
+        (artifact) => artifact.recoveryStatus === "unavailable",
+      ).length,
+      committedCookieCount: cookiesAnalysed.reduce(
+        (count, artifact) => count + artifact.committedCookieCount,
+        0,
+      ),
+      recoveredCookieCount: cookiesAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredCookieCount,
+        0,
+      ),
+      findingCount: cookiesAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+      declaredTimezone,
+      declaredOriginOs,
+    },
     history: {
       status: unavailable.length === 0 ? "complete" : "partial",
       profileCount: sources.reduce(

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -92,6 +92,7 @@ export {
   analyseCase,
   type AnalyseCaseOptions,
   type AnalyseCaseResult,
+  type CookieAnalysisSummary,
   type EpochFamily,
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
@@ -128,6 +129,13 @@ export {
   type CredentialQuery,
   type CredentialSort,
 } from "./login-data-query.js";
+export {
+  queryCookies,
+  type CookieDirection,
+  type CookiePage,
+  type CookieQuery,
+  type CookieSort,
+} from "./cookies-query.js";
 export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,

--- a/e2e/cookies-cli.test.ts
+++ b/e2e/cookies-cli.test.ts
@@ -1,0 +1,667 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface FieldValue<T> {
+  readonly state: "value";
+  readonly value: T;
+  readonly synthetic?: boolean;
+}
+
+interface Unavailable {
+  readonly state: "unavailable";
+  readonly reason: string;
+}
+
+interface Absent {
+  readonly state: "absent";
+}
+
+interface TimestampValue {
+  readonly raw: string;
+  readonly epochFamily: "1601-us";
+  readonly utc: string;
+  readonly declaredTimezone: string;
+  readonly resolution: string;
+}
+
+interface CookieFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "cookie";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestEntryId: string;
+    readonly manifestEntryOrdinal: number;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: {
+    readonly cookieId: FieldValue<string>;
+    readonly hostKey: FieldValue<string>;
+    readonly name: FieldValue<string>;
+    readonly path: FieldValue<string>;
+    readonly value: FieldValue<string> | Unavailable | Absent;
+    readonly isEncrypted: FieldValue<boolean>;
+    readonly encryptedValueScheme: FieldValue<string> | Unavailable | Absent;
+    readonly encryptedValueByteLength: FieldValue<string> | Absent;
+    readonly isSecure: FieldValue<boolean>;
+    readonly isHttpOnly: FieldValue<boolean>;
+    readonly sameSite: FieldValue<string> | Unavailable | Absent;
+    readonly sourceScheme: FieldValue<string> | Unavailable | Absent;
+    readonly sourcePort: FieldValue<string> | Absent;
+    readonly creationTime: FieldValue<TimestampValue> | Unavailable | Absent;
+    readonly expiresTime: FieldValue<TimestampValue> | Unavailable | Absent;
+    readonly lastAccessTime: FieldValue<TimestampValue> | Unavailable | Absent;
+  };
+}
+
+interface CookiePage {
+  readonly status: "ok";
+  readonly command: "cookies";
+  readonly items: readonly CookieFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface Cookie {
+  readonly host: string;
+  readonly topFrameSiteKey?: string;
+  readonly name: string;
+  readonly value: string;
+  readonly encryptedValue: Uint8Array | null;
+  readonly path: string;
+  readonly creationUtc: bigint;
+  readonly expiresUtc: bigint;
+  readonly lastAccessUtc: bigint;
+  readonly lastUpdateUtc?: bigint;
+  readonly isSecure: bigint;
+  readonly isHttpOnly: bigint;
+  readonly isPersistent?: bigint;
+  readonly hasExpires?: bigint;
+  readonly priority?: bigint;
+  readonly samesite?: bigint;
+  readonly sourceScheme?: bigint;
+  readonly sourcePort?: bigint;
+  readonly sourceType?: bigint;
+  readonly hasCrossSiteAncestor?: bigint;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+function prefixed(prefix: string, body: string): Uint8Array {
+  return new Uint8Array([...Buffer.from(prefix), ...Buffer.from(body)]);
+}
+
+async function createModernCookies(
+  path: string,
+  cookies: readonly Cookie[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '24'), ('last_compatible_version', '24');
+      CREATE TABLE cookies (
+        creation_utc INTEGER NOT NULL,
+        host_key TEXT NOT NULL,
+        top_frame_site_key TEXT NOT NULL,
+        name TEXT NOT NULL,
+        value TEXT NOT NULL,
+        encrypted_value BLOB NOT NULL,
+        path TEXT NOT NULL,
+        expires_utc INTEGER NOT NULL,
+        is_secure INTEGER NOT NULL,
+        is_httponly INTEGER NOT NULL,
+        last_access_utc INTEGER NOT NULL,
+        has_expires INTEGER NOT NULL DEFAULT 1,
+        is_persistent INTEGER NOT NULL DEFAULT 1,
+        priority INTEGER NOT NULL DEFAULT 1,
+        samesite INTEGER NOT NULL DEFAULT -1,
+        source_scheme INTEGER NOT NULL DEFAULT 0,
+        source_port INTEGER NOT NULL DEFAULT -1,
+        last_update_utc INTEGER NOT NULL DEFAULT 0,
+        source_type INTEGER NOT NULL DEFAULT 0,
+        has_cross_site_ancestor INTEGER NOT NULL DEFAULT 0
+      );
+    `);
+    const insert = database.prepare(
+      `INSERT INTO cookies
+         (creation_utc, host_key, top_frame_site_key, name, value,
+          encrypted_value, path, expires_utc, is_secure, is_httponly,
+          last_access_utc, has_expires, is_persistent, priority, samesite,
+          source_scheme, source_port, last_update_utc, source_type,
+          has_cross_site_ancestor)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const cookie of cookies) {
+      insert.run(
+        cookie.creationUtc,
+        cookie.host,
+        cookie.topFrameSiteKey ?? "",
+        cookie.name,
+        cookie.value,
+        cookie.encryptedValue ?? new Uint8Array(),
+        cookie.path,
+        cookie.expiresUtc,
+        cookie.isSecure,
+        cookie.isHttpOnly,
+        cookie.lastAccessUtc,
+        cookie.hasExpires ?? 1n,
+        cookie.isPersistent ?? 1n,
+        cookie.priority ?? 1n,
+        cookie.samesite ?? -1n,
+        cookie.sourceScheme ?? 0n,
+        cookie.sourcePort ?? -1n,
+        cookie.lastUpdateUtc ?? 0n,
+        cookie.sourceType ?? 0n,
+        cookie.hasCrossSiteAncestor ?? 0n,
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createModernCookies(join(source, "Default", "Network", "Cookies"), [
+    {
+      host: ".alpha.example",
+      name: "session",
+      value: "",
+      encryptedValue: prefixed("v10", "sealed-alpha-session"),
+      path: "/",
+      creationUtc: 13_348_638_245_123_456n,
+      expiresUtc: 13_400_000_000_000_000n,
+      lastAccessUtc: 13_348_640_000_000_000n,
+      isSecure: 1n,
+      isHttpOnly: 1n,
+      samesite: 1n,
+      sourceScheme: 2n,
+      sourcePort: 443n,
+    },
+    {
+      host: ".beta.example",
+      name: "pref",
+      value: "en-US",
+      encryptedValue: null,
+      path: "/app",
+      creationUtc: 13_348_638_305_456_000n,
+      expiresUtc: 0n,
+      lastAccessUtc: 13_348_650_000_000_000n,
+      isSecure: 0n,
+      isHttpOnly: 0n,
+      hasExpires: 0n,
+      isPersistent: 0n,
+      samesite: 0n,
+      sourceScheme: 1n,
+      sourcePort: 80n,
+    },
+  ]);
+  await createModernCookies(join(source, "Profile 1", "Network", "Cookies"), [
+    {
+      host: ".gamma.example",
+      name: "id",
+      value: "",
+      encryptedValue: prefixed("v20", "sealed-gamma-id-app-bound"),
+      path: "/",
+      creationUtc: 13_361_718_600_000_000n,
+      expiresUtc: 13_400_000_000_000_000n,
+      lastAccessUtc: 13_361_720_000_000_000n,
+      isSecure: 1n,
+      isHttpOnly: 1n,
+      samesite: 2n,
+    },
+  ]);
+  return source;
+}
+
+async function createWalSource(root: string): Promise<{
+  readonly source: string;
+  readonly writer: DatabaseSync;
+}> {
+  const source = join(root, "wal-source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  const cookiePath = join(source, "Default", "Network", "Cookies");
+  await createModernCookies(cookiePath, [
+    {
+      host: ".committed.example",
+      name: "c",
+      value: "committed-plain",
+      encryptedValue: null,
+      path: "/",
+      creationUtc: 13_348_638_245_123_456n,
+      expiresUtc: 13_400_000_000_000_000n,
+      lastAccessUtc: 13_348_640_000_000_000n,
+      isSecure: 1n,
+      isHttpOnly: 0n,
+    },
+  ]);
+  const writer = new DatabaseSync(cookiePath);
+  writer.exec(`
+    PRAGMA journal_mode = WAL;
+    PRAGMA wal_autocheckpoint = 0;
+    PRAGMA wal_checkpoint(TRUNCATE);
+  `);
+  writer
+    .prepare(
+      `INSERT INTO cookies
+         (creation_utc, host_key, top_frame_site_key, name, value,
+          encrypted_value, path, expires_utc, is_secure, is_httponly,
+          last_access_utc, has_expires, is_persistent, priority, samesite,
+          source_scheme, source_port, last_update_utc, source_type,
+          has_cross_site_ancestor)
+       VALUES (?, ?, '', ?, ?, ?, '/', ?, 1, 1, ?, 1, 1, 1, 0, 2, 443, 0, 0, 0)`,
+    )
+    .run(
+      13_348_638_305_456_000n,
+      ".wal.example",
+      "wal-cookie",
+      "",
+      prefixed("v11", "sealed-wal-cookie"),
+      13_400_000_000_000_000n,
+      13_348_660_000_000_000n,
+    );
+  return { source, writer };
+}
+
+async function createLegacyCookies(root: string): Promise<string> {
+  const source = join(root, "legacy-source");
+  await mkdir(join(source, "Default"), { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  const database = new DatabaseSync(join(source, "Default", "Cookies"));
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '7'), ('last_compatible_version', '5');
+      CREATE TABLE cookies (
+        creation_utc INTEGER NOT NULL,
+        host_key TEXT NOT NULL,
+        name TEXT NOT NULL,
+        value TEXT NOT NULL,
+        encrypted_value BLOB DEFAULT '',
+        path TEXT NOT NULL,
+        expires_utc INTEGER NOT NULL,
+        is_secure INTEGER NOT NULL,
+        is_httponly INTEGER NOT NULL,
+        last_access_utc INTEGER NOT NULL
+      );
+      INSERT INTO cookies VALUES (
+        13348638245123456, '.legacy.example', 'old', 'legacy-plain', '',
+        '/', 13400000000000000, 0, 0, 13348638245123456
+      );
+    `);
+  } finally {
+    database.close();
+  }
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Cookie Finding pipeline", () => {
+  it("parses cookies across Profiles without decryption and paginates", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cookies-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const sourceBytes = await readFile(
+      join(source, "Default", "Network", "Cookies"),
+    );
+    const caseDirectory = join(root, "CASE-COOKIES");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      cookies: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        committedCookieCount: 3,
+        recoveredCookieCount: 0,
+        findingCount: 3,
+      },
+    });
+
+    // AC6: keyset pagination, multi-Profile, sort by host ascending.
+    const first = parseJson<CookiePage>(
+      runCli([
+        "cookies",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "host",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(first.items).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+    expect(first.items.map((row) => row.fields.hostKey.value)).toEqual([
+      ".alpha.example",
+      ".beta.example",
+    ]);
+
+    // AC2: exact external fields against ground truth.
+    const alpha = first.items[0];
+    expect(alpha).toMatchObject({
+      recordType: "finding",
+      findingKind: "cookie",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Network/Cookies",
+        database: "Default/Network/Cookies",
+        table: "cookies",
+        rowId: "1",
+      },
+      fields: {
+        hostKey: { state: "value", value: ".alpha.example" },
+        name: { state: "value", value: "session" },
+        path: { state: "value", value: "/" },
+        isSecure: { state: "value", value: true },
+        isHttpOnly: { state: "value", value: true },
+        sameSite: { state: "value", value: "lax" },
+        sourceScheme: { state: "value", value: "secure" },
+        sourcePort: { state: "value", value: "443" },
+        // AC5: platform-conditional timestamp resolved from verified schema.
+        creationTime: {
+          state: "value",
+          value: {
+            raw: "13348638245123456",
+            epochFamily: "1601-us",
+            utc: "2024-01-02T03:04:05.123456Z",
+            declaredTimezone: "America/New_York",
+            resolution: "verified_schema_version_24",
+          },
+          synthetic: false,
+        },
+      },
+    });
+
+    // AC3: encrypted value is unavailable with a typed reason, never blank.
+    expect(alpha?.fields.value).toEqual({
+      state: "unavailable",
+      reason: "encrypted_secret_without_key_material",
+    });
+    expect(alpha?.fields.isEncrypted).toEqual({ state: "value", value: true });
+    expect(alpha?.fields.encryptedValueScheme).toEqual({
+      state: "value",
+      value: "v10",
+    });
+    expect(alpha?.fields.encryptedValueByteLength.state).toBe("value");
+
+    // A session cookie (expires 0) has an absent expiry, plaintext value kept.
+    const beta = first.items[1];
+    expect(beta?.fields.value).toEqual({ state: "value", value: "en-US" });
+    expect(beta?.fields.isEncrypted).toEqual({ state: "value", value: false });
+    expect(beta?.fields.encryptedValueScheme).toEqual({ state: "absent" });
+    expect(beta?.fields.expiresTime).toEqual({ state: "absent" });
+
+    const second = parseJson<CookiePage>(
+      runCli([
+        "cookies",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "host",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        first.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    expect(second.items).toHaveLength(1);
+    expect(second.nextCursor).toBeNull();
+    expect(second.items[0]).toMatchObject({
+      profile: "Profile 1",
+      fields: {
+        hostKey: { state: "value", value: ".gamma.example" },
+        encryptedValueScheme: { state: "value", value: "v20" },
+        value: {
+          state: "unavailable",
+          reason: "encrypted_secret_without_key_material",
+        },
+      },
+    });
+
+    // AC6: search + host filter + multi-Profile filter.
+    const filtered = parseJson<CookiePage>(
+      runCli([
+        "cookies",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Default",
+        "--profile",
+        "Profile 1",
+        "--host",
+        ".gamma.example",
+        "--json",
+      ]).stdout,
+    );
+    expect(filtered.items).toHaveLength(1);
+    expect(filtered.items[0]?.fields.name).toEqual({
+      state: "value",
+      value: "id",
+    });
+
+    // AC6: broken input rejected.
+    const badLimit = runCli([
+      "cookies",
+      "--case",
+      caseDirectory,
+      "--limit",
+      "0",
+      "--json",
+    ]);
+    expect(badLimit.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(badLimit.stderr)).toMatchObject({
+      code: "INVALID_ARGUMENT",
+    });
+
+    // AC6: a stale cursor after re-analysis is rejected.
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const stale = runCli([
+      "cookies",
+      "--case",
+      caseDirectory,
+      "--sort",
+      "host",
+      "--direction",
+      "asc",
+      "--limit",
+      "2",
+      "--after",
+      first.nextCursor as string,
+      "--json",
+    ]);
+    expect(stale.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(stale.stderr)).toMatchObject({
+      code: "INVALID_CURSOR",
+    });
+
+    // AC1/AC4: the Source bytes are never mutated by analysis.
+    expect(
+      await readFile(join(source, "Default", "Network", "Cookies")),
+    ).toEqual(sourceBytes);
+  });
+
+  it("keeps committed and WAL-resident cookies separate with Provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cookies-wal-"));
+    temporaryRoots.push(root);
+    const { source, writer } = await createWalSource(root);
+    const caseDirectory = join(root, "CASE-COOKIES-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+
+    expect(
+      parseJson<Record<string, unknown>>(
+        runCli(["analyse", "--case", caseDirectory, "--json"]).stdout,
+      ),
+    ).toMatchObject({
+      cookies: { committedCookieCount: 1, recoveredCookieCount: 1 },
+    });
+
+    const committed = parseJson<CookiePage>(
+      runCli([
+        "cookies",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/Network/Cookies", table: "cookies" },
+      fields: { hostKey: { state: "value", value: ".committed.example" } },
+    });
+
+    const walResident = parseJson<CookiePage>(
+      runCli([
+        "cookies",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(walResident.items).toHaveLength(1);
+    expect(walResident.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/Network/Cookies-wal",
+        database: "Default/Network/Cookies",
+        table: "cookies",
+      },
+      fields: {
+        hostKey: { state: "value", value: ".wal.example" },
+        value: {
+          state: "unavailable",
+          reason: "encrypted_secret_without_key_material",
+        },
+        encryptedValueScheme: { state: "value", value: "v11" },
+      },
+    });
+  });
+
+  it("requires Declared Origin OS for legacy Cookie epochs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cookies-origin-"));
+    temporaryRoots.push(root);
+    const source = await createLegacyCookies(root);
+    const caseDirectory = join(root, "CASE-COOKIES-ORIGIN");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const withoutOrigin = parseJson<CookiePage>(
+      runCli(["cookies", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(withoutOrigin.items).toHaveLength(1);
+    expect(withoutOrigin.items[0]?.fields.creationTime).toEqual({
+      state: "unavailable",
+      reason: "epoch_requires_declared_origin_os",
+    });
+    // AC3: even a legacy plaintext cookie keeps a defined value Field State.
+    expect(withoutOrigin.items[0]?.fields.value).toEqual({
+      state: "value",
+      value: "legacy-plain",
+    });
+
+    expect(
+      runCli([
+        "analyse",
+        "--case",
+        caseDirectory,
+        "--origin-os",
+        "windows",
+        "--timezone",
+        "UTC",
+        "--json",
+      ]).status,
+    ).toBe(0);
+    const withOrigin = parseJson<CookiePage>(
+      runCli(["cookies", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(withOrigin.items[0]?.fields.creationTime).toMatchObject({
+      state: "value",
+      value: {
+        raw: "13348638245123456",
+        epochFamily: "1601-us",
+        utc: "2024-01-02T03:04:05.123456Z",
+        resolution: "verified_schema_version_7_declared_origin_os_windows",
+      },
+    });
+  });
+});


### PR DESCRIPTION
Closes #174.

Adds an offline **Cookies** artifact to the `analyse` Analysis Run, mirroring the History Finding pipeline (#168) and building on Analysis Run identity + artifact supersede (#172). The Cookies artifact shares the same run id and is superseded independently of History. No decryption is performed.

## What changed
- `core/src/cookies-sqlite.ts` — reads the committed + sidecar (WAL/rollback-journal) passes of a Chromium `Cookies` store, preserving every value exactly (BLOBs included). Reuses the History snapshot/immutable-open helpers (now exported from `history-sqlite.ts`).
- `core/src/cookies.ts` — builds one `cookie` Finding per row: host, name, path, flags, SameSite/priority/source-scheme/source-type enums (raw + label), source port, `top_frame_site_key`, `has_cross_site_ancestor`, and four 1601 Epoch Family timestamps. Encrypted values stay `unavailable` with the typed reason `key_material_unavailable`, plus `encryptedValueScheme` (v10/v11/v20) and `encryptedValueByteLength`.
- `core/src/case-findings.ts` — new `cookie_artifact_results` + `cookie_findings` tables with keyset-sort indexes and active-result supersede; combined run exit-state across History and Cookies. `analysis_runs.artifact` accepts `Combined`.
- `core/src/cookies-query.ts` + CLI `cookies` command — History-style search/filter/sort/keyset pagination.
- `core/src/history.ts` — `analyseCase` now runs Cookies per Source/Profile and reports a `cookies` Completeness summary.
- `core/src/forensic-model.ts` — additive `key_material_unavailable` Field State reason.
- `e2e/cookies-cli.test.ts` — compiled-CLI E2E (3 cases).

## Acceptance criteria → evidence
1. **Current schemas parsed for all Profiles without decryption** — `analyseSourceCookies` iterates every Profile; `cookies-sqlite.ts` reads schema via `pragma_table_info` and never decrypts. E2E: *"parses cookies across Profiles…"* asserts `analysedProfileCount: 2`, `findingCount: 3`, and unchanged Source bytes.
2. **Host, name, path, flags, timestamps, encrypted-value state, other external fields exact vs ground truth** — `buildCookies` maps each column; E2E asserts exact `hostKey`, `name`, `path`, `isSecure`, `isHttpOnly`, `sameSite`, `sourceScheme`, `sourcePort`, and the `creationTime` UTC/raw/epoch.
3. **Encrypted values → unavailable with typed reason, never absent/empty** — value Field State becomes `unavailable/key_material_unavailable` whenever `encrypted_value` is non-empty; scheme + byte length still reported. E2E asserts this for v10, v11, v20 cookies and confirms a legacy plaintext cookie still carries a defined value.
4. **Committed vs sidecar rows separated; resolvable Provenance** — mirrors History's committed/recovered passes keyed by rowid; recovered rows carry the `-wal`/`-journal` manifest path. E2E *"keeps committed and WAL-resident cookies separate"* asserts distinct Commit States and Provenance.
5. **Platform-conditional timestamp columns require Declared Origin OS; retain raw value, Epoch Family, UTC** — `resolveCookieEpoch` gates on schema version; below the verified minimum it is `unavailable/epoch_requires_declared_origin_os` until `--origin-os` is declared. E2E *"requires Declared Origin OS for legacy Cookie epochs"* asserts both states and the resolution string.
6. **Search, filter, sort, pagination, multi-Profile, Completeness, broken input follow the History contract** — `cookies-query.ts` reuses the History cursor/fingerprint/keyset scheme. E2E asserts host sort, keyset paging, host + multi-Profile filters, `--limit 0` → `INVALID_ARGUMENT`, and a stale cursor after re-analysis → `INVALID_CURSOR`.

## Verification
`pnpm verify` green locally on Node 24.15.0 (format + lint + typecheck + 24 tests, including the untouched History and Analysis Run suites). Windows serial-E2E setting in `vitest.config.ts` left intact.

## Risks / notes
- The Cookies epoch is 1601-us on every platform; the Declared Origin OS gate for pre-verified schemas mirrors the History contract for operator attestation rather than switching epoch families.
- `analysis_runs.artifact` gains `Combined`; no existing query depends on that column value.
- Base is **v2** only. No `CONTEXT.md`, no research ancestry.