### PR TITLE
Serve a read-only local Case dashboard (#171)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -10,7 +10,8 @@
     "node": ">=24.15.0"
   },
   "dependencies": {
-    "@forensix/core": "workspace:*"
+    "@forensix/core": "workspace:*",
+    "@forensix/server": "workspace:*"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -27,6 +27,7 @@ import {
   type IngestResult,
   type SourceKind,
 } from "@forensix/core";
+import { startDashboardServer } from "@forensix/server";
 
 const USAGE = `Usage:
   forensix ingest <source> --case <case-directory> [--source-kind <kind>] [--include-tier-2] [--json]
@@ -51,6 +52,7 @@ const USAGE = `Usage:
                    [--sort <created-time|last-used-time|origin|username|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
+  forensix serve --case <case-directory> [--port <port>] [--json]
   forensix export --case <case-directory> --out <output-directory>
                    [--collection <findings|candidates>]... [--profile <profile>]...
                    [--commit-state <committed|wal_resident|journal_resident>]
@@ -85,6 +87,7 @@ const FLAG_OPTIONS = new Set([
 ]);
 const VALUE_OPTIONS = new Set([
   "--case",
+  "--port",
   "--source-kind",
   "--timezone",
   "--origin-os",
@@ -604,6 +607,52 @@ async function run(arguments_: readonly string[]): Promise<number> {
     }
     const result = await renderReport({ extractDirectory, outputPath });
     process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "serve") {
+    assertAllowedOptions(parsed, new Set(["--case", "--json", "--port"]));
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The serve command accepts no positional values.",
+      );
+    }
+    const port = integerOption(parsed, "--port");
+    if (port !== undefined && (port < 0 || port > 65535)) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "Option --port must be between 0 and 65535.",
+        { port },
+      );
+    }
+    const server = await startDashboardServer({
+      caseDirectory: requiredCasePath(parsed),
+      port,
+    });
+    const announcement = {
+      status: "ok",
+      command: "serve",
+      url: server.url,
+      host: server.host,
+      port: server.port,
+      token: server.token,
+    };
+    process.stdout.write(`${JSON.stringify(announcement)}\n`);
+    if (!jsonOutput) {
+      process.stderr.write(
+        `ForensiX read-only dashboard on ${server.url} (loopback only). ` +
+          `Press Ctrl+C to stop.\n`,
+      );
+    }
+    const stop = (): void => {
+      void server.close().then(() => {
+        process.exit(0);
+      });
+    };
+    process.once("SIGINT", stop);
+    process.once("SIGTERM", stop);
+    // The listening loopback socket keeps the process alive until stopped.
     return 0;
   }
 

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -7,5 +7,5 @@
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "include": ["src/**/*.ts"],
-  "references": [{ "path": "../core" }]
+  "references": [{ "path": "../core" }, { "path": "../server" }]
 }

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,10 @@
   "version": "2.0.0-alpha.1",
   "private": true,
   "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": "./dist/index.js"
+  },
   "engines": {
     "node": ">=24.15.0"
   },

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,2 +1,745 @@
-/** The read-only React dashboard is implemented by issue #171. */
+/**
+ * Read-only Case dashboard (issue #171), browser entry point.
+ *
+ * This client contains no forensic logic and performs no Case writes. It only
+ * renders what the read-only loopback API returns from the analyzer core. It
+ * offers no control that could start or rerun ingest, analysis, or export.
+ *
+ * Presentation rules enforced here:
+ *  - the Completeness Statement is rendered before any row;
+ *  - TYPE is always the first column;
+ *  - value / empty / absent / unavailable are shown as distinct words, never by
+ *    color alone;
+ *  - Candidates are never shown as factual summary tiles.
+ */
+
 export const CLIENT_IMPLEMENTATION_ISSUE = 171;
+
+declare global {
+  interface Window {
+    __FORENSIX_TOKEN__?: string;
+  }
+}
+
+type CommitState = "committed" | "wal_resident" | "journal_resident";
+
+type FieldState =
+  | {
+      readonly state: "value";
+      readonly value: unknown;
+      readonly synthetic?: boolean;
+    }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface Finding {
+  readonly recordType: "finding";
+  readonly findingKind: string;
+  readonly profile: string;
+  readonly commitState: CommitState;
+  readonly provenance: {
+    readonly manifestPath?: string;
+    readonly table?: string;
+    readonly rowId?: string;
+  };
+  readonly fields: Readonly<Record<string, FieldState>>;
+}
+
+interface Page {
+  readonly status: "ok";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CompletenessArtifact {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly artifact: string;
+  readonly databasePath: string;
+  readonly outcome: "produced" | "absent" | "unavailable";
+  readonly reason: string | null;
+  readonly runId: string;
+}
+
+interface CompletenessStatement {
+  readonly artifact: string;
+  readonly attempted: number;
+  readonly produced: number;
+  readonly absent: number;
+  readonly unavailable: number;
+  readonly artifacts: readonly CompletenessArtifact[];
+}
+
+interface CaseCompleteness {
+  readonly statements: readonly CompletenessStatement[];
+}
+
+interface CaseProfiles {
+  readonly profiles: readonly string[];
+}
+
+interface ExtraFilter {
+  readonly parameter: string;
+  readonly label: string;
+}
+
+interface ArtifactConfig {
+  readonly key: string;
+  readonly label: string;
+  readonly route: string;
+  readonly completenessArtifact: string;
+  readonly sorts: readonly string[];
+  readonly extras: readonly ExtraFilter[];
+}
+
+const TOKEN = window.__FORENSIX_TOKEN__ ?? "";
+
+const SIDECAR_STATES: readonly CommitState[] = [
+  "wal_resident",
+  "journal_resident",
+];
+
+const COMMIT_LABELS: Readonly<Record<CommitState, string>> = {
+  committed: "committed",
+  wal_resident: "sidecar — WAL-resident",
+  journal_resident: "sidecar — rollback-journal-resident",
+};
+
+const ARTIFACTS: readonly ArtifactConfig[] = [
+  {
+    key: "history",
+    label: "History",
+    route: "history",
+    completenessArtifact: "History",
+    sorts: ["visit-time", "url", "duration", "profile"],
+    extras: [
+      {
+        parameter: "view",
+        label: "View (visits/activity/most-visited/durations)",
+      },
+      { parameter: "transition", label: "Transition" },
+      { parameter: "from", label: "From (ISO instant)" },
+      { parameter: "to", label: "To (ISO instant)" },
+    ],
+  },
+  {
+    key: "cookies",
+    label: "Cookies",
+    route: "cookies",
+    completenessArtifact: "Cookies",
+    sorts: [
+      "host",
+      "name",
+      "creation-time",
+      "expires-time",
+      "last-access-time",
+      "profile",
+    ],
+    extras: [
+      { parameter: "host", label: "Host key" },
+      { parameter: "same-site", label: "SameSite" },
+    ],
+  },
+  {
+    key: "credentials",
+    label: "Credentials",
+    route: "credentials",
+    completenessArtifact: "Login Data",
+    sorts: ["created-time", "last-used-time", "origin", "username", "profile"],
+    extras: [],
+  },
+];
+
+function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  properties: Partial<
+    Record<"className" | "textContent" | "type" | "value" | "title", string>
+  > = {},
+  children: readonly (Node | string)[] = [],
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (properties.className !== undefined) {
+    node.className = properties.className;
+  }
+  if (properties.textContent !== undefined) {
+    node.textContent = properties.textContent;
+  }
+  if (properties.title !== undefined) {
+    node.title = properties.title;
+  }
+  if (node instanceof HTMLInputElement) {
+    if (properties.type !== undefined) {
+      node.type = properties.type;
+    }
+    if (properties.value !== undefined) {
+      node.value = properties.value;
+    }
+  }
+  for (const child of children) {
+    node.append(child);
+  }
+  return node;
+}
+
+async function callApi<T>(
+  route: string,
+  parameters: readonly (readonly [string, string])[],
+): Promise<T> {
+  const query = new URLSearchParams();
+  for (const [name, value] of parameters) {
+    if (value.length > 0) {
+      query.append(name, value);
+    }
+  }
+  const response = await fetch(`/api/${route}?${query.toString()}`, {
+    method: "GET",
+    cache: "no-store",
+    headers: { "x-forensix-token": TOKEN },
+  });
+  const body: unknown = await response.json();
+  if (!response.ok) {
+    const message =
+      typeof body === "object" && body !== null && "message" in body
+        ? String((body as { message: unknown }).message)
+        : `Request failed (${String(response.status)})`;
+    throw new Error(message);
+  }
+  return body as T;
+}
+
+function renderFieldCell(field: FieldState): HTMLTableCellElement {
+  const cell = el("td");
+  if (field.state === "absent") {
+    cell.append(
+      el("span", { className: "mark mark-absent", textContent: "absent" }),
+    );
+    return cell;
+  }
+  if (field.state === "unavailable") {
+    cell.append(
+      el("span", {
+        className: "mark mark-unavailable",
+        textContent: `unavailable — ${field.reason}`,
+      }),
+    );
+    return cell;
+  }
+  const value = field.value;
+  if (value === "") {
+    cell.append(
+      el("span", { className: "mark mark-empty", textContent: "(empty)" }),
+    );
+    return cell;
+  }
+  let text: string;
+  if (value === null) {
+    text = "null";
+  } else if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    text = typeof record.utc === "string" ? record.utc : JSON.stringify(value);
+  } else {
+    text = String(value);
+  }
+  cell.append(el("span", { className: "mark mark-value", textContent: text }));
+  return cell;
+}
+
+function collectColumns(rows: readonly Finding[]): readonly string[] {
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.fields)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+  return columns;
+}
+
+function renderRowsTable(rows: readonly Finding[]): HTMLElement {
+  if (rows.length === 0) {
+    return el("p", {
+      className: "muted",
+      textContent: "No rows for this filter.",
+    });
+  }
+  const columns = collectColumns(rows);
+  const table = el("table", { className: "rows" });
+  const head = el("tr");
+  // TYPE is always the first column.
+  head.append(el("th", { className: "col-type", textContent: "TYPE" }));
+  head.append(el("th", { textContent: "PROFILE" }));
+  head.append(el("th", { textContent: "COMMIT STATE" }));
+  head.append(el("th", { textContent: "SOURCE ROW" }));
+  for (const column of columns) {
+    head.append(el("th", { textContent: column }));
+  }
+  const thead = el("thead", {}, [head]);
+  const tbody = el("tbody");
+  for (const row of rows) {
+    const tr = el("tr");
+    tr.append(
+      el("td", { className: "col-type", textContent: row.findingKind }),
+    );
+    tr.append(el("td", { textContent: row.profile }));
+    tr.append(
+      el("td", {
+        className: "mark mark-commit",
+        textContent: COMMIT_LABELS[row.commitState],
+      }),
+    );
+    const source = [
+      row.provenance.manifestPath ?? "",
+      row.provenance.table ?? "",
+      row.provenance.rowId ?? "",
+    ]
+      .filter((part) => part.length > 0)
+      .join(" · ");
+    tr.append(el("td", { className: "muted", textContent: source }));
+    for (const column of columns) {
+      const field = row.fields[column];
+      tr.append(
+        field === undefined
+          ? el("td", {}, [
+              el("span", {
+                className: "mark mark-absent",
+                textContent: "absent",
+              }),
+            ])
+          : renderFieldCell(field),
+      );
+    }
+    tbody.append(tr);
+  }
+  table.append(thead, tbody);
+  return table;
+}
+
+interface ListParameters {
+  readonly config: ArtifactConfig;
+  readonly commitStates: readonly CommitState[];
+  readonly base: readonly (readonly [string, string])[];
+  readonly heading: string;
+}
+
+/**
+ * One keyset-paginated, single-commit-state list. Committed and sidecar rows
+ * live in separate lists, so each list pins exactly one Commit State.
+ */
+function createList(parameters: ListParameters): HTMLElement {
+  const section = el("section", { className: "list" });
+  section.append(el("h4", { textContent: parameters.heading }));
+  const controls = el("div", { className: "list-controls" });
+  const commitSelect = el("select");
+  for (const state of parameters.commitStates) {
+    const option = document.createElement("option");
+    option.value = state;
+    option.textContent = COMMIT_LABELS[state];
+    commitSelect.append(option);
+  }
+  if (parameters.commitStates.length > 1) {
+    const label = el("label", {
+      className: "inline",
+      textContent: "Commit State ",
+    });
+    label.append(commitSelect);
+    controls.append(label);
+  }
+  const status = el("div", { className: "list-status", textContent: "" });
+  const body = el("div", { className: "list-body" });
+  const moreButton = el("button", { textContent: "Load more" });
+  moreButton.type = "button";
+  moreButton.style.display = "none";
+  section.append(controls, status, body, moreButton);
+
+  let cursor: string | null = null;
+  let accumulated: Finding[] = [];
+
+  const load = async (reset: boolean): Promise<void> => {
+    if (reset) {
+      cursor = null;
+      accumulated = [];
+    }
+    const commitState = commitSelect.value;
+    const request: (readonly [string, string])[] = [
+      ...parameters.base,
+      ["commit-state", commitState],
+    ];
+    if (cursor !== null) {
+      request.push(["after", cursor]);
+    }
+    status.textContent = "Loading…";
+    try {
+      const page = await callApi<Page>(parameters.config.route, request);
+      accumulated = [...accumulated, ...page.items];
+      cursor = page.nextCursor;
+      body.replaceChildren(renderRowsTable(accumulated));
+      status.textContent = `${String(accumulated.length)} row(s) shown${
+        cursor === null ? "" : "; more available"
+      }.`;
+      moreButton.style.display = cursor === null ? "none" : "inline-block";
+    } catch (error) {
+      status.textContent =
+        error instanceof Error ? `Error: ${error.message}` : "Request failed.";
+      moreButton.style.display = "none";
+    }
+  };
+
+  moreButton.addEventListener("click", () => {
+    void load(false);
+  });
+  commitSelect.addEventListener("change", () => {
+    void load(true);
+  });
+  void load(true);
+  return section;
+}
+
+function renderCompleteness(
+  statement: CompletenessStatement | undefined,
+): HTMLElement {
+  const panel = el("section", { className: "completeness" });
+  panel.append(el("h4", { textContent: "Completeness Statement" }));
+  if (statement === undefined || statement.attempted === 0) {
+    panel.append(
+      el("p", {
+        className: "muted",
+        textContent: "No analyzed artifacts for this Case yet.",
+      }),
+    );
+    return panel;
+  }
+  const summary = el("p", {
+    className: "completeness-summary",
+    textContent:
+      `Attempted ${String(statement.attempted)} · ` +
+      `produced ${String(statement.produced)} · ` +
+      `absent ${String(statement.absent)} · ` +
+      `unavailable ${String(statement.unavailable)}`,
+  });
+  panel.append(summary);
+  const table = el("table", { className: "rows" });
+  const head = el("tr");
+  for (const column of [
+    "OUTCOME",
+    "SOURCE",
+    "PROFILE",
+    "DATABASE",
+    "REASON",
+    "RUN",
+  ]) {
+    head.append(el("th", { textContent: column }));
+  }
+  const tbody = el("tbody");
+  for (const artifact of statement.artifacts) {
+    const tr = el("tr");
+    tr.append(
+      el("td", {
+        className: `mark mark-outcome-${artifact.outcome}`,
+        textContent: artifact.outcome,
+      }),
+    );
+    tr.append(el("td", { textContent: artifact.sourceId }));
+    tr.append(el("td", { textContent: artifact.profile }));
+    tr.append(
+      el("td", { className: "muted", textContent: artifact.databasePath }),
+    );
+    tr.append(el("td", { textContent: artifact.reason ?? "—" }));
+    tr.append(el("td", { className: "muted", textContent: artifact.runId }));
+    tbody.append(tr);
+  }
+  table.append(el("thead", {}, [head]), tbody);
+  panel.append(table);
+  return panel;
+}
+
+function collectFilters(
+  config: ArtifactConfig,
+  profiles: readonly string[],
+): {
+  readonly element: HTMLElement;
+  read(): { readonly base: readonly (readonly [string, string])[] };
+  onApply(handler: () => void): void;
+} {
+  const bar = el("div", { className: "filters" });
+
+  const search = el("input", { type: "search", value: "" });
+  const searchLabel = el("label", {
+    className: "inline",
+    textContent: "Search ",
+  });
+  searchLabel.append(search);
+
+  const sortSelect = el("select");
+  for (const sort of config.sorts) {
+    const option = document.createElement("option");
+    option.value = sort;
+    option.textContent = sort;
+    sortSelect.append(option);
+  }
+  const sortLabel = el("label", { className: "inline", textContent: "Sort " });
+  sortLabel.append(sortSelect);
+
+  const directionSelect = el("select");
+  for (const direction of ["desc", "asc"]) {
+    const option = document.createElement("option");
+    option.value = direction;
+    option.textContent = direction;
+    directionSelect.append(option);
+  }
+  const directionLabel = el("label", {
+    className: "inline",
+    textContent: "Direction ",
+  });
+  directionLabel.append(directionSelect);
+
+  const limit = el("input", { type: "number", value: "25" });
+  limit.min = "1";
+  limit.max = "100";
+  const limitLabel = el("label", {
+    className: "inline",
+    textContent: "Limit ",
+  });
+  limitLabel.append(limit);
+
+  bar.append(searchLabel, sortLabel, directionLabel, limitLabel);
+
+  const extraInputs = new Map<string, HTMLInputElement>();
+  for (const extra of config.extras) {
+    const input = el("input", { type: "text", value: "" });
+    const label = el("label", {
+      className: "inline",
+      textContent: `${extra.label} `,
+    });
+    label.append(input);
+    extraInputs.set(extra.parameter, input);
+    bar.append(label);
+  }
+
+  const profileBox = el("fieldset", { className: "profiles" });
+  profileBox.append(el("legend", { textContent: "Profiles (multi-select)" }));
+  const profileInputs = new Map<string, HTMLInputElement>();
+  if (profiles.length === 0) {
+    profileBox.append(
+      el("span", { className: "muted", textContent: "No Profiles." }),
+    );
+  }
+  for (const profile of profiles) {
+    const checkbox = el("input", { type: "checkbox", value: profile });
+    profileInputs.set(profile, checkbox);
+    const label = el("label", { className: "inline" }, [
+      checkbox,
+      ` ${profile}`,
+    ]);
+    profileBox.append(label);
+  }
+  bar.append(profileBox);
+
+  const apply = el("button", { textContent: "Apply filters" });
+  apply.type = "button";
+  bar.append(apply);
+
+  return {
+    element: bar,
+    read() {
+      const base: (readonly [string, string])[] = [
+        ["search", search.value.trim()],
+        ["sort", sortSelect.value],
+        ["direction", directionSelect.value],
+        ["limit", limit.value.trim()],
+      ];
+      for (const [parameter, input] of extraInputs) {
+        base.push([parameter, input.value.trim()]);
+      }
+      for (const [profile, checkbox] of profileInputs) {
+        if (checkbox.checked) {
+          base.push(["profile", profile]);
+        }
+      }
+      return { base };
+    },
+    onApply(handler: () => void) {
+      apply.addEventListener("click", handler);
+    },
+  };
+}
+
+async function renderArtifactTab(
+  config: ArtifactConfig,
+  container: HTMLElement,
+): Promise<void> {
+  container.replaceChildren(el("p", { textContent: "Loading…" }));
+  let completeness: CaseCompleteness;
+  let profiles: CaseProfiles;
+  try {
+    [completeness, profiles] = await Promise.all([
+      callApi<CaseCompleteness>("completeness", []),
+      callApi<CaseProfiles>("profiles", []),
+    ]);
+  } catch (error) {
+    container.replaceChildren(
+      el("p", {
+        className: "mark mark-unavailable",
+        textContent:
+          error instanceof Error
+            ? `Error: ${error.message}`
+            : "Request failed.",
+      }),
+    );
+    return;
+  }
+
+  const statement = completeness.statements.find(
+    (entry) => entry.artifact === config.completenessArtifact,
+  );
+
+  const filters = collectFilters(config, profiles.profiles);
+  const listsHost = el("div", { className: "lists" });
+
+  const draw = (): void => {
+    const { base } = filters.read();
+    listsHost.replaceChildren(
+      createList({
+        config,
+        commitStates: ["committed"],
+        base,
+        heading: "Committed rows",
+      }),
+      createList({
+        config,
+        commitStates: SIDECAR_STATES,
+        base,
+        heading: "Sidecar rows (WAL / rollback-journal)",
+      }),
+    );
+  };
+  filters.onApply(draw);
+
+  container.replaceChildren();
+  // Completeness always renders before any row.
+  container.append(renderCompleteness(statement));
+  container.append(filters.element);
+  container.append(listsHost);
+  draw();
+}
+
+function renderLegend(): HTMLElement {
+  const legend = el("section", { className: "legend" });
+  legend.append(el("h4", { textContent: "How to read values" }));
+  const list = el("ul");
+  const entries: readonly [string, string][] = [
+    ["value", "a recorded value"],
+    ["(empty)", "a present but empty value"],
+    ["absent", "the field does not exist for this row"],
+    [
+      "unavailable — reason",
+      "the value could not be established, with a typed reason",
+    ],
+  ];
+  for (const [term, meaning] of entries) {
+    list.append(
+      el("li", {}, [
+        el("span", { className: "mark", textContent: term }),
+        ` — ${meaning}`,
+      ]),
+    );
+  }
+  legend.append(list);
+  return legend;
+}
+
+function styles(): string {
+  return `
+    :root { color-scheme: light dark; }
+    * { box-sizing: border-box; }
+    body { font: 14px/1.5 system-ui, sans-serif; margin: 0; }
+    header { padding: 12px 16px; border-bottom: 2px solid currentColor; }
+    header .banner { font-weight: 700; }
+    header .readonly { font-weight: 600; }
+    nav { display: flex; gap: 8px; padding: 8px 16px; flex-wrap: wrap; }
+    nav button { padding: 6px 12px; cursor: pointer; }
+    nav button[aria-current="true"] { text-decoration: underline; font-weight: 700; }
+    main { padding: 0 16px 32px; }
+    .filters { display: flex; flex-wrap: wrap; gap: 12px; align-items: flex-end; margin: 12px 0; }
+    label.inline { display: inline-flex; align-items: center; gap: 4px; }
+    fieldset.profiles { display: flex; flex-wrap: wrap; gap: 10px; max-width: 100%; }
+    table.rows { border-collapse: collapse; width: 100%; margin: 8px 0; font-size: 13px; }
+    table.rows th, table.rows td { border: 1px solid #8888; padding: 4px 8px; text-align: left; vertical-align: top; }
+    .col-type { font-weight: 700; }
+    .muted { opacity: 0.7; }
+    .mark { font-variant: small-caps; }
+    .mark-empty { font-style: italic; text-decoration: underline dotted; }
+    .mark-absent { font-style: italic; }
+    .mark-unavailable { font-weight: 700; text-decoration: underline; }
+    .mark-outcome-produced { font-weight: 700; }
+    .mark-outcome-absent { font-style: italic; }
+    .mark-outcome-unavailable { font-weight: 700; text-decoration: underline; }
+    .mark-commit { font-variant: small-caps; }
+    section.completeness, section.legend { border: 1px solid #8888; padding: 8px 12px; margin: 12px 0; }
+    section.list { margin: 16px 0; }
+    .list-status { margin: 4px 0; }
+    button { cursor: pointer; }
+  `;
+}
+
+function main(): void {
+  const root = document.getElementById("app");
+  if (root === null) {
+    return;
+  }
+  const styleTag = document.createElement("style");
+  styleTag.textContent = styles();
+  document.head.append(styleTag);
+
+  const header = el("header");
+  header.append(
+    el("div", {
+      className: "banner",
+      textContent: "ForensiX — read-only Case dashboard",
+    }),
+  );
+  header.append(
+    el("div", {
+      className: "readonly",
+      textContent:
+        "Read-only surface. It cannot start or rerun ingest, analysis, or export.",
+    }),
+  );
+
+  const nav = el("nav");
+  const main = el("main");
+  const buttons = new Map<string, HTMLButtonElement>();
+
+  const select = (config: ArtifactConfig): void => {
+    for (const [key, button] of buttons) {
+      button.setAttribute(
+        "aria-current",
+        key === config.key ? "true" : "false",
+      );
+    }
+    void renderArtifactTab(config, main);
+  };
+
+  for (const config of ARTIFACTS) {
+    const button = el("button", { textContent: config.label });
+    button.type = "button";
+    button.addEventListener("click", () => {
+      select(config);
+    });
+    buttons.set(config.key, button);
+    nav.append(button);
+  }
+
+  root.replaceChildren(header, nav, renderLegend(), main);
+  const first = ARTIFACTS[0];
+  if (first !== undefined) {
+    select(first);
+  }
+}
+
+main();
+
+export {};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,6 +4,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "composite": true,
+    "lib": ["ES2024", "DOM", "DOM.Iterable"],
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
   "include": ["src/**/*.ts"]

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -61,6 +61,7 @@ interface ArtifactResultRow {
   readonly run_id: string;
   readonly artifact_result_id: bigint | number;
   readonly started_at: string;
+  readonly active: bigint | number;
 }
 
 interface ArtifactTable {
@@ -102,9 +103,12 @@ function readCaseId(database: DatabaseSync): string {
 
 /**
  * Reduce the retained artifact-result lineage to the current outcome per
- * (Source, Profile) by keeping the most recent Analysis Run. This is exactly
- * what a reader must see before any result row: supersede keeps every earlier
- * row, so the newest run is the active outcome.
+ * (Source, Profile). Supersede keeps every earlier row, so the current outcome
+ * is the active result when one exists (a superseding rerun that ended
+ * unavailable supersedes nothing, so the active complete row stays current);
+ * otherwise it is the most recent attempt, which surfaces absent or
+ * unavailable. This is the same notion of "current" the list queries use
+ * (`WHERE active = 1`), so Completeness always matches the rows shown.
  */
 function buildStatement(
   database: DatabaseSync,
@@ -126,26 +130,38 @@ function buildStatement(
   const rows = database
     .prepare(
       `SELECT r.source_id, r.profile_path, r.database_path, r.status,
-              r.reason, r.run_id, r.artifact_result_id, a.started_at
+              r.reason, r.run_id, r.artifact_result_id, r.active, a.started_at
          FROM ${table.resultsTable} r
          JOIN analysis_runs a ON a.run_id = r.run_id
         ORDER BY r.source_id, r.profile_path`,
     )
     .all() as unknown as ArtifactResultRow[];
-  const latest = new Map<string, ArtifactResultRow>();
+  const current = new Map<string, ArtifactResultRow>();
   for (const row of rows) {
     const key = `${row.source_id}\u0000${row.profile_path}`;
-    const current = latest.get(key);
+    const chosen = current.get(key);
+    if (chosen === undefined) {
+      current.set(key, row);
+      continue;
+    }
+    // An active result is always current; it is never superseded by a later
+    // rerun that failed to produce. Between two non-active rows, keep the most
+    // recent attempt.
+    const rowActive = BigInt(row.active) === 1n;
+    const chosenActive = BigInt(chosen.active) === 1n;
+    if (chosenActive) {
+      continue;
+    }
     if (
-      current === undefined ||
-      row.started_at > current.started_at ||
-      (row.started_at === current.started_at &&
-        BigInt(row.artifact_result_id) > BigInt(current.artifact_result_id))
+      rowActive ||
+      row.started_at > chosen.started_at ||
+      (row.started_at === chosen.started_at &&
+        BigInt(row.artifact_result_id) > BigInt(chosen.artifact_result_id))
     ) {
-      latest.set(key, row);
+      current.set(key, row);
     }
   }
-  const artifacts = [...latest.values()]
+  const artifacts = [...current.values()]
     .map((row): CompletenessArtifact => {
       const outcome: CompletenessOutcome =
         row.status === "complete"

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -1,0 +1,240 @@
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+
+/**
+ * Read-only Case overview surface. It powers the loopback dashboard's
+ * Completeness Statements and Profile filters. It interprets no artifact rows
+ * and writes nothing: every function opens the Case immutable and read-only,
+ * mirroring the History/Cookies/Login Data query contracts.
+ */
+
+export type OverviewArtifact = "History" | "Cookies" | "Login Data";
+export type CompletenessOutcome = "produced" | "absent" | "unavailable";
+
+export interface CompletenessArtifact {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly artifact: OverviewArtifact;
+  readonly databasePath: string;
+  readonly outcome: CompletenessOutcome;
+  readonly reason: string | null;
+  readonly runId: string;
+}
+
+export interface CompletenessStatement {
+  readonly artifact: OverviewArtifact;
+  readonly attempted: number;
+  readonly produced: number;
+  readonly absent: number;
+  readonly unavailable: number;
+  readonly artifacts: readonly CompletenessArtifact[];
+}
+
+export interface CaseCompleteness {
+  readonly status: "ok";
+  readonly command: "completeness";
+  readonly caseId: string;
+  readonly statements: readonly CompletenessStatement[];
+}
+
+export interface CaseProfiles {
+  readonly status: "ok";
+  readonly command: "profiles";
+  readonly caseId: string;
+  readonly profiles: readonly string[];
+}
+
+interface OverviewQuery {
+  readonly caseDirectory: string;
+}
+
+interface ArtifactResultRow {
+  readonly source_id: string;
+  readonly profile_path: string;
+  readonly database_path: string;
+  readonly status: string;
+  readonly reason: string | null;
+  readonly run_id: string;
+  readonly artifact_result_id: bigint | number;
+  readonly started_at: string;
+}
+
+interface ArtifactTable {
+  readonly artifact: OverviewArtifact;
+  readonly resultsTable: string;
+}
+
+const ARTIFACT_TABLES: readonly ArtifactTable[] = [
+  { artifact: "History", resultsTable: "history_artifact_results" },
+  { artifact: "Cookies", resultsTable: "cookie_artifact_results" },
+  { artifact: "Login Data", resultsTable: "login_data_artifact_results" },
+];
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function tableExists(database: DatabaseSync, name: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ?",
+      )
+      .get(name) !== undefined
+  );
+}
+
+function readCaseId(database: DatabaseSync): string {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  return caseRow.case_id;
+}
+
+/**
+ * Reduce the retained artifact-result lineage to the current outcome per
+ * (Source, Profile) by keeping the most recent Analysis Run. This is exactly
+ * what a reader must see before any result row: supersede keeps every earlier
+ * row, so the newest run is the active outcome.
+ */
+function buildStatement(
+  database: DatabaseSync,
+  table: ArtifactTable,
+): CompletenessStatement {
+  if (
+    !tableExists(database, table.resultsTable) ||
+    !tableExists(database, "analysis_runs")
+  ) {
+    return {
+      artifact: table.artifact,
+      attempted: 0,
+      produced: 0,
+      absent: 0,
+      unavailable: 0,
+      artifacts: [],
+    };
+  }
+  const rows = database
+    .prepare(
+      `SELECT r.source_id, r.profile_path, r.database_path, r.status,
+              r.reason, r.run_id, r.artifact_result_id, a.started_at
+         FROM ${table.resultsTable} r
+         JOIN analysis_runs a ON a.run_id = r.run_id
+        ORDER BY r.source_id, r.profile_path`,
+    )
+    .all() as unknown as ArtifactResultRow[];
+  const latest = new Map<string, ArtifactResultRow>();
+  for (const row of rows) {
+    const key = `${row.source_id}\u0000${row.profile_path}`;
+    const current = latest.get(key);
+    if (
+      current === undefined ||
+      row.started_at > current.started_at ||
+      (row.started_at === current.started_at &&
+        BigInt(row.artifact_result_id) > BigInt(current.artifact_result_id))
+    ) {
+      latest.set(key, row);
+    }
+  }
+  const artifacts = [...latest.values()]
+    .map((row): CompletenessArtifact => {
+      const outcome: CompletenessOutcome =
+        row.status === "complete"
+          ? "produced"
+          : row.status === "absent"
+            ? "absent"
+            : "unavailable";
+      return {
+        sourceId: row.source_id,
+        profile: row.profile_path,
+        artifact: table.artifact,
+        databasePath: row.database_path,
+        outcome,
+        reason:
+          outcome === "unavailable"
+            ? (row.reason ?? "unspecified")
+            : row.reason,
+        runId: row.run_id,
+      };
+    })
+    .sort((left, right) =>
+      left.sourceId === right.sourceId
+        ? left.profile.localeCompare(right.profile)
+        : left.sourceId.localeCompare(right.sourceId),
+    );
+  return {
+    artifact: table.artifact,
+    attempted: artifacts.length,
+    produced: artifacts.filter((row) => row.outcome === "produced").length,
+    absent: artifacts.filter((row) => row.outcome === "absent").length,
+    unavailable: artifacts.filter((row) => row.outcome === "unavailable")
+      .length,
+    artifacts,
+  };
+}
+
+/**
+ * The Completeness Statement for every artifact type, computed before any row
+ * is read. The dashboard shows this above every list.
+ */
+export function queryCompleteness(input: OverviewQuery): CaseCompleteness {
+  const database = openCase(input.caseDirectory);
+  try {
+    const caseId = readCaseId(database);
+    return {
+      status: "ok",
+      command: "completeness",
+      caseId,
+      statements: ARTIFACT_TABLES.map((table) =>
+        buildStatement(database, table),
+      ),
+    };
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * The distinct Profiles that currently carry active Findings across every
+ * artifact type. It backs the multi-Profile filter shared by all lists.
+ */
+export function queryProfiles(input: OverviewQuery): CaseProfiles {
+  const database = openCase(input.caseDirectory);
+  try {
+    const caseId = readCaseId(database);
+    const profiles = new Set<string>();
+    for (const table of ARTIFACT_TABLES) {
+      if (!tableExists(database, table.resultsTable)) {
+        continue;
+      }
+      const rows = database
+        .prepare(
+          `SELECT DISTINCT profile_path
+             FROM ${table.resultsTable}
+            WHERE active = 1
+            ORDER BY profile_path`,
+        )
+        .all() as unknown as { readonly profile_path: string }[];
+      for (const row of rows) {
+        profiles.add(row.profile_path);
+      }
+    }
+    return {
+      status: "ok",
+      command: "profiles",
+      caseId,
+      profiles: [...profiles].sort((left, right) => left.localeCompare(right)),
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -119,6 +119,16 @@ export {
   type ResolvedKeyMaterial,
 } from "./key-material.js";
 export {
+  queryCompleteness,
+  queryProfiles,
+  type CaseCompleteness,
+  type CaseProfiles,
+  type CompletenessArtifact,
+  type CompletenessOutcome,
+  type CompletenessStatement,
+  type OverviewArtifact,
+} from "./case-overview.js";
+export {
   queryHistory,
   type HistoryDirection,
   type HistoryPage,

--- a/e2e/serve-cli.test.ts
+++ b/e2e/serve-cli.test.ts
@@ -1,0 +1,387 @@
+import {
+  spawn,
+  spawnSync,
+  type ChildProcessWithoutNullStreams,
+} from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+const runningServers: ChildProcessWithoutNullStreams[] = [];
+
+interface Announcement {
+  readonly status: "ok";
+  readonly command: "serve";
+  readonly url: string;
+  readonly host: string;
+  readonly port: number;
+  readonly token: string;
+}
+
+interface FieldState {
+  readonly state: "value" | "absent" | "unavailable";
+  readonly value?: unknown;
+  readonly reason?: string;
+}
+
+interface Finding {
+  readonly recordType: "finding";
+  readonly findingKind: string;
+  readonly profile: string;
+  readonly commitState: string;
+  readonly fields: Readonly<Record<string, FieldState>>;
+}
+
+interface Page {
+  readonly status: "ok";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+} {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+async function createHistory(
+  path: string,
+  rows: readonly {
+    readonly id: bigint;
+    readonly urlId: bigint;
+    readonly url: string;
+    readonly title: string;
+    readonly visitTime: bigint;
+    readonly fromVisit: bigint;
+    readonly transition: bigint;
+    readonly duration: bigint;
+  }[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
+        from_visit INTEGER, external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER, originator_cache_guid TEXT,
+        originator_visit_id INTEGER, originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER, app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY, segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL, visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    const insertUrl = database.prepare(
+      `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertVisit = database.prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const row of rows) {
+      insertUrl.run(row.urlId, row.url, row.title, 1, 1, row.visitTime, 0);
+      insertVisit.run(
+        row.id,
+        row.urlId,
+        row.visitTime,
+        row.fromVisit,
+        "",
+        row.transition,
+        0,
+        row.duration,
+        1,
+        0,
+        "origin-cache-guid",
+        row.id + 1000n,
+        0,
+        0,
+        1,
+        1,
+        row.id + 2000n,
+        "com.example.browser",
+      );
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"), [
+    {
+      id: 1n,
+      urlId: 10n,
+      url: "https://alpha.example/start",
+      title: "Alpha start",
+      visitTime: 13_348_638_245_123_456n,
+      fromVisit: 0n,
+      transition: 0x10000001n,
+      duration: 2_500_000n,
+    },
+    {
+      id: 2n,
+      urlId: 11n,
+      url: "https://alpha.example/next",
+      title: "Alpha next",
+      visitTime: 13_348_638_305_456_000n,
+      fromVisit: 1n,
+      transition: 1n,
+      duration: 5_000_000n,
+    },
+  ]);
+  await createHistory(join(source, "Profile 1", "History"), [
+    {
+      id: 7n,
+      urlId: 70n,
+      url: "https://beta.example/",
+      title: "Beta",
+      visitTime: 13_361_718_600_000_000n,
+      fromVisit: 0n,
+      transition: 8n,
+      duration: 750_000n,
+    },
+  ]);
+  return source;
+}
+
+async function startServer(caseDirectory: string): Promise<Announcement> {
+  const child = spawn(
+    process.execPath,
+    [compiledCli, "serve", "--case", caseDirectory, "--port", "0", "--json"],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  runningServers.push(child);
+  let buffer = "";
+  return await new Promise<Announcement>((resolvePromise, rejectPromise) => {
+    const timer = setTimeout(() => {
+      rejectPromise(new Error("serve did not announce in time"));
+    }, 15_000);
+    child.stdout.on("data", (chunk: Buffer) => {
+      buffer += chunk.toString("utf8");
+      const line = buffer.split("\n").find((entry) => entry.trim().length > 0);
+      if (line === undefined) {
+        return;
+      }
+      try {
+        const parsed = JSON.parse(line) as Announcement;
+        if (parsed.command === "serve") {
+          clearTimeout(timer);
+          resolvePromise(parsed);
+        }
+      } catch {
+        // Wait for a complete line.
+      }
+    });
+    child.on("error", rejectPromise);
+    child.on("exit", (code) => {
+      clearTimeout(timer);
+      rejectPromise(new Error(`serve exited early with code ${String(code)}`));
+    });
+  });
+}
+
+async function stopServers(): Promise<void> {
+  for (const child of runningServers.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+}
+
+afterEach(async () => {
+  await stopServers();
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI read-only Case dashboard", () => {
+  it("serves a loopback, token-gated, read-only surface over the analyzer core", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-serve-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const caseDirectory = join(root, "CASE-SERVE");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    expect(
+      runCli([
+        "analyse",
+        "--case",
+        caseDirectory,
+        "--timezone",
+        "America/New_York",
+        "--json",
+      ]).status,
+    ).toBe(0);
+
+    const server = await startServer(caseDirectory);
+    // AC1: loopback bind, no host option, per-run token.
+    expect(server.host).toBe("127.0.0.1");
+    expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
+    expect(server.token.length).toBeGreaterThanOrEqual(32);
+    const base = server.url.replace(/\/$/, "");
+    const auth = { "x-forensix-token": server.token };
+
+    // AC1: a request without the per-run token is rejected.
+    const noToken = await fetch(`${base}/api/history`);
+    expect(noToken.status).toBe(401);
+
+    // AC1: a non-loopback Origin is rejected even with a valid token.
+    const badOrigin = await fetch(`${base}/api/history`, {
+      headers: { ...auth, origin: "https://evil.example" },
+    });
+    expect(badOrigin.status).toBe(403);
+
+    // AC1: a loopback Origin with the token is accepted.
+    const okOrigin = await fetch(`${base}/api/history?limit=10`, {
+      headers: { ...auth, origin: `${base}` },
+    });
+    expect(okOrigin.status).toBe(200);
+
+    // AC3 + read-only: only GET is answered; writes/methods are refused.
+    const post = await fetch(`${base}/api/history`, {
+      method: "POST",
+      headers: auth,
+    });
+    expect(post.status).toBe(405);
+
+    // AC3: there is no ingest/analyse/export route at all.
+    for (const route of ["ingest", "analyse", "export"]) {
+      const response = await fetch(`${base}/api/${route}`, { headers: auth });
+      expect(response.status).toBe(400);
+    }
+
+    // AC5: Completeness is available before rows and typed per artifact.
+    const completeness = (await (
+      await fetch(`${base}/api/completeness`, { headers: auth })
+    ).json()) as {
+      readonly caseId: string;
+      readonly statements: readonly {
+        readonly artifact: string;
+        readonly attempted: number;
+        readonly produced: number;
+      }[];
+    };
+    expect(completeness.caseId.length).toBeGreaterThan(0);
+    const history = completeness.statements.find(
+      (entry) => entry.artifact === "History",
+    );
+    expect(history?.attempted).toBe(2);
+    expect(history?.produced).toBe(2);
+
+    // AC4: multi-Profile filter data is exposed.
+    const profiles = (await (
+      await fetch(`${base}/api/profiles`, { headers: auth })
+    ).json()) as { readonly profiles: readonly string[] };
+    expect([...profiles.profiles].sort()).toEqual(["Default", "Profile 1"]);
+
+    // AC4: keyset pagination returns bounded pages with a cursor.
+    const firstPage = (await (
+      await fetch(`${base}/api/history?sort=visit-time&direction=asc&limit=1`, {
+        headers: auth,
+      })
+    ).json()) as Page;
+    expect(firstPage.items).toHaveLength(1);
+    expect(firstPage.nextCursor).not.toBeNull();
+    expect(firstPage.items[0]?.findingKind).toBe("history_visit");
+    const secondPage = (await (
+      await fetch(
+        `${base}/api/history?sort=visit-time&direction=asc&limit=1&after=${encodeURIComponent(
+          firstPage.nextCursor ?? "",
+        )}`,
+        { headers: auth },
+      )
+    ).json()) as Page;
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0]?.fields.url).not.toEqual(
+      firstPage.items[0]?.fields.url,
+    );
+
+    // AC4: multi-Profile + search filters compose.
+    const filtered = (await (
+      await fetch(
+        `${base}/api/history?profile=Profile%201&search=beta.example&limit=10`,
+        { headers: auth },
+      )
+    ).json()) as Page;
+    expect(filtered.items).toHaveLength(1);
+    expect(filtered.items[0]?.profile).toBe("Profile 1");
+
+    // AC5: committed and sidecar rows are separate lists (one Commit State each).
+    const committed = (await (
+      await fetch(`${base}/api/history?commit-state=committed&limit=100`, {
+        headers: auth,
+      })
+    ).json()) as Page;
+    expect(committed.items).toHaveLength(3);
+    expect(
+      committed.items.every((row) => row.commitState === "committed"),
+    ).toBe(true);
+    const walResident = (await (
+      await fetch(`${base}/api/history?commit-state=wal_resident&limit=100`, {
+        headers: auth,
+      })
+    ).json()) as Page;
+    expect(walResident.items).toHaveLength(0);
+
+    // AC2: the HTML shell injects the per-run token and loads the client bundle.
+    const shell = await (await fetch(`${base}/`, { headers: auth })).text();
+    expect(shell).toContain("__FORENSIX_TOKEN__");
+    expect(shell).toContain('src="/index.js"');
+    const bundle = await (
+      await fetch(`${base}/index.js`, { headers: auth })
+    ).text();
+    expect(bundle).toContain("CLIENT_IMPLEMENTATION_ISSUE");
+
+    await stopServers();
+  }, 30_000);
+});

--- a/e2e/serve-cli.test.ts
+++ b/e2e/serve-cli.test.ts
@@ -4,6 +4,7 @@ import {
   type ChildProcessWithoutNullStreams,
 } from "node:child_process";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -42,6 +43,26 @@ interface Page {
   readonly items: readonly Finding[];
   readonly nextCursor: string | null;
   readonly limit: number;
+}
+
+function rawGet(
+  port: number,
+  path: string,
+  headers: Readonly<Record<string, string>>,
+): Promise<number> {
+  return new Promise<number>((resolvePromise, rejectPromise) => {
+    const request = httpRequest(
+      { host: "127.0.0.1", port, path, method: "GET", headers },
+      (response) => {
+        response.resume();
+        response.on("end", () => {
+          resolvePromise(response.statusCode ?? 0);
+        });
+      },
+    );
+    request.on("error", rejectPromise);
+    request.end();
+  });
 }
 
 function runCli(arguments_: readonly string[]): {
@@ -269,23 +290,57 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
     expect(server.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/$/);
     expect(server.token.length).toBeGreaterThanOrEqual(32);
     const base = server.url.replace(/\/$/, "");
-    const auth = { "x-forensix-token": server.token };
+    const authToken = { "x-forensix-token": server.token };
+    // The browser page always sends a same-origin loopback Origin; simulate it.
+    const auth = { ...authToken, origin: base };
 
-    // AC1: a request without the per-run token is rejected.
+    // AC1: a request without the per-run token is rejected (token gate first).
     const noToken = await fetch(`${base}/api/history`);
     expect(noToken.status).toBe(401);
 
     // AC1: a non-loopback Origin is rejected even with a valid token.
     const badOrigin = await fetch(`${base}/api/history`, {
-      headers: { ...auth, origin: "https://evil.example" },
+      headers: { ...authToken, origin: "https://evil.example" },
     });
     expect(badOrigin.status).toBe(403);
 
+    // AC1 hardening: a token with an absent Origin and no same-origin Fetch
+    // Metadata proof is rejected — "loopback Origin only", not "or no Origin".
+    const absentOrigin = await fetch(`${base}/api/history`, {
+      headers: authToken,
+    });
+    expect(absentOrigin.status).toBe(403);
+
+    // A same-origin GET that omits Origin but carries Fetch Metadata is allowed,
+    // so the real browser dashboard keeps working.
+    expect(
+      await rawGet(server.port, "/api/history?limit=1", {
+        ...authToken,
+        "sec-fetch-site": "same-origin",
+      }),
+    ).toBe(200);
+
+    // AC1 hardening: a loopback socket but a spoofed (rebinding) Host is
+    // rejected by the Host allowlist.
+    expect(
+      await rawGet(server.port, "/api/history", {
+        ...authToken,
+        host: "evil.example",
+      }),
+    ).toBe(403);
+
     // AC1: a loopback Origin with the token is accepted.
     const okOrigin = await fetch(`${base}/api/history?limit=10`, {
-      headers: { ...auth, origin: `${base}` },
+      headers: auth,
     });
     expect(okOrigin.status).toBe(200);
+
+    // The token is never accepted from the URL; a query-param token is ignored.
+    const queryToken = await fetch(
+      `${base}/api/history?token=${encodeURIComponent(server.token)}`,
+      { headers: { origin: base } },
+    );
+    expect(queryToken.status).toBe(401);
 
     // AC3 + read-only: only GET is answered; writes/methods are refused.
     const post = await fetch(`${base}/api/history`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,12 +38,22 @@ importers:
       '@forensix/core':
         specifier: workspace:*
         version: link:../core
+      '@forensix/server':
+        specifier: workspace:*
+        version: link:../server
 
   client: {}
 
   core: {}
 
-  server: {}
+  server:
+    dependencies:
+      '@forensix/client':
+        specifier: workspace:*
+        version: link:../client
+      '@forensix/core':
+        specifier: workspace:*
+        version: link:../core
 
 packages:
 

--- a/server/package.json
+++ b/server/package.json
@@ -3,8 +3,18 @@
   "version": "2.0.0-alpha.1",
   "private": true,
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "engines": {
     "node": ">=24.15.0"
+  },
+  "dependencies": {
+    "@forensix/core": "workspace:*",
+    "@forensix/client": "workspace:*"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,2 +1,367 @@
-/** The read-only loopback adapter is implemented by issue #171. */
+import { randomBytes, timingSafeEqual } from "node:crypto";
+import { readFileSync } from "node:fs";
+import {
+  createServer,
+  type IncomingMessage,
+  type Server,
+  type ServerResponse,
+} from "node:http";
+import { createRequire } from "node:module";
+
+import {
+  ForensixError,
+  queryCompleteness,
+  queryCookies,
+  queryCredentials,
+  queryHistory,
+  queryProfiles,
+  type CommitState,
+  type CookieDirection,
+  type CookieSort,
+  type CredentialDirection,
+  type CredentialSort,
+  type HistoryDirection,
+  type HistorySort,
+  type HistoryView,
+} from "@forensix/core";
+
+/**
+ * Read-only loopback dashboard adapter (issue #171).
+ *
+ * The server is a thin adapter over the analyzer core. It contains no forensic
+ * logic and performs no Case writes: every route maps request parameters onto a
+ * core read query that opens the Case immutable and read-only. There is no
+ * ingest, analyse, or export route, so the dashboard can neither start nor
+ * rerun any pipeline.
+ *
+ * Security posture:
+ *  - binds only to 127.0.0.1 (there is no host-exposure option);
+ *  - mints one per-run bearer token that every /api request must present;
+ *  - rejects any request whose Origin header is not a loopback origin.
+ */
+
 export const SERVER_IMPLEMENTATION_ISSUE = 171;
+
+export interface StartDashboardServerOptions {
+  readonly caseDirectory: string;
+  /** TCP port. 0 (default) asks the OS for an ephemeral loopback port. */
+  readonly port?: number;
+}
+
+export interface DashboardServer {
+  readonly url: string;
+  readonly token: string;
+  readonly port: number;
+  readonly host: "127.0.0.1";
+  close(): Promise<void>;
+}
+
+const LOOPBACK_HOST = "127.0.0.1" as const;
+const TOKEN_HEADER = "x-forensix-token";
+const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+
+const require = createRequire(import.meta.url);
+
+function loadClientBundle(): string {
+  return readFileSync(require.resolve("@forensix/client"), "utf8");
+}
+
+function htmlShell(token: string): string {
+  const safeToken = JSON.stringify(token);
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="referrer" content="no-referrer" />
+    <title>ForensiX read-only Case dashboard</title>
+    <script>window.__FORENSIX_TOKEN__ = ${safeToken};</script>
+    <script type="module" src="/index.js"></script>
+  </head>
+  <body>
+    <noscript>This read-only dashboard needs JavaScript to render Case lists.</noscript>
+    <div id="app">Loading read-only Case dashboard…</div>
+  </body>
+</html>
+`;
+}
+
+function isLoopbackOrigin(origin: string | undefined): boolean {
+  if (origin === undefined || origin === "null") {
+    // A same-origin GET navigation or fetch may omit Origin. The bearer token
+    // still gates every /api response, so an absent Origin is acceptable.
+    return true;
+  }
+  try {
+    const parsed = new URL(origin);
+    return LOOPBACK_HOSTNAMES.has(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function tokensMatch(expected: string, provided: string | undefined): boolean {
+  if (provided === undefined) {
+    return false;
+  }
+  const expectedBytes = Buffer.from(expected, "utf8");
+  const providedBytes = Buffer.from(provided, "utf8");
+  if (expectedBytes.length !== providedBytes.length) {
+    return false;
+  }
+  return timingSafeEqual(expectedBytes, providedBytes);
+}
+
+function sendJson(
+  response: ServerResponse,
+  statusCode: number,
+  body: unknown,
+): void {
+  const payload = `${JSON.stringify(body)}\n`;
+  response.writeHead(statusCode, {
+    "content-type": "application/json; charset=utf-8",
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+  });
+  response.end(payload);
+}
+
+function sendText(
+  response: ServerResponse,
+  statusCode: number,
+  contentType: string,
+  body: string,
+): void {
+  response.writeHead(statusCode, {
+    "content-type": contentType,
+    "cache-control": "no-store",
+    "x-content-type-options": "nosniff",
+  });
+  response.end(body);
+}
+
+function statusForError(error: ForensixError): number {
+  switch (error.code) {
+    case "INVALID_ARGUMENT":
+    case "INVALID_CURSOR":
+      return 400;
+    case "ANALYSIS_NOT_FOUND":
+      return 404;
+    default:
+      return 409;
+  }
+}
+
+function firstString(value: string | null): string | undefined {
+  return value ?? undefined;
+}
+
+function integerParameter(
+  parameters: URLSearchParams,
+  name: string,
+): number | undefined {
+  const value = parameters.get(name);
+  if (value === null) {
+    return undefined;
+  }
+  if (!/^[0-9]+$/.test(value)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Query parameter ${name} must be an integer.`,
+      { parameter: name, value },
+    );
+  }
+  return Number(value);
+}
+
+function handleApi(
+  route: string,
+  parameters: URLSearchParams,
+  caseDirectory: string,
+): unknown {
+  const profiles = parameters.getAll("profile");
+  const commitState = firstString(parameters.get("commit-state")) as
+    | CommitState
+    | undefined;
+  switch (route) {
+    case "completeness":
+      return queryCompleteness({ caseDirectory });
+    case "profiles":
+      return queryProfiles({ caseDirectory });
+    case "history":
+      return queryHistory({
+        caseDirectory,
+        view: firstString(parameters.get("view")) as HistoryView | undefined,
+        profiles,
+        search: firstString(parameters.get("search")),
+        commitState,
+        transition: firstString(parameters.get("transition")),
+        from: firstString(parameters.get("from")),
+        to: firstString(parameters.get("to")),
+        sort: firstString(parameters.get("sort")) as HistorySort | undefined,
+        direction: firstString(parameters.get("direction")) as
+          | HistoryDirection
+          | undefined,
+        limit: integerParameter(parameters, "limit"),
+        after: firstString(parameters.get("after")),
+      });
+    case "cookies":
+      return queryCookies({
+        caseDirectory,
+        profiles,
+        search: firstString(parameters.get("search")),
+        commitState,
+        host: firstString(parameters.get("host")),
+        sameSite: firstString(parameters.get("same-site")),
+        sort: firstString(parameters.get("sort")) as CookieSort | undefined,
+        direction: firstString(parameters.get("direction")) as
+          | CookieDirection
+          | undefined,
+        limit: integerParameter(parameters, "limit"),
+        after: firstString(parameters.get("after")),
+      });
+    case "credentials":
+      return queryCredentials({
+        caseDirectory,
+        profiles,
+        search: firstString(parameters.get("search")),
+        commitState,
+        sort: firstString(parameters.get("sort")) as CredentialSort | undefined,
+        direction: firstString(parameters.get("direction")) as
+          | CredentialDirection
+          | undefined,
+        limit: integerParameter(parameters, "limit"),
+        after: firstString(parameters.get("after")),
+      });
+    default:
+      throw new ForensixError("INVALID_ARGUMENT", "Unknown dashboard route.", {
+        route,
+      });
+  }
+}
+
+function handleRequest(
+  request: IncomingMessage,
+  response: ServerResponse,
+  token: string,
+  caseDirectory: string,
+  clientBundle: string,
+): void {
+  const origin = request.headers.origin;
+  if (!isLoopbackOrigin(Array.isArray(origin) ? origin[0] : origin)) {
+    sendJson(response, 403, {
+      code: "FORBIDDEN_ORIGIN",
+      message: "The dashboard accepts loopback origins only.",
+    });
+    return;
+  }
+  // The dashboard is strictly read-only: only GET is ever answered.
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    sendJson(response, 405, {
+      code: "METHOD_NOT_ALLOWED",
+      message: "The read-only dashboard answers GET requests only.",
+    });
+    return;
+  }
+
+  const requestUrl = new URL(request.url ?? "/", `http://${LOOPBACK_HOST}`);
+  const path = requestUrl.pathname;
+
+  if (path === "/" || path === "/index.html") {
+    sendText(response, 200, "text/html; charset=utf-8", htmlShell(token));
+    return;
+  }
+  if (path === "/index.js") {
+    sendText(response, 200, "text/javascript; charset=utf-8", clientBundle);
+    return;
+  }
+
+  if (path.startsWith("/api/")) {
+    const headerToken = request.headers[TOKEN_HEADER];
+    const provided = Array.isArray(headerToken)
+      ? headerToken[0]
+      : (headerToken ?? firstString(requestUrl.searchParams.get("token")));
+    if (!tokensMatch(token, provided)) {
+      sendJson(response, 401, {
+        code: "UNAUTHORIZED",
+        message: "A valid per-run dashboard token is required.",
+      });
+      return;
+    }
+    const route = path.slice("/api/".length);
+    try {
+      sendJson(
+        response,
+        200,
+        handleApi(route, requestUrl.searchParams, caseDirectory),
+      );
+    } catch (error) {
+      if (error instanceof ForensixError) {
+        sendJson(response, statusForError(error), error.toDiagnostic());
+        return;
+      }
+      sendJson(response, 500, {
+        code: "DASHBOARD_ERROR",
+        message: "The dashboard could not read the Case.",
+      });
+    }
+    return;
+  }
+
+  sendJson(response, 404, {
+    code: "NOT_FOUND",
+    message: "No such dashboard resource.",
+  });
+}
+
+export async function startDashboardServer(
+  options: StartDashboardServerOptions,
+): Promise<DashboardServer> {
+  const token = randomBytes(32).toString("base64url");
+  // Load the client bundle up front so a missing build fails before binding.
+  const clientBundle = loadClientBundle();
+  const server: Server = createServer((request, response) => {
+    handleRequest(
+      request,
+      response,
+      token,
+      options.caseDirectory,
+      clientBundle,
+    );
+  });
+
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.once("error", rejectPromise);
+    // Bind loopback only. There is deliberately no host option.
+    server.listen(options.port ?? 0, LOOPBACK_HOST, () => {
+      server.removeListener("error", rejectPromise);
+      resolvePromise();
+    });
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("The dashboard could not bind a loopback port.");
+  }
+  const port = address.port;
+  const url = `http://${LOOPBACK_HOST}:${port}/`;
+
+  return {
+    url,
+    token,
+    port,
+    host: LOOPBACK_HOST,
+    close(): Promise<void> {
+      return new Promise<void>((resolvePromise, rejectPromise) => {
+        server.close((error) => {
+          if (error) {
+            rejectPromise(error);
+            return;
+          }
+          resolvePromise();
+        });
+      });
+    },
+  };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -59,6 +59,8 @@ export interface DashboardServer {
 const LOOPBACK_HOST = "127.0.0.1" as const;
 const TOKEN_HEADER = "x-forensix-token";
 const LOOPBACK_HOSTNAMES = new Set(["127.0.0.1", "localhost", "[::1]", "::1"]);
+// Fetch Metadata values that prove a request was not initiated cross-site.
+const SAME_ORIGIN_FETCH_SITES = new Set(["same-origin", "none"]);
 
 const require = createRequire(import.meta.url);
 
@@ -86,18 +88,55 @@ function htmlShell(token: string): string {
 `;
 }
 
-function isLoopbackOrigin(origin: string | undefined): boolean {
-  if (origin === undefined || origin === "null") {
-    // A same-origin GET navigation or fetch may omit Origin. The bearer token
-    // still gates every /api response, so an absent Origin is acceptable.
-    return true;
+function headerValue(
+  value: string | readonly string[] | undefined,
+): string | undefined {
+  return Array.isArray(value) ? value[0] : (value as string | undefined);
+}
+
+/**
+ * The host authority (without port) the request was addressed to. It is the
+ * anchor for the loopback Host allowlist that defeats DNS-rebinding.
+ */
+function hostAuthority(hostHeader: string | undefined): string | null {
+  if (hostHeader === undefined || hostHeader.length === 0) {
+    return null;
   }
-  try {
-    const parsed = new URL(origin);
-    return LOOPBACK_HOSTNAMES.has(parsed.hostname);
-  } catch {
-    return false;
+  if (hostHeader.startsWith("[")) {
+    const end = hostHeader.indexOf("]");
+    return end === -1 ? null : hostHeader.slice(0, end + 1);
   }
+  const colon = hostHeader.lastIndexOf(":");
+  return colon === -1 ? hostHeader : hostHeader.slice(0, colon);
+}
+
+/**
+ * Reject any Host header that does not name a loopback authority. A rebinding
+ * attacker's page carries its own hostname in Host even though it resolves to
+ * 127.0.0.1, so this closes that vector regardless of the socket binding.
+ */
+function isLoopbackHost(hostHeader: string | undefined): boolean {
+  const authority = hostAuthority(hostHeader);
+  return authority !== null && LOOPBACK_HOSTNAMES.has(authority);
+}
+
+/**
+ * Whether an /api request is proven to originate from the loopback dashboard
+ * itself. An Origin, when present, must be loopback. When Origin is absent the
+ * request must carry Fetch Metadata proving it was not initiated cross-site;
+ * an absent Origin with no such proof is rejected.
+ */
+function isSameOriginApiRequest(request: IncomingMessage): boolean {
+  const origin = headerValue(request.headers.origin);
+  if (origin !== undefined && origin !== "null") {
+    try {
+      return LOOPBACK_HOSTNAMES.has(new URL(origin).hostname);
+    } catch {
+      return false;
+    }
+  }
+  const fetchSite = headerValue(request.headers["sec-fetch-site"]);
+  return fetchSite !== undefined && SAME_ORIGIN_FETCH_SITES.has(fetchSite);
 }
 
 function tokensMatch(expected: string, provided: string | undefined): boolean {
@@ -247,11 +286,11 @@ function handleRequest(
   caseDirectory: string,
   clientBundle: string,
 ): void {
-  const origin = request.headers.origin;
-  if (!isLoopbackOrigin(Array.isArray(origin) ? origin[0] : origin)) {
+  // Loopback Host allowlist first: defeats DNS-rebinding before any work.
+  if (!isLoopbackHost(headerValue(request.headers.host))) {
     sendJson(response, 403, {
-      code: "FORBIDDEN_ORIGIN",
-      message: "The dashboard accepts loopback origins only.",
+      code: "FORBIDDEN_HOST",
+      message: "The dashboard answers loopback hosts only.",
     });
     return;
   }
@@ -268,7 +307,15 @@ function handleRequest(
   const path = requestUrl.pathname;
 
   if (path === "/" || path === "/index.html") {
-    sendText(response, 200, "text/html; charset=utf-8", htmlShell(token));
+    response.writeHead(200, {
+      "content-type": "text/html; charset=utf-8",
+      "cache-control": "no-store",
+      "x-content-type-options": "nosniff",
+      "x-frame-options": "DENY",
+      "content-security-policy":
+        "default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'unsafe-inline'; connect-src 'self'",
+    });
+    response.end(htmlShell(token));
     return;
   }
   if (path === "/index.js") {
@@ -277,14 +324,19 @@ function handleRequest(
   }
 
   if (path.startsWith("/api/")) {
-    const headerToken = request.headers[TOKEN_HEADER];
-    const provided = Array.isArray(headerToken)
-      ? headerToken[0]
-      : (headerToken ?? firstString(requestUrl.searchParams.get("token")));
-    if (!tokensMatch(token, provided)) {
+    // The per-run token is accepted from the request header only; it is never
+    // read from the URL, so it cannot leak through logs or referrers.
+    if (!tokensMatch(token, headerValue(request.headers[TOKEN_HEADER]))) {
       sendJson(response, 401, {
         code: "UNAUTHORIZED",
         message: "A valid per-run dashboard token is required.",
+      });
+      return;
+    }
+    if (!isSameOriginApiRequest(request)) {
+      sendJson(response, 403, {
+        code: "FORBIDDEN_ORIGIN",
+        message: "The dashboard accepts same-origin loopback requests only.",
       });
       return;
     }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -6,5 +6,6 @@
     "composite": true,
     "tsBuildInfoFile": "dist/.tsbuildinfo"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../core" }, { "path": "../client" }]
 }


### PR DESCRIPTION
Closes #171.

A separate read-only surface over the analyzer core. No second analysis, no write path. A `forensix serve` subcommand starts a loopback-only dashboard; the server and browser client only query the core and never write to the Case.

## Architecture
- **`core/src/case-overview.ts`** — new read-only queries `queryCompleteness` and `queryProfiles`. Both open the Case immutable/read-only and interpret no artifact rows. Completeness reduces the retained artifact-result lineage to the active outcome per (Source, Profile) per artifact (History, Cookies, Login Data), honoring supersede, and reports attempted/produced/absent/unavailable with typed reasons.
- **`server/src/index.ts`** — `node:http` adapter (no external deps). Binds `127.0.0.1` only, mints one per-run token, enforces loopback Origin, answers GET only, and maps request params onto the existing `queryHistory` / `queryCookies` / `queryCredentials` contracts. There is deliberately no ingest/analyse/export route.
- **`client/src/index.ts`** — framework-free browser dashboard served by the server. Renders Completeness before rows, TYPE as the first column, distinct words for value / (empty) / absent / unavailable — reason, separate committed vs sidecar lists, keyset "Load more" pagination, multi-Profile + search + sort + direction filters. No Candidate tiles; uncertainty is conveyed by words (small-caps/underline), never color alone.
- **`cli/src/cli.ts`** — `forensix serve --case <dir> [--port <port>] [--json]`. No `--host` option.

## Acceptance criteria → where met
| # | Criterion | Where |
|---|-----------|-------|
| 1 | Binds only to 127.0.0.1, no host option, per-run token, loopback Origin only | `server/src/index.ts` (`startDashboardServer` listens on `LOOPBACK_HOST`; `randomBytes(32)` token via `timingSafeEqual`; `isLoopbackOrigin`); e2e asserts host, 401 no-token, 403 bad Origin |
| 2 | Server + client query core, no forensic logic, no Case writes | Server maps params → core read queries only; core queries open `readOnly:true, immutable=1`; client fetches `/api/*`; depcruiser forbids core→adapter edges |
| 3 | Cannot start/rerun ingest, analysis, or export | Only GET is answered (405 otherwise); no ingest/analyse/export route exists (e2e asserts 405 on POST and 400 on those routes) |
| 4 | Every list multi-Profile, searchable, filterable, sortable, keyset-paginated | Reuses History query contract for all three lists; e2e asserts keyset cursor + multi-Profile/search compose |
| 5 | Completeness before rows; TYPE first column; empty/absent/unavailable distinct; committed vs sidecar separate lists | `renderCompleteness` rendered before lists; `TYPE` first `<th>`; distinct `mark-empty` / `mark-absent` / `mark-unavailable` words; committed list pinned to `committed`, sidecar list to `wal_resident`/`journal_resident` (e2e asserts separation) |
| 6 | No Candidate summary tile; uncertainty in words not color alone | Client never renders Candidates; a legend + word labels convey state; styling uses italic/underline/small-caps, not color as the sole signal |

## Tests
`pnpm verify` green locally on Node 24.15.0 — format, lint (incl. dependency-cruiser), typecheck, and all 36 tests. New `e2e/serve-cli.test.ts` drives the compiled CLI (ingest → analyse → serve) and exercises every criterion over real HTTP against the loopback server. `vitest.config.ts` unchanged.

## Risks
- Client is framework-free vanilla TS (not React) to keep the build to plain `tsc` and avoid adding a bundler/dependencies; still fully satisfies "client queries the core, no forensic logic, no writes."
- Server reads the client bundle via `createRequire(...).resolve("@forensix/client")` at start; a missing client build fails fast before binding.
- Base/target is `v2` only. Not for master.