### PR TITLE
feat(#183): decrypt supported OSCrypt values offline by explicit opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,28 @@ Use `--commit-state` to keep committed and recovered rows separate.
 Each credential Finding carries Provenance, the raw and UTC timestamps with their Epoch Family, and the secret's encryption prefix.
 The secret itself stays `unavailable` with the reason `encrypted_secret_without_key_material` until authorized key material is supplied.
 
+## Decrypt supported secrets offline
+
+Decryption is disabled by default.
+An authorized investigator opts in with `--decrypt` and supplies authorized key material that carries Provenance.
+The Analyzer stays offline: it makes no network calls, runs no provider daemons, never queries a live suspect key store, and never writes Source bytes.
+
+```sh
+node cli/dist/cli.js analyse \
+  --case "/path/to/CASE-001" \
+  --decrypt \
+  --key-material "/path/to/key-material.json" \
+  --recipient-key "/path/to/recipient.pem" \
+  --json
+```
+
+Key material is either operator-`supplied` (`forensix/supplied-key-material/1`) or Collector-`captured` (`forensix/key-material-bundle/1`).
+A captured bundle seals each derived OSCrypt row key to an X25519 recipient key, so `--recipient-key` unseals it offline (see `collector/contracts/key-material`).
+Each row is dispatched independently by its own `v10`, `v11`, or `v20` prefix, so a mixed-version database is handled correctly.
+Supported routes are Linux basic, GNOME Keyring, KWallet, macOS Keychain, the Windows `v10` key, and legacy Windows DPAPI, each only within its evidenced bounds.
+A decrypted secret becomes a `value`; it is a Redaction State secret and stays withheld in an Extract unless `--include-secrets` is set.
+Everything else stays `unavailable` with a distinct typed reason and is never a guessed unwrap: `unsupported_app_bound_v20` (Windows `v20` App-Bound), `unsupported_encryption_route`, `no_authorized_key_material`, `decryption_wrong_key`, `decryption_malformed_ciphertext`, `decryption_missing_context`, and `decryption_authentication_failed`.
+
 ## Export a canonical Extract
 
 An Extract is a scoped, deterministic, citable read over the Case.

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -30,7 +30,8 @@ import {
 
 const USAGE = `Usage:
   forensix ingest <source> --case <case-directory> [--source-kind <kind>] [--include-tier-2] [--json]
-  forensix analyse --case <case-directory> [--timezone <iana-zone>] [--origin-os <windows|macos|linux>] [--json]
+  forensix analyse --case <case-directory> [--timezone <iana-zone>] [--origin-os <windows|macos|linux>]
+                   [--decrypt --key-material <path> [--recipient-key <path>]] [--json]
   forensix history --case <case-directory> [--view <visits|activity|most-visited|durations>]
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
@@ -80,6 +81,7 @@ const FLAG_OPTIONS = new Set([
   "--include-tier-2",
   "--csv",
   "--include-secrets",
+  "--decrypt",
 ]);
 const VALUE_OPTIONS = new Set([
   "--case",
@@ -103,6 +105,8 @@ const VALUE_OPTIONS = new Set([
   "--collection",
   "--examiner",
   "--extract",
+  "--key-material",
+  "--recipient-key",
 ]);
 const REPEATABLE_OPTIONS = new Set(["--profile", "--collection"]);
 
@@ -318,12 +322,32 @@ async function run(arguments_: readonly string[]): Promise<number> {
   if (parsed.command === "analyse") {
     assertAllowedOptions(
       parsed,
-      new Set(["--case", "--json", "--timezone", "--origin-os"]),
+      new Set([
+        "--case",
+        "--json",
+        "--timezone",
+        "--origin-os",
+        "--decrypt",
+        "--key-material",
+        "--recipient-key",
+      ]),
     );
     if (parsed.positionals.length !== 0) {
       throw new ForensixError(
         "INVALID_ARGUMENT",
         "The analyse command accepts no positional values.",
+      );
+    }
+    const decryptionEnabled = hasOption(parsed, "--decrypt");
+    const keyMaterialPath = optionValue(parsed, "--key-material");
+    const recipientKeyPath = optionValue(parsed, "--recipient-key");
+    if (
+      !decryptionEnabled &&
+      (keyMaterialPath !== undefined || recipientKeyPath !== undefined)
+    ) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "Key material options require the explicit --decrypt opt-in.",
       );
     }
     const result = await analyseCase({
@@ -334,6 +358,9 @@ async function run(arguments_: readonly string[]): Promise<number> {
         "macos",
         "linux",
       ] as const) as DeclaredOriginOs | undefined,
+      decryptionEnabled,
+      ...(keyMaterialPath === undefined ? {} : { keyMaterialPath }),
+      ...(recipientKeyPath === undefined ? {} : { recipientKeyPath }),
       invocation: arguments_,
     });
     process.stdout.write(`${JSON.stringify(result)}\n`);

--- a/core/src/cookies.ts
+++ b/core/src/cookies.ts
@@ -248,16 +248,19 @@ function buildCookies(options: {
     const plaintextValue = preservedString(row.value, columns.has("value"));
     const encrypted =
       row.encryptedValue instanceof Uint8Array ? row.encryptedValue : null;
-    const isEncrypted = encrypted !== null && encrypted.length > 0;
-    const schemeClass =
-      isEncrypted && encrypted !== null ? schemeOf(encrypted) : null;
+    // The encrypted secret, narrowed to a non-empty blob; an empty blob is not
+    // a secret. `encrypted` is kept for the retained byte-length metadata.
+    const secretBlob =
+      encrypted !== null && encrypted.length > 0 ? encrypted : null;
+    const isEncrypted = secretBlob !== null;
+    const schemeClass = secretBlob !== null ? schemeOf(secretBlob) : null;
     // The displayed scheme keeps only the canonical v10/v11/v20 classes; a
     // legacy (unprefixed) blob has no recognised scheme string.
     const scheme =
       schemeClass === null || schemeClass === "legacy" ? null : schemeClass;
     const decrypted =
-      isEncrypted && encrypted !== null
-        ? decryptSecretField(encrypted, options.profile, options.decryption)
+      secretBlob !== null
+        ? decryptSecretField(secretBlob, options.profile, options.decryption)
         : null;
 
     const sameSite = enumFields(

--- a/core/src/cookies.ts
+++ b/core/src/cookies.ts
@@ -25,7 +25,8 @@ import {
   type Provenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
-import { decryptOscryptValue, type DecryptionSettings } from "./oscrypt.js";
+import { decryptSecretField } from "./decrypted-field.js";
+import { schemeOf, type DecryptionSettings } from "./oscrypt.js";
 
 /**
  * Chromium stores cookie times as `base::Time`: microseconds since the Windows
@@ -68,55 +69,6 @@ interface ManifestIdentity {
 
 interface BuiltCookie {
   readonly persisted: PersistedCookieFinding;
-}
-
-interface DecryptedSecret {
-  readonly value: FieldState<string>;
-  readonly route: FieldState<string>;
-  readonly keyMaterialRecordId: FieldState<string>;
-  readonly plaintext: string | null;
-}
-
-/**
- * Resolve the plaintext of an encrypted value strictly within the opt-in gate.
- * With decryption disabled the value stays `unavailable` with the historic
- * typed reason. With decryption enabled the row is dispatched offline by its
- * own prefix; success yields the plaintext plus the citing key-material
- * Provenance, and every failure keeps a distinct typed reason.
- */
-function decryptSecret(
-  encrypted: Uint8Array,
-  profile: string,
-  decryption: DecryptionSettings,
-): DecryptedSecret {
-  if (!decryption.enabled) {
-    return {
-      value: unavailableField("encrypted_secret_without_key_material"),
-      route: absentField(),
-      keyMaterialRecordId: absentField(),
-      plaintext: null,
-    };
-  }
-  const outcome = decryptOscryptValue({
-    ciphertext: encrypted,
-    profile,
-    keyMaterial: decryption.keyMaterial,
-  });
-  if (outcome.state === "unavailable") {
-    return {
-      value: unavailableField(outcome.reason),
-      route: absentField(),
-      keyMaterialRecordId: absentField(),
-      plaintext: null,
-    };
-  }
-  const plaintext = Buffer.from(outcome.plaintext).toString("utf8");
-  return {
-    value: valueField(plaintext),
-    route: valueField(outcome.route),
-    keyMaterialRecordId: valueField(outcome.provenance.recordId),
-    plaintext,
-  };
 }
 
 function preservedString(
@@ -260,18 +212,6 @@ function timestampField(
   );
 }
 
-function encryptionScheme(bytes: Uint8Array): string | null {
-  if (bytes.length < 3) {
-    return null;
-  }
-  const prefix = String.fromCharCode(
-    bytes[0] ?? 0,
-    bytes[1] ?? 0,
-    bytes[2] ?? 0,
-  );
-  return /^v(?:10|11|20)$/.test(prefix) ? prefix : null;
-}
-
 function buildCookies(options: {
   readonly rows: readonly RawCookie[];
   readonly schema: CookieSchema;
@@ -309,10 +249,15 @@ function buildCookies(options: {
     const encrypted =
       row.encryptedValue instanceof Uint8Array ? row.encryptedValue : null;
     const isEncrypted = encrypted !== null && encrypted.length > 0;
-    const scheme = isEncrypted ? encryptionScheme(encrypted) : null;
+    const schemeClass =
+      isEncrypted && encrypted !== null ? schemeOf(encrypted) : null;
+    // The displayed scheme keeps only the canonical v10/v11/v20 classes; a
+    // legacy (unprefixed) blob has no recognised scheme string.
+    const scheme =
+      schemeClass === null || schemeClass === "legacy" ? null : schemeClass;
     const decrypted =
       isEncrypted && encrypted !== null
-        ? decryptSecret(encrypted, options.profile, options.decryption)
+        ? decryptSecretField(encrypted, options.profile, options.decryption)
         : null;
 
     const sameSite = enumFields(

--- a/core/src/cookies.ts
+++ b/core/src/cookies.ts
@@ -25,6 +25,7 @@ import {
   type Provenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
+import { decryptOscryptValue, type DecryptionSettings } from "./oscrypt.js";
 
 /**
  * Chromium stores cookie times as `base::Time`: microseconds since the Windows
@@ -67,6 +68,55 @@ interface ManifestIdentity {
 
 interface BuiltCookie {
   readonly persisted: PersistedCookieFinding;
+}
+
+interface DecryptedSecret {
+  readonly value: FieldState<string>;
+  readonly route: FieldState<string>;
+  readonly keyMaterialRecordId: FieldState<string>;
+  readonly plaintext: string | null;
+}
+
+/**
+ * Resolve the plaintext of an encrypted value strictly within the opt-in gate.
+ * With decryption disabled the value stays `unavailable` with the historic
+ * typed reason. With decryption enabled the row is dispatched offline by its
+ * own prefix; success yields the plaintext plus the citing key-material
+ * Provenance, and every failure keeps a distinct typed reason.
+ */
+function decryptSecret(
+  encrypted: Uint8Array,
+  profile: string,
+  decryption: DecryptionSettings,
+): DecryptedSecret {
+  if (!decryption.enabled) {
+    return {
+      value: unavailableField("encrypted_secret_without_key_material"),
+      route: absentField(),
+      keyMaterialRecordId: absentField(),
+      plaintext: null,
+    };
+  }
+  const outcome = decryptOscryptValue({
+    ciphertext: encrypted,
+    profile,
+    keyMaterial: decryption.keyMaterial,
+  });
+  if (outcome.state === "unavailable") {
+    return {
+      value: unavailableField(outcome.reason),
+      route: absentField(),
+      keyMaterialRecordId: absentField(),
+      plaintext: null,
+    };
+  }
+  const plaintext = Buffer.from(outcome.plaintext).toString("utf8");
+  return {
+    value: valueField(plaintext),
+    route: valueField(outcome.route),
+    keyMaterialRecordId: valueField(outcome.provenance.recordId),
+    plaintext,
+  };
 }
 
 function preservedString(
@@ -230,6 +280,7 @@ function buildCookies(options: {
   readonly manifest: ManifestIdentity;
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
+  readonly decryption: DecryptionSettings;
 }): BuiltCookie[] {
   const columns = options.schema.cookieColumns;
   return options.rows.map((row) => {
@@ -259,6 +310,10 @@ function buildCookies(options: {
       row.encryptedValue instanceof Uint8Array ? row.encryptedValue : null;
     const isEncrypted = encrypted !== null && encrypted.length > 0;
     const scheme = isEncrypted ? encryptionScheme(encrypted) : null;
+    const decrypted =
+      isEncrypted && encrypted !== null
+        ? decryptSecret(encrypted, options.profile, options.decryption)
+        : null;
 
     const sameSite = enumFields(
       row.samesite,
@@ -319,9 +374,11 @@ function buildCookies(options: {
         row.topFrameSiteKey,
         columns.has("top_frame_site_key"),
       ),
-      value: isEncrypted
-        ? unavailableField("encrypted_secret_without_key_material")
-        : plaintextValue,
+      value: decrypted !== null ? decrypted.value : plaintextValue,
+      valueDecryptionRoute:
+        decrypted !== null ? decrypted.route : absentField(),
+      valueKeyMaterialRecordId:
+        decrypted !== null ? decrypted.keyMaterialRecordId : absentField(),
       isEncrypted: valueField(isEncrypted),
       encryptedValueScheme: isEncrypted
         ? scheme === null
@@ -468,6 +525,7 @@ async function analyseProfile(options: {
   readonly workingCopyPath: string;
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
+  readonly decryption: DecryptionSettings;
 }): Promise<CookieArtifactWrite> {
   const modernPath =
     options.profile === "."
@@ -566,6 +624,7 @@ async function analyseProfile(options: {
       manifest,
       declaredTimezone: options.declaredTimezone,
       declaredOriginOs: options.declaredOriginOs,
+      decryption: options.decryption,
     });
     const recovered =
       passes.recovered === null
@@ -578,6 +637,7 @@ async function analyseProfile(options: {
             manifest: recoveredManifest as ManifestIdentity,
             declaredTimezone: options.declaredTimezone,
             declaredOriginOs: options.declaredOriginOs,
+            decryption: options.decryption,
           });
     return {
       sourceId: options.source.sourceId,
@@ -617,6 +677,7 @@ export interface CookieAnalysisInput {
   readonly workingCopyPath: string;
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
+  readonly decryption: DecryptionSettings;
 }
 
 export async function analyseSourceCookies(
@@ -631,6 +692,7 @@ export async function analyseSourceCookies(
         workingCopyPath: input.workingCopyPath,
         declaredTimezone: input.declaredTimezone,
         declaredOriginOs: input.declaredOriginOs,
+        decryption: input.decryption,
       }),
     );
   }

--- a/core/src/decrypted-field.ts
+++ b/core/src/decrypted-field.ts
@@ -1,0 +1,61 @@
+import {
+  absentField,
+  unavailableField,
+  valueField,
+  type FieldState,
+} from "./forensic-model.js";
+import { decryptOscryptValue, type DecryptionSettings } from "./oscrypt.js";
+
+/**
+ * The Field States a single encrypted secret resolves to. The parser maps
+ * `value` onto its own field name (a Cookie `value` or a credential `secret`)
+ * and carries the decryption route and citing key-material record alongside it.
+ */
+export interface DecryptedSecretField {
+  readonly value: FieldState<string>;
+  readonly route: FieldState<string>;
+  readonly keyMaterialRecordId: FieldState<string>;
+}
+
+/**
+ * Resolve one encrypted secret blob strictly within the opt-in gate. This is
+ * the single decryption seam shared by the Cookies (#174) and Login Data (#177)
+ * parsers so the gate behaves identically for both:
+ *
+ * - Decryption disabled (the default): the secret stays `unavailable` with the
+ *   historic `encrypted_secret_without_key_material` reason and no key material
+ *   is ever consulted.
+ * - Enabled: the blob is dispatched offline by its own prefix. Success yields
+ *   the plaintext plus the citing route and key-material record; every failure
+ *   keeps a distinct typed reason.
+ */
+export function decryptSecretField(
+  ciphertext: Uint8Array,
+  profile: string,
+  decryption: DecryptionSettings,
+): DecryptedSecretField {
+  if (!decryption.enabled) {
+    return {
+      value: unavailableField("encrypted_secret_without_key_material"),
+      route: absentField(),
+      keyMaterialRecordId: absentField(),
+    };
+  }
+  const outcome = decryptOscryptValue({
+    ciphertext,
+    profile,
+    keyMaterial: decryption.keyMaterial,
+  });
+  if (outcome.state === "unavailable") {
+    return {
+      value: unavailableField(outcome.reason),
+      route: absentField(),
+      keyMaterialRecordId: absentField(),
+    };
+  }
+  return {
+    value: valueField(Buffer.from(outcome.plaintext).toString("utf8")),
+    route: valueField(outcome.route),
+    keyMaterialRecordId: valueField(outcome.provenance.recordId),
+  };
+}

--- a/core/src/export.ts
+++ b/core/src/export.ts
@@ -46,6 +46,14 @@ const SECRET_FIELD_PATTERNS = [
   "private_key",
 ] as const;
 
+/**
+ * Field names that are secrets by exact match rather than substring. The Cookie
+ * Finding's decrypted plaintext lives in a field named exactly `value`; it must
+ * be withheld by default without over-matching metadata fields such as
+ * `encryptedValueByteLength`.
+ */
+const SECRET_FIELD_EXACT = new Set(["value"]);
+
 export interface ExportCaseOptions {
   readonly caseDirectory: string;
   readonly outDirectory: string;
@@ -243,7 +251,10 @@ export function computeDerivedDigest(
 
 export function isSecretFieldName(name: string): boolean {
   const lower = name.toLowerCase();
-  return SECRET_FIELD_PATTERNS.some((pattern) => lower.includes(pattern));
+  return (
+    SECRET_FIELD_EXACT.has(lower) ||
+    SECRET_FIELD_PATTERNS.some((pattern) => lower.includes(pattern))
+  );
 }
 
 export interface RedactedField {

--- a/core/src/forensic-model.ts
+++ b/core/src/forensic-model.ts
@@ -8,7 +8,17 @@ export type FieldUnavailableReason =
   | "epoch_requires_declared_origin_os"
   | "timestamp_out_of_range"
   | "unsupported_value"
-  | "encrypted_secret_without_key_material";
+  | "encrypted_secret_without_key_material"
+  // Typed reasons for an opted-in offline OSCrypt decryption attempt. They keep
+  // unsupported schemes, absent key material, wrong credentials, malformed
+  // stores, missing context, and authentication failures distinguishable.
+  | "unsupported_app_bound_v20"
+  | "unsupported_encryption_route"
+  | "no_authorized_key_material"
+  | "decryption_wrong_key"
+  | "decryption_malformed_ciphertext"
+  | "decryption_missing_context"
+  | "decryption_authentication_failed";
 
 export interface ValueField<T> {
   readonly state: "value";

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -12,6 +12,11 @@ import {
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseLoginDataProfile } from "./login-data.js";
 import {
+  loadAuthorizedKeyMaterial,
+  type KeyMaterialIssue,
+} from "./key-material.js";
+import { DECRYPTION_DISABLED, type DecryptionSettings } from "./oscrypt.js";
+import {
   loadCaseSources,
   workingCopyAbsolutePath,
   type CaseSourceRecord,
@@ -60,6 +65,22 @@ export interface AnalyseCaseOptions {
   readonly declaredTimezone?: string;
   readonly declaredOriginOs?: DeclaredOriginOs;
   readonly invocation?: readonly string[];
+  /**
+   * Explicit operator opt-in to offline OSCrypt decryption. Disabled by
+   * default. When enabled, `keyMaterialPath` is required; encrypted values stay
+   * `unavailable` with typed reasons whenever key material is missing or fails.
+   */
+  readonly decryptionEnabled?: boolean;
+  /** Path to supplied or captured authorized key material with Provenance. */
+  readonly keyMaterialPath?: string;
+  /** Recipient X25519 private key (PEM) used to unseal captured key material. */
+  readonly recipientKeyPath?: string;
+}
+
+export interface DecryptionSummary {
+  readonly enabled: boolean;
+  readonly keyMaterialCount: number;
+  readonly keyMaterialIssueCount: number;
 }
 
 export interface HistoryAnalysisSummary {
@@ -132,6 +153,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly history: HistoryAnalysisSummary;
   readonly cookies: CookieAnalysisSummary;
   readonly loginData: LoginDataAnalysisSummary;
+  readonly decryption: DecryptionSummary;
 }
 
 interface ManifestIdentity {
@@ -1166,6 +1188,24 @@ export async function analyseCase(
   );
   const declaredOriginOs = options.declaredOriginOs ?? null;
   const startedAt = new Date().toISOString();
+  let decryption: DecryptionSettings = DECRYPTION_DISABLED;
+  let keyMaterialIssues: readonly KeyMaterialIssue[] = [];
+  if (options.decryptionEnabled === true) {
+    if (options.keyMaterialPath === undefined) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "Decryption opt-in requires authorized key material; pass --key-material.",
+      );
+    }
+    const resolved = loadAuthorizedKeyMaterial({
+      keyMaterialPath: options.keyMaterialPath,
+      ...(options.recipientKeyPath === undefined
+        ? {}
+        : { recipientKeyPath: options.recipientKeyPath }),
+    });
+    decryption = { enabled: true, keyMaterial: resolved.material };
+    keyMaterialIssues = resolved.issues;
+  }
   const verification = await verifyWorkingCopy(caseDirectory);
   const sources = loadCaseSources(caseDirectory);
   const artifacts: HistoryArtifactWrite[] = [];
@@ -1189,6 +1229,7 @@ export async function analyseCase(
           profile: profile.path,
           workingCopyPath,
           declaredTimezone,
+          decryption,
         }),
       );
     }
@@ -1198,6 +1239,7 @@ export async function analyseCase(
         workingCopyPath,
         declaredTimezone,
         declaredOriginOs,
+        decryption,
       })),
     );
   }
@@ -1333,6 +1375,11 @@ export async function analyseCase(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),
+    },
+    decryption: {
+      enabled: decryption.enabled,
+      keyMaterialCount: decryption.keyMaterial.length,
+      keyMaterialIssueCount: keyMaterialIssues.length,
     },
   };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -93,11 +93,31 @@ export {
   type AnalyseCaseOptions,
   type AnalyseCaseResult,
   type CookieAnalysisSummary,
+  type DecryptionSummary,
   type EpochFamily,
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
 } from "./history.js";
+export {
+  DECRYPTION_DISABLED,
+  OSCRYPT_ROUTES,
+  decryptOscryptValue,
+  schemeOf,
+  type AuthorizedKeyMaterial,
+  type DecryptionFailureReason,
+  type DecryptionOutcome,
+  type DecryptionSettings,
+  type KeyMaterialProvenance,
+  type OscryptRoute,
+  type OscryptScheme,
+} from "./oscrypt.js";
+export {
+  loadAuthorizedKeyMaterial,
+  type KeyMaterialIssue,
+  type LoadKeyMaterialOptions,
+  type ResolvedKeyMaterial,
+} from "./key-material.js";
 export {
   queryHistory,
   type HistoryDirection,

--- a/core/src/key-material.ts
+++ b/core/src/key-material.ts
@@ -1,0 +1,422 @@
+import {
+  createDecipheriv,
+  createPrivateKey,
+  createPublicKey,
+  diffieHellman,
+  hkdfSync,
+  type KeyObject,
+} from "node:crypto";
+import { readFileSync } from "node:fs";
+
+import { ForensixError } from "./errors.js";
+import type {
+  AuthorizedKeyMaterial,
+  KeyMaterialProvenance,
+  OscryptRoute,
+} from "./oscrypt.js";
+
+/**
+ * Resolve authorized OSCrypt key material for the offline Analyzer.
+ *
+ * This module only reads the operator-provided key-material file (and, for
+ * captured material, the operator's recipient private key). It never reads a
+ * live key store, never writes Source bytes, and makes no network calls. It
+ * supports two input shapes:
+ *
+ * - `supplied`: an operator-authored file that names each route, its key kind,
+ *   and the raw key bytes, each carrying explicit Provenance.
+ * - `captured`: sealed records from the Collector's `key_material/` subtree
+ *   (see `collector/contracts/key-material`). Each `captured` record seals a
+ *   derived OSCrypt row key to an X25519 recipient key; the operator supplies
+ *   the matching private key to unseal it offline.
+ *
+ * Records that do not carry a usable row key, or that map to an unsupported
+ * route, are skipped and reported as typed issues; they never become a guessed
+ * key.
+ */
+
+const SEAL_INFO = "forensix/key-material-seal/1";
+
+export interface KeyMaterialIssue {
+  readonly recordId: string;
+  readonly reason: string;
+}
+
+export interface ResolvedKeyMaterial {
+  readonly material: readonly AuthorizedKeyMaterial[];
+  readonly issues: readonly KeyMaterialIssue[];
+}
+
+export interface LoadKeyMaterialOptions {
+  readonly keyMaterialPath: string;
+  /** PEM (PKCS8) X25519 private key path, required to unseal captured records. */
+  readonly recipientKeyPath?: string;
+}
+
+interface SuppliedEntry {
+  readonly recordId?: string;
+  readonly record_id?: string;
+  readonly route: OscryptRoute;
+  readonly keyKind?: AuthorizedKeyMaterial["keyKind"];
+  readonly key_kind?: AuthorizedKeyMaterial["keyKind"];
+  readonly secretBase64?: string;
+  readonly secret_base64?: string;
+  readonly rowPrefix?: "" | "v10" | "v11" | "v20";
+  readonly row_prefix?: "" | "v10" | "v11" | "v20";
+  readonly profile?: string | null;
+  readonly masterKeyGuid?: string;
+  readonly master_key_guid?: string;
+  readonly provider?: {
+    readonly platform?: KeyMaterialProvenance["providerPlatform"];
+    readonly name?: string;
+    readonly item?: string;
+    readonly scope?: string;
+  };
+}
+
+interface SuppliedFile {
+  readonly schema: "forensix/supplied-key-material/1";
+  readonly entries: readonly SuppliedEntry[];
+}
+
+interface CapturedProvider {
+  readonly platform: "darwin" | "linux" | "windows" | "unknown";
+  readonly name: string;
+  readonly item: string;
+  readonly scope: string;
+}
+
+interface CapturedContext {
+  readonly name: string;
+  readonly value: string;
+}
+
+interface CapturedPolicy {
+  readonly row_prefix: "" | "v10" | "v11" | "v20";
+  readonly support: "supported" | "unsupported" | "unavailable";
+  readonly reason?: string;
+}
+
+interface CapturedEvidence {
+  readonly path: string;
+  readonly sha256: string;
+  readonly version?: string;
+  readonly policy?: string;
+}
+
+interface CapturedSealedMaterial {
+  readonly algorithm: "x25519-hkdf-sha256-aes-256-gcm";
+  readonly recipient_fingerprint: string;
+  readonly ephemeral_public_key: string;
+  readonly salt: string;
+  readonly nonce: string;
+  readonly ciphertext: string;
+  readonly associated_data_sha256: string;
+}
+
+interface CapturedRecord {
+  readonly schema_version: "forensix/key-material-record/1";
+  readonly record_id: string;
+  readonly capture_state: "captured" | "unsupported" | "unavailable";
+  readonly key_kind: "oscrypt_row_key";
+  readonly usable_row_key: boolean;
+  readonly provider: CapturedProvider;
+  readonly context: readonly CapturedContext[];
+  readonly policy: CapturedPolicy;
+  readonly evidence: readonly CapturedEvidence[];
+  readonly sealed_material: CapturedSealedMaterial | null;
+}
+
+interface CapturedFile {
+  readonly schema: "forensix/key-material-bundle/1";
+  readonly records: readonly CapturedRecord[];
+}
+
+function invalid(message: string): ForensixError {
+  return new ForensixError("INVALID_ARGUMENT", message);
+}
+
+function readJson(path: string): unknown {
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (error) {
+    throw invalid(`Key material file could not be read: ${String(error)}`);
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw invalid(`Key material file is not valid JSON: ${String(error)}`);
+  }
+}
+
+function providerFromSupplied(
+  entry: SuppliedEntry,
+): Pick<
+  KeyMaterialProvenance,
+  "providerPlatform" | "providerName" | "providerItem" | "providerScope"
+> {
+  const provider = entry.provider ?? {};
+  return {
+    providerPlatform: provider.platform ?? "unknown",
+    providerName: provider.name ?? "supplied",
+    providerItem: provider.item ?? "supplied",
+    providerScope: provider.scope ?? "supplied",
+  };
+}
+
+function resolveSupplied(file: SuppliedFile): ResolvedKeyMaterial {
+  const material: AuthorizedKeyMaterial[] = [];
+  const issues: KeyMaterialIssue[] = [];
+  file.entries.forEach((entry, index) => {
+    const recordId = entry.recordId ?? entry.record_id ?? `supplied-${index}`;
+    const secretBase64 = entry.secretBase64 ?? entry.secret_base64;
+    if (secretBase64 === undefined) {
+      issues.push({ recordId, reason: "missing_secret" });
+      return;
+    }
+    const secret = new Uint8Array(Buffer.from(secretBase64, "base64"));
+    if (secret.length === 0) {
+      issues.push({ recordId, reason: "empty_secret" });
+      return;
+    }
+    const provenance: KeyMaterialProvenance = {
+      origin: "supplied",
+      recordId,
+      route: entry.route,
+      rowPrefix: entry.rowPrefix ?? entry.row_prefix ?? "",
+      profileScope: entry.profile ?? null,
+      evidenceSha256: [],
+      ...providerFromSupplied(entry),
+    };
+    const masterKeyGuid = entry.masterKeyGuid ?? entry.master_key_guid;
+    material.push({
+      provenance,
+      keyKind: entry.keyKind ?? entry.key_kind ?? "row_key",
+      secret,
+      ...(masterKeyGuid === undefined ? {} : { masterKeyGuid }),
+    });
+  });
+  return { material, issues };
+}
+
+/**
+ * Map a captured record's provider and policy onto a supported route. Returns
+ * `null` (and the caller records an issue) for anything outside the evidenced
+ * bounds, so an unsupported provider never silently becomes a guessed route.
+ */
+function routeFromRecord(record: CapturedRecord): OscryptRoute | null {
+  const platform = record.provider.platform;
+  const name = record.provider.name.toLowerCase();
+  if (platform === "darwin") {
+    return "macos-keychain";
+  }
+  if (platform === "windows") {
+    return record.policy.row_prefix === "v10"
+      ? "windows-dpapi-v10"
+      : record.policy.row_prefix === ""
+        ? "windows-dpapi-legacy"
+        : null;
+  }
+  if (platform === "linux") {
+    if (name.includes("kwallet")) {
+      return "kwallet";
+    }
+    if (
+      name.includes("keyring") ||
+      name.includes("libsecret") ||
+      name.includes("gnome")
+    ) {
+      return "gnome-keyring";
+    }
+    if (name.includes("basic") || name.includes("plain")) {
+      return "linux-basic";
+    }
+  }
+  return null;
+}
+
+function base64(value: string): Buffer {
+  return Buffer.from(value, "base64");
+}
+
+/**
+ * Rebuild the associated data the Collector authenticated: one compact JSON
+ * line of the record with `sealed_material` set to `null`, in the record schema
+ * field order, terminated by LF.
+ */
+export function associatedDataLine(record: CapturedRecord): string {
+  const ordered: Record<string, unknown> = {
+    schema_version: record.schema_version,
+    record_id: record.record_id,
+    capture_state: record.capture_state,
+    key_kind: record.key_kind,
+    usable_row_key: record.usable_row_key,
+    provider: {
+      platform: record.provider.platform,
+      name: record.provider.name,
+      item: record.provider.item,
+      scope: record.provider.scope,
+    },
+    context: record.context.map((entry) => ({
+      name: entry.name,
+      value: entry.value,
+    })),
+    policy: {
+      row_prefix: record.policy.row_prefix,
+      support: record.policy.support,
+      ...(record.policy.reason === undefined
+        ? {}
+        : { reason: record.policy.reason }),
+    },
+    evidence: record.evidence.map((entry) => ({
+      path: entry.path,
+      sha256: entry.sha256,
+      ...(entry.version === undefined ? {} : { version: entry.version }),
+      ...(entry.policy === undefined ? {} : { policy: entry.policy }),
+    })),
+    sealed_material: null,
+  };
+  return `${JSON.stringify(ordered)}\n`;
+}
+
+function unsealRowKey(
+  record: CapturedRecord,
+  recipientPrivateKey: KeyObject,
+): Uint8Array {
+  const sealed = record.sealed_material;
+  if (sealed === null) {
+    throw invalid("captured record has no sealed material");
+  }
+  const ephemeralPublicKey = createPublicKey({
+    key: Buffer.concat([
+      // SubjectPublicKeyInfo prefix for a raw 32-byte X25519 public key.
+      Buffer.from("302a300506032b656e032100", "hex"),
+      base64(sealed.ephemeral_public_key),
+    ]),
+    format: "der",
+    type: "spki",
+  });
+  const shared = diffieHellman({
+    privateKey: recipientPrivateKey,
+    publicKey: ephemeralPublicKey,
+  });
+  const sealKey = Buffer.from(
+    hkdfSync("sha256", shared, base64(sealed.salt), SEAL_INFO, 32),
+  );
+  const ciphertext = base64(sealed.ciphertext);
+  if (ciphertext.length < 16) {
+    throw invalid("sealed ciphertext is too short");
+  }
+  const body = ciphertext.subarray(0, ciphertext.length - 16);
+  const tag = ciphertext.subarray(ciphertext.length - 16);
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    sealKey,
+    base64(sealed.nonce),
+  );
+  decipher.setAAD(Buffer.from(associatedDataLine(record), "utf8"));
+  decipher.setAuthTag(tag);
+  return new Uint8Array(
+    Buffer.concat([decipher.update(body), decipher.final()]),
+  );
+}
+
+function profileScopeFromContext(record: CapturedRecord): string | null {
+  const entry = record.context.find((item) => item.name === "profile");
+  return entry === undefined || entry.value.length === 0 ? null : entry.value;
+}
+
+function resolveCaptured(
+  file: CapturedFile,
+  recipientKeyPath: string | undefined,
+): ResolvedKeyMaterial {
+  const material: AuthorizedKeyMaterial[] = [];
+  const issues: KeyMaterialIssue[] = [];
+  let recipientKey: KeyObject | null = null;
+  if (recipientKeyPath !== undefined) {
+    try {
+      recipientKey = createPrivateKey(readFileSync(recipientKeyPath, "utf8"));
+    } catch (error) {
+      throw invalid(`Recipient private key is unusable: ${String(error)}`);
+    }
+  }
+  for (const record of file.records) {
+    if (record.capture_state !== "captured" || !record.usable_row_key) {
+      issues.push({
+        recordId: record.record_id,
+        reason: record.policy.reason ?? `capture_state_${record.capture_state}`,
+      });
+      continue;
+    }
+    const route = routeFromRecord(record);
+    if (route === null) {
+      issues.push({
+        recordId: record.record_id,
+        reason: "unsupported_route",
+      });
+      continue;
+    }
+    if (recipientKey === null) {
+      issues.push({
+        recordId: record.record_id,
+        reason: "recipient_private_key_required",
+      });
+      continue;
+    }
+    let secret: Uint8Array;
+    try {
+      secret = unsealRowKey(record, recipientKey);
+    } catch (error) {
+      issues.push({
+        recordId: record.record_id,
+        reason: `unseal_failed:${
+          error instanceof ForensixError ? error.message : String(error)
+        }`,
+      });
+      continue;
+    }
+    material.push({
+      provenance: {
+        origin: "captured",
+        recordId: record.record_id,
+        route,
+        rowPrefix: record.policy.row_prefix,
+        providerPlatform: record.provider.platform,
+        providerName: record.provider.name,
+        providerItem: record.provider.item,
+        providerScope: record.provider.scope,
+        profileScope: profileScopeFromContext(record),
+        evidenceSha256: record.evidence.map((entry) => entry.sha256),
+      },
+      keyKind: "row_key",
+      secret,
+    });
+  }
+  return { material, issues };
+}
+
+/**
+ * Load and resolve authorized key material from an operator-provided file.
+ * Throws `INVALID_ARGUMENT` only for a structurally unusable file; individual
+ * records that cannot be resolved are reported as typed issues.
+ */
+export function loadAuthorizedKeyMaterial(
+  options: LoadKeyMaterialOptions,
+): ResolvedKeyMaterial {
+  const parsed = readJson(options.keyMaterialPath);
+  if (parsed === null || typeof parsed !== "object") {
+    throw invalid("Key material file must be a JSON object.");
+  }
+  const schema = (parsed as { readonly schema?: unknown }).schema;
+  if (schema === "forensix/supplied-key-material/1") {
+    return resolveSupplied(parsed as SuppliedFile);
+  }
+  if (schema === "forensix/key-material-bundle/1") {
+    return resolveCaptured(parsed as CapturedFile, options.recipientKeyPath);
+  }
+  throw invalid(
+    "Key material file has an unrecognised schema; expected " +
+      "forensix/supplied-key-material/1 or forensix/key-material-bundle/1.",
+  );
+}

--- a/core/src/login-data.ts
+++ b/core/src/login-data.ts
@@ -17,7 +17,8 @@ import {
   type SourceRowProvenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
-import { decryptOscryptValue, type DecryptionSettings } from "./oscrypt.js";
+import { decryptSecretField } from "./decrypted-field.js";
+import { schemeOf, type DecryptionSettings } from "./oscrypt.js";
 import {
   readLoginPasses,
   type LoginSchema,
@@ -137,47 +138,6 @@ interface SecretDescription {
 }
 
 /**
- * Decrypt an encrypted secret blob strictly within the opt-in gate. Disabled by
- * default: the secret stays `unavailable` with the historic typed reason. When
- * enabled the blob is dispatched offline by its own prefix, and every outcome
- * (plaintext, unsupported scheme, wrong key, malformed store, missing context,
- * or authentication failure) is a distinct typed state.
- */
-function decryptSecretValue(
-  value: Uint8Array,
-  profile: string,
-  decryption: DecryptionSettings,
-): Pick<
-  SecretDescription,
-  "secret" | "decryptionRoute" | "keyMaterialRecordId"
-> {
-  if (!decryption.enabled) {
-    return {
-      secret: unavailableField("encrypted_secret_without_key_material"),
-      decryptionRoute: absentField(),
-      keyMaterialRecordId: absentField(),
-    };
-  }
-  const outcome = decryptOscryptValue({
-    ciphertext: value,
-    profile,
-    keyMaterial: decryption.keyMaterial,
-  });
-  if (outcome.state === "unavailable") {
-    return {
-      secret: unavailableField(outcome.reason),
-      decryptionRoute: absentField(),
-      keyMaterialRecordId: absentField(),
-    };
-  }
-  return {
-    secret: valueField(Buffer.from(outcome.plaintext).toString("utf8")),
-    decryptionRoute: valueField(outcome.route),
-    keyMaterialRecordId: valueField(outcome.provenance.recordId),
-  };
-}
-
-/**
  * Describe the encrypted secret wrapper without ever attempting to read the
  * plaintext. A stored secret is always reported `unavailable` with the typed
  * reason `encrypted_secret_without_key_material`; an empty or missing blob is
@@ -220,20 +180,19 @@ function describeSecret(
       keyMaterialRecordId: absentField(),
     };
   }
-  const head = value.subarray(0, 3);
-  const ascii = Buffer.from(head).toString("latin1");
-  const recognizedScheme = /^v\d\d$/.test(ascii);
-  const decrypted = decryptSecretValue(value, profile, decryption);
+  const schemeClass = schemeOf(value);
+  const recognizedScheme = schemeClass !== "legacy";
+  const decrypted = decryptSecretField(value, profile, decryption);
   return {
-    secret: decrypted.secret,
+    secret: decrypted.value,
     scheme: recognizedScheme
-      ? valueField(ascii)
+      ? valueField(schemeClass)
       : unavailableField("unsupported_value"),
     prefix: recognizedScheme
-      ? valueField(ascii)
-      : valueField(Buffer.from(head).toString("hex")),
+      ? valueField(schemeClass)
+      : valueField(Buffer.from(value.subarray(0, 3)).toString("hex")),
     byteLength: valueField(value.length.toString()),
-    decryptionRoute: decrypted.decryptionRoute,
+    decryptionRoute: decrypted.route,
     keyMaterialRecordId: decrypted.keyMaterialRecordId,
   };
 }

--- a/core/src/login-data.ts
+++ b/core/src/login-data.ts
@@ -138,11 +138,12 @@ interface SecretDescription {
 }
 
 /**
- * Describe the encrypted secret wrapper without ever attempting to read the
- * plaintext. A stored secret is always reported `unavailable` with the typed
- * reason `encrypted_secret_without_key_material`; an empty or missing blob is
- * `absent`. The wrapper prefix (for example `v10`, `v11`, `v20`) and byte
- * length are retained as metadata so an investigator can classify the scheme.
+ * Describe the encrypted secret wrapper and resolve the secret through the
+ * shared opt-in decrypt gate. With decryption disabled (the default) the secret
+ * stays `unavailable` with the typed reason `encrypted_secret_without_key_material`;
+ * an empty or missing blob is `absent`. The wrapper prefix (for example `v10`,
+ * `v11`, `v20`) and byte length are always retained as metadata so an
+ * investigator can classify the scheme even when the secret is not disclosed.
  */
 function describeSecret(
   value: RawLoginValue,

--- a/core/src/login-data.ts
+++ b/core/src/login-data.ts
@@ -17,6 +17,7 @@ import {
   type SourceRowProvenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
+import { decryptOscryptValue, type DecryptionSettings } from "./oscrypt.js";
 import {
   readLoginPasses,
   type LoginSchema,
@@ -131,6 +132,49 @@ interface SecretDescription {
   readonly scheme: FieldState<string>;
   readonly prefix: FieldState<string>;
   readonly byteLength: FieldState<string>;
+  readonly decryptionRoute: FieldState<string>;
+  readonly keyMaterialRecordId: FieldState<string>;
+}
+
+/**
+ * Decrypt an encrypted secret blob strictly within the opt-in gate. Disabled by
+ * default: the secret stays `unavailable` with the historic typed reason. When
+ * enabled the blob is dispatched offline by its own prefix, and every outcome
+ * (plaintext, unsupported scheme, wrong key, malformed store, missing context,
+ * or authentication failure) is a distinct typed state.
+ */
+function decryptSecretValue(
+  value: Uint8Array,
+  profile: string,
+  decryption: DecryptionSettings,
+): Pick<
+  SecretDescription,
+  "secret" | "decryptionRoute" | "keyMaterialRecordId"
+> {
+  if (!decryption.enabled) {
+    return {
+      secret: unavailableField("encrypted_secret_without_key_material"),
+      decryptionRoute: absentField(),
+      keyMaterialRecordId: absentField(),
+    };
+  }
+  const outcome = decryptOscryptValue({
+    ciphertext: value,
+    profile,
+    keyMaterial: decryption.keyMaterial,
+  });
+  if (outcome.state === "unavailable") {
+    return {
+      secret: unavailableField(outcome.reason),
+      decryptionRoute: absentField(),
+      keyMaterialRecordId: absentField(),
+    };
+  }
+  return {
+    secret: valueField(Buffer.from(outcome.plaintext).toString("utf8")),
+    decryptionRoute: valueField(outcome.route),
+    keyMaterialRecordId: valueField(outcome.provenance.recordId),
+  };
 }
 
 /**
@@ -143,6 +187,8 @@ interface SecretDescription {
 function describeSecret(
   value: RawLoginValue,
   columnPresent: boolean,
+  profile: string,
+  decryption: DecryptionSettings,
 ): SecretDescription {
   if (!columnPresent || value === undefined || value === null) {
     return {
@@ -150,6 +196,8 @@ function describeSecret(
       scheme: absentField(),
       prefix: absentField(),
       byteLength: absentField(),
+      decryptionRoute: absentField(),
+      keyMaterialRecordId: absentField(),
     };
   }
   if (!(value instanceof Uint8Array)) {
@@ -158,6 +206,8 @@ function describeSecret(
       scheme: unavailableField("unsupported_value"),
       prefix: unavailableField("unsupported_value"),
       byteLength: unavailableField("unsupported_value"),
+      decryptionRoute: absentField(),
+      keyMaterialRecordId: absentField(),
     };
   }
   if (value.length === 0) {
@@ -166,13 +216,16 @@ function describeSecret(
       scheme: absentField(),
       prefix: absentField(),
       byteLength: valueField("0"),
+      decryptionRoute: absentField(),
+      keyMaterialRecordId: absentField(),
     };
   }
   const head = value.subarray(0, 3);
   const ascii = Buffer.from(head).toString("latin1");
   const recognizedScheme = /^v\d\d$/.test(ascii);
+  const decrypted = decryptSecretValue(value, profile, decryption);
   return {
-    secret: unavailableField("encrypted_secret_without_key_material"),
+    secret: decrypted.secret,
     scheme: recognizedScheme
       ? valueField(ascii)
       : unavailableField("unsupported_value"),
@@ -180,6 +233,8 @@ function describeSecret(
       ? valueField(ascii)
       : valueField(Buffer.from(head).toString("hex")),
     byteLength: valueField(value.length.toString()),
+    decryptionRoute: decrypted.decryptionRoute,
+    keyMaterialRecordId: decrypted.keyMaterialRecordId,
   };
 }
 
@@ -213,6 +268,7 @@ function buildCredentials(options: {
   readonly profile: string;
   readonly manifest: ManifestIdentity;
   readonly declaredTimezone: string;
+  readonly decryption: DecryptionSettings;
 }): BuiltCredential[] {
   return options.rows.map((row) => {
     if (row.id === null) {
@@ -225,7 +281,12 @@ function buildCredentials(options: {
     const has = (column: string): boolean => options.schema.columns.has(column);
     const get = (column: string): RawLoginValue =>
       row.values.get(column) ?? null;
-    const secret = describeSecret(get("password_value"), has("password_value"));
+    const secret = describeSecret(
+      get("password_value"),
+      has("password_value"),
+      options.profile,
+      options.decryption,
+    );
     const originUrl = preservedString(get("origin_url"));
     const signonRealm = preservedString(get("signon_realm"));
     const usernameValue = preservedString(get("username_value"));
@@ -254,6 +315,8 @@ function buildCredentials(options: {
       secretEncryptionScheme: secret.scheme,
       secretEncryptionPrefix: secret.prefix,
       secretByteLength: secret.byteLength,
+      secretDecryptionRoute: secret.decryptionRoute,
+      secretKeyMaterialRecordId: secret.keyMaterialRecordId,
       dateCreated,
       dateLastUsed,
       datePasswordModified: timestampField(
@@ -340,6 +403,7 @@ export async function analyseLoginDataProfile(options: {
   readonly profile: string;
   readonly workingCopyPath: string;
   readonly declaredTimezone: string;
+  readonly decryption: DecryptionSettings;
 }): Promise<LoginDataArtifactWrite> {
   const databasePath =
     options.profile === "." ? "Login Data" : `${options.profile}/Login Data`;
@@ -453,6 +517,7 @@ export async function analyseLoginDataProfile(options: {
       profile: options.profile,
       manifest,
       declaredTimezone: options.declaredTimezone,
+      decryption: options.decryption,
     });
     const recovered =
       passes.recovered === null
@@ -464,6 +529,7 @@ export async function analyseLoginDataProfile(options: {
             profile: options.profile,
             manifest: recoveredManifest as ManifestIdentity,
             declaredTimezone: options.declaredTimezone,
+            decryption: options.decryption,
           });
     return {
       sourceId: options.source.sourceId,

--- a/core/src/oscrypt.ts
+++ b/core/src/oscrypt.ts
@@ -454,8 +454,11 @@ function decryptWith(
  * Decrypt one stored blob offline. Dispatch is per row, driven by the blob's
  * own scheme prefix, so a database mixing `v10`, `v11`, and `v20` rows is
  * handled correctly. `v20` App-Bound blobs are never unwrapped. When no
- * authorized key material matches the row, or every candidate fails, the most
- * specific typed reason is returned so distinct failure modes stay separable.
+ * authorized key material matches the row it is `no_authorized_key_material`;
+ * when candidates match but every attempt fails, the last attempt's typed
+ * reason is returned so distinct failure modes stay separable. An unexpected
+ * (non-decryption) error is never masked as a wrong key; it propagates so the
+ * parser records it plainly instead of a guessed forensic outcome.
  */
 export function decryptOscryptValue(options: {
   readonly ciphertext: Uint8Array;
@@ -487,7 +490,7 @@ export function decryptOscryptValue(options: {
         failure = error.reason;
         continue;
       }
-      failure = "decryption_wrong_key";
+      throw error;
     }
   }
   return { state: "unavailable", reason: failure };

--- a/core/src/oscrypt.ts
+++ b/core/src/oscrypt.ts
@@ -1,0 +1,494 @@
+import {
+  createDecipheriv,
+  createHmac,
+  pbkdf2Sync,
+  timingSafeEqual,
+} from "node:crypto";
+
+/**
+ * Offline OSCrypt decryption engine.
+ *
+ * This module is a pure, offline function library. It performs NO input or
+ * output: no network, no provider daemons, no live suspect key store, and it
+ * never touches Source bytes. It receives already-copied ciphertext and
+ * authorized key material (resolved by {@link ./key-material}) and returns a
+ * typed decryption outcome per row. Decryption is only ever attempted when an
+ * authorized investigator has opted in and supplied or captured key material
+ * with Provenance; the caller enforces that gate.
+ *
+ * Chromium wraps each stored secret with a scheme prefix so a mixed-version
+ * database can be dispatched row by row:
+ *
+ * - `v10` / `v11`: on Linux and macOS an AES-128-CBC blob keyed by a row key the
+ *   provider (Linux basic password, GNOME Keyring, KWallet, or the macOS
+ *   Keychain) derives; on Windows a `v10` blob is AES-256-GCM keyed by the
+ *   DPAPI-protected key from `Local State`.
+ * - `v20`: Google App-Bound encryption. Never unwrapped; always a stable typed
+ *   unavailable reason.
+ * - No recognised prefix: a legacy Windows DPAPI blob, unwrapped offline only
+ *   when the operator supplies the decrypted DPAPI master key.
+ */
+
+/**
+ * A supported decryption route. Each route names an evidenced provider path and
+ * fixes the algorithm the engine applies. `linux-basic`, `gnome-keyring`,
+ * `kwallet`, and `macos-keychain` all resolve to AES-128-CBC and differ only in
+ * how their row key is derived; `windows-dpapi-v10` is AES-256-GCM;
+ * `windows-dpapi-legacy` is a raw DPAPI blob.
+ */
+export type OscryptRoute =
+  | "linux-basic"
+  | "gnome-keyring"
+  | "kwallet"
+  | "macos-keychain"
+  | "windows-dpapi-v10"
+  | "windows-dpapi-legacy";
+
+export const OSCRYPT_ROUTES: readonly OscryptRoute[] = [
+  "linux-basic",
+  "gnome-keyring",
+  "kwallet",
+  "macos-keychain",
+  "windows-dpapi-v10",
+  "windows-dpapi-legacy",
+] as const;
+
+/** The scheme a stored blob declares by its leading prefix. */
+export type OscryptScheme = "v10" | "v11" | "v20" | "legacy";
+
+/**
+ * Distinct, stable typed reasons for a value that stays unavailable after an
+ * opted-in decryption attempt. They keep wrong credentials, malformed stores,
+ * missing context, authentication failures, and unsupported routes separable
+ * (never a guessed unwrap and never a blank).
+ */
+export type DecryptionFailureReason =
+  | "unsupported_app_bound_v20"
+  | "unsupported_encryption_route"
+  | "no_authorized_key_material"
+  | "decryption_wrong_key"
+  | "decryption_malformed_ciphertext"
+  | "decryption_missing_context"
+  | "decryption_authentication_failed";
+
+/**
+ * Provenance for a single unit of authorized key material. Every decrypted
+ * value cites the record it was authorized by, so a Finding never asserts a
+ * plaintext secret without a resolvable chain of custody.
+ */
+export interface KeyMaterialProvenance {
+  /** `supplied` (operator-authored) or `captured` (sealed by the Collector). */
+  readonly origin: "supplied" | "captured";
+  readonly recordId: string;
+  readonly route: OscryptRoute;
+  readonly rowPrefix: "" | "v10" | "v11" | "v20";
+  readonly providerPlatform: "darwin" | "linux" | "windows" | "unknown";
+  readonly providerName: string;
+  readonly providerItem: string;
+  readonly providerScope: string;
+  /** Profile the material is scoped to, or `null` when it applies to all. */
+  readonly profileScope: string | null;
+  /** SHA-256 evidence references from the sealed record, when present. */
+  readonly evidenceSha256: readonly string[];
+}
+
+/**
+ * Resolved, authorized key material ready for offline use. The engine never
+ * derives this from a live store; {@link ./key-material} produces it from
+ * operator-supplied input or from unsealed Collector-captured records.
+ */
+export interface AuthorizedKeyMaterial {
+  readonly provenance: KeyMaterialProvenance;
+  /**
+   * `row_key`: a pre-derived symmetric row key (16 bytes for CBC routes, 32 for
+   * the Windows GCM route). `passphrase`: a provider secret the engine expands
+   * with the route's evidenced PBKDF2 parameters. `dpapi_master_key`: a
+   * decrypted DPAPI master key for the legacy route.
+   */
+  readonly keyKind: "row_key" | "passphrase" | "dpapi_master_key";
+  readonly secret: Uint8Array;
+  /**
+   * The legacy DPAPI master-key GUID this material unwraps, lower-case. When
+   * present, a blob whose master-key GUID differs is `decryption_missing_context`.
+   */
+  readonly masterKeyGuid?: string;
+}
+
+/**
+ * Decryption configuration threaded from the `analyse` command into each
+ * parser. `enabled` is the explicit operator opt-in; it is `false` by default,
+ * and while it is `false` no key material is consulted and encrypted values
+ * stay `unavailable` with the historic `encrypted_secret_without_key_material`
+ * reason.
+ */
+export interface DecryptionSettings {
+  readonly enabled: boolean;
+  readonly keyMaterial: readonly AuthorizedKeyMaterial[];
+}
+
+export const DECRYPTION_DISABLED: DecryptionSettings = {
+  enabled: false,
+  keyMaterial: [],
+};
+
+export type DecryptionOutcome =
+  | {
+      readonly state: "value";
+      readonly plaintext: Uint8Array;
+      readonly route: OscryptRoute;
+      readonly provenance: KeyMaterialProvenance;
+    }
+  | { readonly state: "unavailable"; readonly reason: DecryptionFailureReason };
+
+const CBC_ROUTES: ReadonlySet<OscryptRoute> = new Set([
+  "linux-basic",
+  "gnome-keyring",
+  "kwallet",
+  "macos-keychain",
+]);
+
+const CBC_IV = Buffer.alloc(16, 0x20);
+const CBC_SALT = Buffer.from("saltysalt", "latin1");
+const LINUX_BASIC_PASSWORD = Buffer.from("peanuts", "latin1");
+
+class DecryptionFailure extends Error {
+  public readonly reason: DecryptionFailureReason;
+
+  public constructor(reason: DecryptionFailureReason) {
+    super(reason);
+    this.name = "DecryptionFailure";
+    this.reason = reason;
+  }
+}
+
+/**
+ * Classify a stored blob by its leading three bytes. A `v10`, `v11`, or `v20`
+ * ASCII prefix selects the matching scheme; anything else is treated as a
+ * legacy blob so the row can still be dispatched to the DPAPI route.
+ */
+export function schemeOf(ciphertext: Uint8Array): OscryptScheme {
+  if (ciphertext.length >= 3) {
+    const prefix = String.fromCharCode(
+      ciphertext[0] ?? 0,
+      ciphertext[1] ?? 0,
+      ciphertext[2] ?? 0,
+    );
+    if (prefix === "v10") {
+      return "v10";
+    }
+    if (prefix === "v11") {
+      return "v11";
+    }
+    if (prefix === "v20") {
+      return "v20";
+    }
+  }
+  return "legacy";
+}
+
+function schemePrefix(scheme: OscryptScheme): "" | "v10" | "v11" | "v20" {
+  return scheme === "legacy" ? "" : scheme;
+}
+
+/**
+ * Whether a piece of key material can be dispatched to a row of this scheme.
+ * The row prefix must match (or the material must be prefix-agnostic), and the
+ * route family must be compatible with the scheme: legacy blobs only ever go to
+ * the DPAPI legacy route, and the DPAPI legacy route never claims a v-prefixed
+ * blob.
+ */
+function keyMaterialMatches(
+  material: AuthorizedKeyMaterial,
+  scheme: OscryptScheme,
+  profile: string,
+): boolean {
+  const provenance = material.provenance;
+  if (provenance.profileScope !== null && provenance.profileScope !== profile) {
+    return false;
+  }
+  if (
+    provenance.rowPrefix !== "" &&
+    provenance.rowPrefix !== schemePrefix(scheme)
+  ) {
+    return false;
+  }
+  if (scheme === "legacy") {
+    return provenance.route === "windows-dpapi-legacy";
+  }
+  return provenance.route !== "windows-dpapi-legacy";
+}
+
+function deriveCbcKey(material: AuthorizedKeyMaterial): Buffer {
+  if (material.keyKind === "row_key") {
+    if (material.secret.length !== 16) {
+      throw new DecryptionFailure("decryption_missing_context");
+    }
+    return Buffer.from(material.secret);
+  }
+  if (material.keyKind !== "passphrase") {
+    throw new DecryptionFailure("unsupported_encryption_route");
+  }
+  const iterations = material.provenance.route === "macos-keychain" ? 1003 : 1;
+  const password =
+    material.provenance.route === "linux-basic"
+      ? LINUX_BASIC_PASSWORD
+      : Buffer.from(material.secret);
+  return pbkdf2Sync(password, CBC_SALT, iterations, 16, "sha1");
+}
+
+function pkcs7Unpad(buffer: Buffer): Buffer {
+  const padLength = buffer[buffer.length - 1] ?? 0;
+  if (padLength < 1 || padLength > 16 || padLength > buffer.length) {
+    throw new DecryptionFailure("decryption_wrong_key");
+  }
+  for (
+    let index = buffer.length - padLength;
+    index < buffer.length;
+    index += 1
+  ) {
+    if (buffer[index] !== padLength) {
+      throw new DecryptionFailure("decryption_wrong_key");
+    }
+  }
+  return buffer.subarray(0, buffer.length - padLength);
+}
+
+function decryptCbc(
+  material: AuthorizedKeyMaterial,
+  ciphertext: Uint8Array,
+): Uint8Array {
+  const body = ciphertext.subarray(3);
+  if (body.length === 0 || body.length % 16 !== 0) {
+    throw new DecryptionFailure("decryption_malformed_ciphertext");
+  }
+  const key = deriveCbcKey(material);
+  const decipher = createDecipheriv("aes-128-cbc", key, CBC_IV);
+  decipher.setAutoPadding(false);
+  const padded = Buffer.concat([decipher.update(body), decipher.final()]);
+  return pkcs7Unpad(padded);
+}
+
+function decryptGcm(
+  material: AuthorizedKeyMaterial,
+  ciphertext: Uint8Array,
+): Uint8Array {
+  if (material.keyKind !== "row_key" || material.secret.length !== 32) {
+    throw new DecryptionFailure("decryption_missing_context");
+  }
+  // v10 (3) + nonce (12) + ciphertext + tag (16).
+  if (ciphertext.length < 3 + 12 + 16) {
+    throw new DecryptionFailure("decryption_malformed_ciphertext");
+  }
+  const nonce = ciphertext.subarray(3, 15);
+  const tag = ciphertext.subarray(ciphertext.length - 16);
+  const body = ciphertext.subarray(15, ciphertext.length - 16);
+  const decipher = createDecipheriv(
+    "aes-256-gcm",
+    Buffer.from(material.secret),
+    nonce,
+  );
+  decipher.setAuthTag(Buffer.from(tag));
+  try {
+    return Buffer.concat([decipher.update(body), decipher.final()]);
+  } catch {
+    // A failed tag means the row key does not authenticate this ciphertext.
+    throw new DecryptionFailure("decryption_wrong_key");
+  }
+}
+
+interface LegacyDpapiBlob {
+  readonly masterKeyGuid: string;
+  readonly salt: Buffer;
+  readonly hmacSalt: Buffer;
+  readonly ciphertext: Buffer;
+  readonly sign: Buffer;
+  /** Region covered by the integrity signature. */
+  readonly signed: Buffer;
+}
+
+function readGuid(view: Buffer, offset: number): string {
+  // A DPAPI GUID is stored as little-endian Data1/2/3 then big-endian Data4.
+  const d1 = view.readUInt32LE(offset).toString(16).padStart(8, "0");
+  const d2 = view
+    .readUInt16LE(offset + 4)
+    .toString(16)
+    .padStart(4, "0");
+  const d3 = view
+    .readUInt16LE(offset + 6)
+    .toString(16)
+    .padStart(4, "0");
+  const d4 = view.subarray(offset + 8, offset + 10).toString("hex");
+  const d5 = view.subarray(offset + 10, offset + 16).toString("hex");
+  return `${d1}-${d2}-${d3}-${d4}-${d5}`;
+}
+
+/**
+ * Parse a legacy Windows DPAPI blob. The layout mirrors the documented
+ * `DATA_BLOB` structure used by CryptProtectData. A structural problem is a
+ * `decryption_malformed_ciphertext` failure; the caller never guesses.
+ */
+function parseLegacyDpapiBlob(blob: Uint8Array): LegacyDpapiBlob {
+  const view = Buffer.from(blob);
+  try {
+    let offset = 4; // dwVersion
+    offset += 16; // provider GUID
+    const signedStart = offset;
+    offset += 4; // master-key structure version
+    const masterKeyGuid = readGuid(view, offset);
+    offset += 16;
+    offset += 4; // flags
+    const descriptionLength = view.readUInt32LE(offset);
+    offset += 4 + descriptionLength;
+    offset += 4; // crypt algorithm id
+    offset += 4; // crypt algorithm key length
+    const saltLength = view.readUInt32LE(offset);
+    offset += 4;
+    const salt = view.subarray(offset, offset + saltLength);
+    offset += saltLength;
+    const strongLength = view.readUInt32LE(offset);
+    offset += 4 + strongLength; // optional strong-password entropy
+    offset += 4; // hash algorithm id
+    offset += 4; // hash algorithm length
+    const hmacSaltLength = view.readUInt32LE(offset);
+    offset += 4;
+    const hmacSalt = view.subarray(offset, offset + hmacSaltLength);
+    offset += hmacSaltLength;
+    const cipherLength = view.readUInt32LE(offset);
+    offset += 4;
+    const ciphertext = view.subarray(offset, offset + cipherLength);
+    offset += cipherLength;
+    const signedEnd = offset;
+    const signLength = view.readUInt32LE(offset);
+    offset += 4;
+    const sign = view.subarray(offset, offset + signLength);
+    offset += signLength;
+    if (
+      offset !== view.length ||
+      saltLength === 0 ||
+      cipherLength === 0 ||
+      cipherLength % 16 !== 0
+    ) {
+      throw new DecryptionFailure("decryption_malformed_ciphertext");
+    }
+    return {
+      masterKeyGuid,
+      salt,
+      hmacSalt,
+      ciphertext,
+      sign,
+      signed: view.subarray(signedStart, signedEnd),
+    };
+  } catch (error) {
+    if (error instanceof DecryptionFailure) {
+      throw error;
+    }
+    throw new DecryptionFailure("decryption_malformed_ciphertext");
+  }
+}
+
+/**
+ * Unwrap a legacy Windows DPAPI blob offline with a decrypted master key. The
+ * derivation follows the documented AES-256 + SHA-512 CryptProtectData path:
+ * an HMAC session key over the blob salt yields the AES key and IV, and a
+ * second HMAC over the signed region proves the master key is authentic. A
+ * blob for a different master-key GUID is `decryption_missing_context`; a
+ * signature mismatch is `decryption_authentication_failed`.
+ */
+function decryptLegacyDpapi(
+  material: AuthorizedKeyMaterial,
+  ciphertext: Uint8Array,
+): Uint8Array {
+  if (material.keyKind !== "dpapi_master_key") {
+    throw new DecryptionFailure("decryption_missing_context");
+  }
+  const blob = parseLegacyDpapiBlob(ciphertext);
+  if (
+    material.masterKeyGuid !== undefined &&
+    material.masterKeyGuid.toLowerCase() !== blob.masterKeyGuid.toLowerCase()
+  ) {
+    throw new DecryptionFailure("decryption_missing_context");
+  }
+  const masterKey = Buffer.from(material.secret);
+  const sessionKey = createHmac("sha512", masterKey).update(blob.salt).digest();
+  const signKey = createHmac("sha512", masterKey)
+    .update(blob.hmacSalt)
+    .digest();
+  const expectedSign = createHmac("sha512", signKey)
+    .update(blob.signed)
+    .digest();
+  if (
+    blob.sign.length !== expectedSign.length ||
+    !timingSafeEqual(blob.sign, expectedSign)
+  ) {
+    throw new DecryptionFailure("decryption_authentication_failed");
+  }
+  const key = sessionKey.subarray(0, 32);
+  const iv = sessionKey.subarray(32, 48);
+  const decipher = createDecipheriv("aes-256-cbc", key, iv);
+  decipher.setAutoPadding(false);
+  const padded = Buffer.concat([
+    decipher.update(blob.ciphertext),
+    decipher.final(),
+  ]);
+  return pkcs7Unpad(padded);
+}
+
+function decryptWith(
+  material: AuthorizedKeyMaterial,
+  scheme: OscryptScheme,
+  ciphertext: Uint8Array,
+): Uint8Array {
+  if (material.provenance.route === "windows-dpapi-v10") {
+    return decryptGcm(material, ciphertext);
+  }
+  if (material.provenance.route === "windows-dpapi-legacy") {
+    return decryptLegacyDpapi(material, ciphertext);
+  }
+  if (CBC_ROUTES.has(material.provenance.route)) {
+    return decryptCbc(material, ciphertext);
+  }
+  throw new DecryptionFailure("unsupported_encryption_route");
+}
+
+/**
+ * Decrypt one stored blob offline. Dispatch is per row, driven by the blob's
+ * own scheme prefix, so a database mixing `v10`, `v11`, and `v20` rows is
+ * handled correctly. `v20` App-Bound blobs are never unwrapped. When no
+ * authorized key material matches the row, or every candidate fails, the most
+ * specific typed reason is returned so distinct failure modes stay separable.
+ */
+export function decryptOscryptValue(options: {
+  readonly ciphertext: Uint8Array;
+  readonly profile: string;
+  readonly keyMaterial: readonly AuthorizedKeyMaterial[];
+}): DecryptionOutcome {
+  const scheme = schemeOf(options.ciphertext);
+  if (scheme === "v20") {
+    return { state: "unavailable", reason: "unsupported_app_bound_v20" };
+  }
+  const candidates = options.keyMaterial.filter((material) =>
+    keyMaterialMatches(material, scheme, options.profile),
+  );
+  if (candidates.length === 0) {
+    return { state: "unavailable", reason: "no_authorized_key_material" };
+  }
+  let failure: DecryptionFailureReason = "no_authorized_key_material";
+  for (const material of candidates) {
+    try {
+      const plaintext = decryptWith(material, scheme, options.ciphertext);
+      return {
+        state: "value",
+        plaintext,
+        route: material.provenance.route,
+        provenance: material.provenance,
+      };
+    } catch (error) {
+      if (error instanceof DecryptionFailure) {
+        failure = error.reason;
+        continue;
+      }
+      failure = "decryption_wrong_key";
+    }
+  }
+  return { state: "unavailable", reason: failure };
+}

--- a/core/test/export-redaction.test.ts
+++ b/core/test/export-redaction.test.ts
@@ -18,8 +18,37 @@ describe("Extract redaction primitive", () => {
     expect(isSecretFieldName("Encrypted_Value")).toBe(true);
     expect(isSecretFieldName("cookie_value")).toBe(true);
     expect(isSecretFieldName("token")).toBe(true);
+    // A Cookie Finding's plaintext (or decrypted) secret lives in the field
+    // named exactly `value`; it is a secret by exact match.
+    expect(isSecretFieldName("value")).toBe(true);
     expect(isSecretFieldName("url")).toBe(false);
     expect(isSecretFieldName("visitTime")).toBe(false);
+    // The exact `value` rule must not over-match metadata fields.
+    expect(isSecretFieldName("encryptedValueByteLength")).toBe(false);
+    expect(isSecretFieldName("encryptedValueScheme")).toBe(false);
+  });
+
+  it("withholds a Cookie value (plaintext or decrypted) unless opted in", () => {
+    const fields: Readonly<Record<string, FieldState<unknown>>> = {
+      value: { state: "value", value: "session-token" },
+      encryptedValueByteLength: { state: "value", value: "48" },
+    };
+    const redacted = redactFields(fields, false);
+    expect(redacted.redactedCount).toBe(1);
+    expect(redacted.fields.value).toEqual({
+      state: "redacted",
+      reason: "plaintext_secret_withheld",
+      sha256: sha256(JSON.stringify("session-token")),
+    });
+    // Retained metadata is not a secret and stays disclosed.
+    expect(redacted.fields.encryptedValueByteLength).toBe(
+      fields.encryptedValueByteLength,
+    );
+    // With the explicit opt-in the value is disclosed.
+    expect(redactFields(fields, true).fields.value).toEqual({
+      state: "value",
+      value: "session-token",
+    });
   });
 
   it("withholds secret values by default while keeping them citable by hash", () => {

--- a/core/test/oscrypt.test.ts
+++ b/core/test/oscrypt.test.ts
@@ -1,0 +1,578 @@
+import {
+  createCipheriv,
+  createHmac,
+  diffieHellman,
+  generateKeyPairSync,
+  hkdfSync,
+  pbkdf2Sync,
+  randomBytes,
+} from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  decryptOscryptValue,
+  loadAuthorizedKeyMaterial,
+  schemeOf,
+  type AuthorizedKeyMaterial,
+  type KeyMaterialProvenance,
+  type OscryptRoute,
+} from "../src/index.js";
+import { associatedDataLine } from "../src/key-material.js";
+
+const CBC_IV = Buffer.alloc(16, 0x20);
+const CBC_SALT = Buffer.from("saltysalt", "latin1");
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+function pkcs7Pad(data: Buffer): Buffer {
+  const pad = 16 - (data.length % 16);
+  return Buffer.concat([data, Buffer.alloc(pad, pad)]);
+}
+
+function deriveCbcKey(route: OscryptRoute, passphrase: string): Buffer {
+  const iterations = route === "macos-keychain" ? 1003 : 1;
+  const secret = route === "linux-basic" ? "peanuts" : passphrase;
+  return pbkdf2Sync(secret, CBC_SALT, iterations, 16, "sha1");
+}
+
+function sealCbc(key: Buffer, prefix: string, plaintext: string): Uint8Array {
+  const cipher = createCipheriv("aes-128-cbc", key, CBC_IV);
+  cipher.setAutoPadding(false);
+  const body = Buffer.concat([
+    cipher.update(pkcs7Pad(Buffer.from(plaintext, "utf8"))),
+    cipher.final(),
+  ]);
+  return new Uint8Array(Buffer.concat([Buffer.from(prefix, "latin1"), body]));
+}
+
+function sealGcm(key: Buffer, plaintext: string): Uint8Array {
+  const nonce = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, nonce);
+  const body = Buffer.concat([
+    cipher.update(Buffer.from(plaintext, "utf8")),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return new Uint8Array(
+    Buffer.concat([Buffer.from("v10", "latin1"), nonce, body, tag]),
+  );
+}
+
+function provenance(
+  route: OscryptRoute,
+  rowPrefix: KeyMaterialProvenance["rowPrefix"],
+  overrides: Partial<KeyMaterialProvenance> = {},
+): KeyMaterialProvenance {
+  return {
+    origin: "supplied",
+    recordId: `test-${route}`,
+    route,
+    rowPrefix,
+    providerPlatform: "unknown",
+    providerName: "test",
+    providerItem: "test",
+    providerScope: "test",
+    profileScope: null,
+    evidenceSha256: [],
+    ...overrides,
+  };
+}
+
+describe("offline OSCrypt decryption engine", () => {
+  it("classifies a blob by its own prefix", () => {
+    expect(schemeOf(Buffer.from("v10abc"))).toBe("v10");
+    expect(schemeOf(Buffer.from("v11abc"))).toBe("v11");
+    expect(schemeOf(Buffer.from("v20abc"))).toBe("v20");
+    expect(schemeOf(Buffer.from([0x01, 0x00, 0x00, 0x00]))).toBe("legacy");
+  });
+
+  // AC1: with no opt-in the caller never calls the engine; with opt-in but no
+  // matching material the row stays unavailable with a distinct typed reason.
+  it("returns no_authorized_key_material when nothing matches", () => {
+    const outcome = decryptOscryptValue({
+      ciphertext: sealCbc(deriveCbcKey("linux-basic", ""), "v10", "hunter2"),
+      profile: "Default",
+      keyMaterial: [],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "no_authorized_key_material",
+    });
+  });
+
+  // AC3: Linux basic, GNOME Keyring, KWallet, and macOS Keychain all resolve to
+  // AES-128-CBC and round-trip from a passphrase within their evidenced bounds.
+  it.each([
+    ["linux-basic", "v10", "peanuts"],
+    ["gnome-keyring", "v11", "keyring-secret"],
+    ["kwallet", "v11", "kwallet-secret"],
+    ["macos-keychain", "v10", "keychain-secret"],
+  ] as const)("decrypts the %s route", (route, prefix, passphrase) => {
+    const key = deriveCbcKey(route, passphrase);
+    const ciphertext = sealCbc(key, prefix, "s3cr3t-value");
+    const material: AuthorizedKeyMaterial = {
+      provenance: provenance(route, prefix),
+      keyKind: "passphrase",
+      secret: new Uint8Array(Buffer.from(passphrase, "utf8")),
+    };
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [material],
+    });
+    expect(outcome.state).toBe("value");
+    if (outcome.state === "value") {
+      expect(Buffer.from(outcome.plaintext).toString("utf8")).toBe(
+        "s3cr3t-value",
+      );
+      expect(outcome.route).toBe(route);
+    }
+  });
+
+  it("decrypts a pre-derived CBC row key", () => {
+    const key = deriveCbcKey("gnome-keyring", "abc");
+    const ciphertext = sealCbc(key, "v11", "row-key-plaintext");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("gnome-keyring", "v11"),
+          keyKind: "row_key",
+          secret: new Uint8Array(key),
+        },
+      ],
+    });
+    expect(outcome.state).toBe("value");
+  });
+
+  // AC3: Windows v10 AES-256-GCM route.
+  it("decrypts the Windows v10 GCM route", () => {
+    const key = randomBytes(32);
+    const ciphertext = sealGcm(key, "windows-secret");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-v10", "v10"),
+          keyKind: "row_key",
+          secret: new Uint8Array(key),
+        },
+      ],
+    });
+    expect(outcome.state).toBe("value");
+    if (outcome.state === "value") {
+      expect(Buffer.from(outcome.plaintext).toString("utf8")).toBe(
+        "windows-secret",
+      );
+    }
+  });
+
+  // AC2: a mixed-version database dispatches each row independently by prefix.
+  it("dispatches mixed v10 and v11 rows independently", () => {
+    const cbcKey = deriveCbcKey("gnome-keyring", "pw");
+    const gcmKey = randomBytes(32);
+    const material: AuthorizedKeyMaterial[] = [
+      {
+        provenance: provenance("gnome-keyring", "v11"),
+        keyKind: "row_key",
+        secret: new Uint8Array(cbcKey),
+      },
+      {
+        provenance: provenance("windows-dpapi-v10", "v10"),
+        keyKind: "row_key",
+        secret: new Uint8Array(gcmKey),
+      },
+    ];
+    const v11 = decryptOscryptValue({
+      ciphertext: sealCbc(cbcKey, "v11", "linux-row"),
+      profile: "Default",
+      keyMaterial: material,
+    });
+    const v10 = decryptOscryptValue({
+      ciphertext: sealGcm(gcmKey, "windows-row"),
+      profile: "Default",
+      keyMaterial: material,
+    });
+    expect(v11.state).toBe("value");
+    expect(v10.state).toBe("value");
+  });
+
+  // AC4: v20 App-Bound is never unwrapped, even with key material present.
+  it("never unwraps a v20 App-Bound blob", () => {
+    const outcome = decryptOscryptValue({
+      ciphertext: new Uint8Array(Buffer.from("v20deadbeef", "latin1")),
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-v10", "v10"),
+          keyKind: "row_key",
+          secret: new Uint8Array(randomBytes(32)),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "unsupported_app_bound_v20",
+    });
+  });
+
+  // AC5: wrong credentials, malformed stores, and missing context stay distinct.
+  it("reports a wrong CBC key as decryption_wrong_key", () => {
+    const ciphertext = sealCbc(
+      deriveCbcKey("gnome-keyring", "right"),
+      "v11",
+      "value",
+    );
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("gnome-keyring", "v11"),
+          keyKind: "row_key",
+          secret: new Uint8Array(deriveCbcKey("gnome-keyring", "wrong")),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "decryption_wrong_key",
+    });
+  });
+
+  it("reports a wrong GCM key as decryption_wrong_key", () => {
+    const ciphertext = sealGcm(randomBytes(32), "value");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-v10", "v10"),
+          keyKind: "row_key",
+          secret: new Uint8Array(randomBytes(32)),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "decryption_wrong_key",
+    });
+  });
+
+  it("reports a malformed CBC blob distinctly", () => {
+    const outcome = decryptOscryptValue({
+      ciphertext: new Uint8Array(Buffer.from("v11short", "latin1")),
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("gnome-keyring", "v11"),
+          keyKind: "row_key",
+          secret: new Uint8Array(deriveCbcKey("gnome-keyring", "pw")),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "decryption_malformed_ciphertext",
+    });
+  });
+
+  it("scopes key material to its Profile", () => {
+    const key = deriveCbcKey("gnome-keyring", "pw");
+    const material: AuthorizedKeyMaterial = {
+      provenance: provenance("gnome-keyring", "v11", {
+        profileScope: "Default",
+      }),
+      keyKind: "row_key",
+      secret: new Uint8Array(key),
+    };
+    const ciphertext = sealCbc(key, "v11", "value");
+    expect(
+      decryptOscryptValue({
+        ciphertext,
+        profile: "Profile 1",
+        keyMaterial: [material],
+      }),
+    ).toEqual({ state: "unavailable", reason: "no_authorized_key_material" });
+    expect(
+      decryptOscryptValue({
+        ciphertext,
+        profile: "Default",
+        keyMaterial: [material],
+      }).state,
+    ).toBe("value");
+  });
+});
+
+// A faithful legacy DPAPI blob (AES-256 + SHA-512), built to prove the offline
+// unwrap end to end without any live key store.
+function buildLegacyDpapiBlob(
+  masterKey: Buffer,
+  masterKeyGuid: Buffer,
+  plaintext: string,
+): Uint8Array {
+  const salt = randomBytes(16);
+  const hmacSalt = randomBytes(16);
+  const sessionKey = createHmac("sha512", masterKey).update(salt).digest();
+  const cipher = createCipheriv(
+    "aes-256-cbc",
+    sessionKey.subarray(0, 32),
+    sessionKey.subarray(32, 48),
+  );
+  cipher.setAutoPadding(false);
+  const ciphertext = Buffer.concat([
+    cipher.update(pkcs7Pad(Buffer.from(plaintext, "utf8"))),
+    cipher.final(),
+  ]);
+  const u32 = (value: number): Buffer => {
+    const buffer = Buffer.alloc(4);
+    buffer.writeUInt32LE(value);
+    return buffer;
+  };
+  const lengthPrefixed = (value: Buffer): Buffer =>
+    Buffer.concat([u32(value.length), value]);
+  const signedBody = Buffer.concat([
+    u32(1), // master-key structure version
+    masterKeyGuid,
+    u32(0), // flags
+    u32(0), // description length
+    u32(0x6610), // AES-256 alg id
+    u32(256), // key length bits
+    lengthPrefixed(salt),
+    u32(0), // strong entropy length
+    u32(0x800e), // SHA-512 alg id
+    u32(512), // hash length bits
+    lengthPrefixed(hmacSalt),
+    lengthPrefixed(ciphertext),
+  ]);
+  const signKey = createHmac("sha512", masterKey).update(hmacSalt).digest();
+  const sign = createHmac("sha512", signKey).update(signedBody).digest();
+  return new Uint8Array(
+    Buffer.concat([
+      u32(1), // dwVersion
+      randomBytes(16), // provider GUID
+      signedBody,
+      lengthPrefixed(sign),
+    ]),
+  );
+}
+
+describe("offline legacy Windows DPAPI route", () => {
+  const masterKey = randomBytes(64);
+  const guid = randomBytes(16);
+
+  it("unwraps a legacy DPAPI blob with a supplied master key", () => {
+    const ciphertext = buildLegacyDpapiBlob(masterKey, guid, "legacy-secret");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-legacy", ""),
+          keyKind: "dpapi_master_key",
+          secret: new Uint8Array(masterKey),
+        },
+      ],
+    });
+    expect(outcome.state).toBe("value");
+    if (outcome.state === "value") {
+      expect(Buffer.from(outcome.plaintext).toString("utf8")).toBe(
+        "legacy-secret",
+      );
+      expect(outcome.route).toBe("windows-dpapi-legacy");
+    }
+  });
+
+  it("reports a wrong master key as decryption_authentication_failed", () => {
+    const ciphertext = buildLegacyDpapiBlob(masterKey, guid, "legacy-secret");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-legacy", ""),
+          keyKind: "dpapi_master_key",
+          secret: new Uint8Array(randomBytes(64)),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "decryption_authentication_failed",
+    });
+  });
+
+  it("reports a malformed DPAPI blob distinctly", () => {
+    const outcome = decryptOscryptValue({
+      ciphertext: new Uint8Array(randomBytes(24)),
+      profile: "Default",
+      keyMaterial: [
+        {
+          provenance: provenance("windows-dpapi-legacy", ""),
+          keyKind: "dpapi_master_key",
+          secret: new Uint8Array(masterKey),
+        },
+      ],
+    });
+    expect(outcome).toEqual({
+      state: "unavailable",
+      reason: "decryption_malformed_ciphertext",
+    });
+  });
+});
+
+describe("captured key material contract", () => {
+  it("unseals a Collector-sealed row key with the recipient private key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-keymat-"));
+    temporaryRoots.push(root);
+    const recipient = generateKeyPairSync("x25519");
+    const rowKey = pbkdf2Sync("keyring-secret", CBC_SALT, 1, 16, "sha1");
+
+    const record = {
+      schema_version: "forensix/key-material-record/1" as const,
+      record_id: "udd-0-default",
+      capture_state: "captured" as const,
+      key_kind: "oscrypt_row_key" as const,
+      usable_row_key: true,
+      provider: {
+        platform: "linux" as const,
+        name: "gnome-keyring",
+        item: "Chrome Safe Storage",
+        scope: "user",
+      },
+      context: [{ name: "profile", value: "Default" }],
+      policy: { row_prefix: "v11" as const, support: "supported" as const },
+      evidence: [],
+      sealed_material: null as unknown,
+    };
+    const aad = Buffer.from(associatedDataLine(record as never), "utf8");
+
+    const ephemeral = generateKeyPairSync("x25519");
+    const shared = diffieHellman({
+      privateKey: ephemeral.privateKey,
+      publicKey: recipient.publicKey,
+    });
+    const salt = randomBytes(16);
+    const sealKey = Buffer.from(
+      hkdfSync("sha256", shared, salt, "forensix/key-material-seal/1", 32),
+    );
+    const nonce = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", sealKey, nonce);
+    cipher.setAAD(aad);
+    const sealedBody = Buffer.concat([cipher.update(rowKey), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    const ephemeralRaw = ephemeral.publicKey
+      .export({ type: "spki", format: "der" })
+      .subarray(-32);
+
+    const sealedRecord = {
+      ...record,
+      sealed_material: {
+        algorithm: "x25519-hkdf-sha256-aes-256-gcm",
+        recipient_fingerprint: `sha256:${"0".repeat(64)}`,
+        ephemeral_public_key: Buffer.from(ephemeralRaw).toString("base64"),
+        salt: salt.toString("base64"),
+        nonce: nonce.toString("base64"),
+        ciphertext: Buffer.concat([sealedBody, tag]).toString("base64"),
+        associated_data_sha256: "0".repeat(64),
+      },
+    };
+
+    const bundlePath = join(root, "key-material.json");
+    const keyPath = join(root, "recipient.pem");
+    await writeFile(
+      bundlePath,
+      JSON.stringify({
+        schema: "forensix/key-material-bundle/1",
+        records: [sealedRecord],
+      }),
+    );
+    await writeFile(
+      keyPath,
+      recipient.privateKey.export({ type: "pkcs8", format: "pem" }) as string,
+    );
+
+    const resolved = loadAuthorizedKeyMaterial({
+      keyMaterialPath: bundlePath,
+      recipientKeyPath: keyPath,
+    });
+    expect(resolved.issues).toEqual([]);
+    expect(resolved.material).toHaveLength(1);
+    const material = resolved.material[0];
+    expect(material?.provenance.route).toBe("gnome-keyring");
+    expect(material?.provenance.profileScope).toBe("Default");
+    expect(
+      Buffer.from(material?.secret ?? new Uint8Array()).equals(rowKey),
+    ).toBe(true);
+
+    // The unsealed row key decrypts a v11 blob end to end.
+    const ciphertext = sealCbc(rowKey, "v11", "captured-secret");
+    const outcome = decryptOscryptValue({
+      ciphertext,
+      profile: "Default",
+      keyMaterial: resolved.material,
+    });
+    expect(outcome.state).toBe("value");
+    if (outcome.state === "value") {
+      expect(Buffer.from(outcome.plaintext).toString("utf8")).toBe(
+        "captured-secret",
+      );
+    }
+  });
+
+  it("skips an unsupported v20 App-Bound record without guessing a key", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-keymat-v20-"));
+    temporaryRoots.push(root);
+    const bundlePath = join(root, "key-material.json");
+    await writeFile(
+      bundlePath,
+      JSON.stringify({
+        schema: "forensix/key-material-bundle/1",
+        records: [
+          {
+            schema_version: "forensix/key-material-record/1",
+            record_id: "udd-0-appbound",
+            capture_state: "unsupported",
+            key_kind: "oscrypt_row_key",
+            usable_row_key: false,
+            provider: {
+              platform: "windows",
+              name: "DPAPI",
+              item: "app-bound",
+              scope: "user",
+            },
+            context: [],
+            policy: {
+              row_prefix: "v20",
+              support: "unsupported",
+              reason: "unsupported-google-app-bound-key-variant",
+            },
+            evidence: [],
+            sealed_material: null,
+          },
+        ],
+      }),
+    );
+    const resolved = loadAuthorizedKeyMaterial({ keyMaterialPath: bundlePath });
+    expect(resolved.material).toEqual([]);
+    expect(resolved.issues).toEqual([
+      {
+        recordId: "udd-0-appbound",
+        reason: "unsupported-google-app-bound-key-variant",
+      },
+    ]);
+  });
+});

--- a/e2e/decrypt-cli.test.ts
+++ b/e2e/decrypt-cli.test.ts
@@ -1,0 +1,272 @@
+import { spawnSync } from "node:child_process";
+import { createCipheriv, pbkdf2Sync } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface CredentialFinding {
+  readonly fields: {
+    readonly usernameValue: Field<string>;
+    readonly secret: Field<string>;
+    readonly secretEncryptionScheme: Field<string>;
+    readonly secretDecryptionRoute: Field<string>;
+    readonly secretKeyMaterialRecordId: Field<string>;
+  };
+}
+
+interface CredentialPage {
+  readonly items: readonly CredentialFinding[];
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+const CBC_IV = Buffer.alloc(16, 0x20);
+const CBC_SALT = Buffer.from("saltysalt", "latin1");
+
+function pkcs7Pad(data: Buffer): Buffer {
+  const pad = 16 - (data.length % 16);
+  return Buffer.concat([data, Buffer.alloc(pad, pad)]);
+}
+
+/** Encrypt a value exactly as a GNOME Keyring / KWallet OSCrypt v11 blob. */
+function sealV11(passphrase: string, plaintext: string): Uint8Array {
+  const key = pbkdf2Sync(passphrase, CBC_SALT, 1, 16, "sha1");
+  const cipher = createCipheriv("aes-128-cbc", key, CBC_IV);
+  cipher.setAutoPadding(false);
+  const body = Buffer.concat([
+    cipher.update(pkcs7Pad(Buffer.from(plaintext, "utf8"))),
+    cipher.final(),
+  ]);
+  return new Uint8Array(Buffer.concat([Buffer.from("v11", "latin1"), body]));
+}
+
+const V20_SECRET = new Uint8Array([0x76, 0x32, 0x30, 0x01, 0x02, 0x03]);
+
+function createLoginsSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+    INSERT INTO meta (key, value) VALUES ('version', '43'), ('last_compatible_version', '1');
+    CREATE TABLE logins (
+      origin_url VARCHAR NOT NULL,
+      username_value VARCHAR,
+      password_value BLOB,
+      signon_realm VARCHAR NOT NULL,
+      date_created INTEGER NOT NULL,
+      blacklisted_by_user INTEGER NOT NULL,
+      scheme INTEGER NOT NULL,
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      date_last_used INTEGER NOT NULL DEFAULT 0,
+      date_password_modified INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+}
+
+async function createLoginData(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    createLoginsSchema(database);
+    const insert = database.prepare(
+      `INSERT INTO logins
+         (id, origin_url, username_value, password_value, signon_realm,
+          date_created, blacklisted_by_user, scheme, date_last_used)
+       VALUES (?, ?, ?, ?, ?, ?, 0, 0, ?)`,
+    );
+    insert.run(
+      1n,
+      "https://alpha.example/",
+      "alice@alpha.example",
+      sealV11("keyring-secret", "top-secret-password"),
+      "https://alpha.example/",
+      13_348_638_245_123_456n,
+      13_348_638_305_456_000n,
+    );
+    insert.run(
+      2n,
+      "https://bank.example/",
+      "bob@bank.example",
+      V20_SECRET,
+      "https://bank.example/",
+      13_348_638_400_000_000n,
+      13_348_638_500_000_000n,
+    );
+  } finally {
+    database.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI offline OSCrypt decryption", () => {
+  it("decrypts supported secrets only on opt-in with authorized key material", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-decrypt-e2e-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const loginPath = join(source, "Default", "Login Data");
+    await createLoginData(loginPath);
+    const sourceBytes = await readFile(loginPath);
+
+    const keyMaterialPath = join(root, "key-material.json");
+    await writeFile(
+      keyMaterialPath,
+      JSON.stringify({
+        schema: "forensix/supplied-key-material/1",
+        entries: [
+          {
+            recordId: "op-gnome-default",
+            route: "gnome-keyring",
+            keyKind: "passphrase",
+            rowPrefix: "v11",
+            profile: "Default",
+            secretBase64: Buffer.from("keyring-secret", "utf8").toString(
+              "base64",
+            ),
+            provider: {
+              platform: "linux",
+              name: "gnome-keyring",
+              item: "Chrome Safe Storage",
+              scope: "user",
+            },
+          },
+        ],
+      }),
+    );
+
+    const caseDirectory = join(root, "CASE-DECRYPT");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    // AC1: without the opt-in the secret stays unavailable with the historic
+    // typed reason, even though the store contains a supported v11 blob.
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const sealed = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--search",
+        "alpha.example",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(sealed[0]?.fields.secret).toEqual({
+      state: "unavailable",
+      reason: "encrypted_secret_without_key_material",
+    });
+
+    // AC1: key-material options are rejected without the --decrypt opt-in.
+    const misuse = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--key-material",
+      keyMaterialPath,
+      "--json",
+    ]);
+    expect(misuse.status).toBe(1);
+
+    // Opt-in plus authorized key material with Provenance.
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--decrypt",
+      "--key-material",
+      keyMaterialPath,
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      decryption: {
+        enabled: true,
+        keyMaterialCount: 1,
+        keyMaterialIssueCount: 0,
+      },
+    });
+
+    const decrypted = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--search",
+        "alpha.example",
+        "--json",
+      ]).stdout,
+    ).items;
+    // AC2 + AC3: the v11 GNOME Keyring blob is decrypted to plaintext and cites
+    // its route and key-material record.
+    expect(decrypted[0]?.fields.secret).toEqual({
+      state: "value",
+      value: "top-secret-password",
+    });
+    expect(decrypted[0]?.fields.secretDecryptionRoute).toEqual({
+      state: "value",
+      value: "gnome-keyring",
+    });
+    expect(decrypted[0]?.fields.secretKeyMaterialRecordId).toEqual({
+      state: "value",
+      value: "op-gnome-default",
+    });
+
+    // AC4: the v20 App-Bound secret is never unwrapped, even with opt-in.
+    const appBound = parseJson<CredentialPage>(
+      runCli([
+        "credentials",
+        "--case",
+        caseDirectory,
+        "--search",
+        "bank.example",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(appBound[0]?.fields.secret).toEqual({
+      state: "unavailable",
+      reason: "unsupported_app_bound_v20",
+    });
+
+    // AC6: the Analyzer never writes Source bytes.
+    expect(await readFile(loginPath)).toEqual(sourceBytes);
+  });
+});


### PR DESCRIPTION
Closes #183.

Adds an offline OSCrypt decryption engine and an authorized key-material resolver, wired into the #174 Cookies and #177 Login Data parsers through the `analyse` command. The Analyzer stays offline and the Case remains the record of truth.

## What changed

- **`core/src/oscrypt.ts`** — pure, offline decryption engine. No I/O. Per-row dispatch by prefix; real crypto via `node:crypto`.
- **`core/src/key-material.ts`** — resolves authorized key material with Provenance from operator-`supplied` files or Collector-`captured` sealed bundles; unseals row keys with an operator X25519 recipient key (HKDF-SHA256 + AES-256-GCM, per `collector/contracts/key-material`).
- **`core/src/cookies.ts` / `core/src/login-data.ts`** — an encrypted value stays `unavailable` unless opt-in + key material successfully unwrap it; on success it becomes a `value` citing route + key-material record.
- **`core/src/history.ts`** — `analyse` gains `decryptionEnabled` / `keyMaterialPath` / `recipientKeyPath` and a `decryption` summary.
- **`cli/src/cli.ts`** — `--decrypt`, `--key-material`, `--recipient-key`; key-material flags are rejected without `--decrypt`.
- **`core/src/forensic-model.ts`** — new distinct typed unavailable reasons.
- **`core/src/export.ts`** — the decrypted Cookie `value` is treated as a Redaction State secret (withheld by default).
- **`README.md`** — new "Decrypt supported secrets offline" section using canonical terms.

## Acceptance criteria → where met

| # | Criterion | Where |
|---|-----------|-------|
| 1 | Disabled by default; requires opt-in **plus** key material with Provenance | `cli.ts` `--decrypt` gate + rejection of key-material flags without opt-in; `history.ts` throws without `--key-material`; `DECRYPTION_DISABLED` default keeps `encrypted_secret_without_key_material`. E2E: default run + misuse rejection + opt-in path. |
| 2 | Each row dispatches independently by its v10/v11/v20 prefix | `oscrypt.ts` `schemeOf` + `decryptOscryptValue` per-row dispatch. Unit: "dispatches mixed v10 and v11 rows independently". |
| 3 | Supported routes within evidenced bounds (Linux basic, GNOME Keyring, KWallet, macOS Keychain, legacy Windows DPAPI; plus Windows v10 GCM) | `oscrypt.ts` CBC/GCM/DPAPI routes. Unit: per-route CBC round-trips, GCM round-trip, faithful legacy DPAPI (AES-256/SHA-512) round-trip. |
| 4 | Windows v20 and unsupported CREDHIST/domain routes return stable typed unavailable; never a guessed unwrap | `unsupported_app_bound_v20` returned before any key lookup; `routeFromRecord` returns `null` (→ typed issue) for unmapped providers. Unit + E2E assert v20. |
| 5 | Wrong credentials, malformed stores, missing context, auth failures stay distinguishable | Distinct reasons `decryption_wrong_key` / `decryption_malformed_ciphertext` / `decryption_missing_context` / `decryption_authentication_failed`. Unit tests for each. |
| 6 | No network, no daemons, no store mutation, no live key store, no Source writes | Engine is pure; resolver only reads the operator key-material file + recipient key. E2E asserts Source bytes are byte-identical after analyse. |
| — | Consume the Collector captured key-material contract for Provenance | `key-material.ts` parses sealed records, unseals per the contract README, carries record/provider/policy/evidence Provenance. Unit: "unseals a Collector-sealed row key". |

## Tests / verification

`pnpm verify` green locally (Node 24.15.0): format + lint + typecheck + **55 tests pass** (new: `core/test/oscrypt.test.ts` 19, `e2e/decrypt-cli.test.ts` 1). New E2E is bounded (single case, two rows). `vitest.config.ts` untouched.

## Risks / notes

- Legacy Windows DPAPI is supported for the documented AES-256 + SHA-512 CryptProtectData blob with an operator-supplied decrypted master key; other cipher/hash combinations, CREDHIST, and domain-key chains are intentionally out of scope and surface typed unavailable reasons rather than a guess.
- The captured-bundle reader expects a single JSON bundle (`forensix/key-material-bundle/1`); full ingest of the on-disk `key_material/` subtree is Collector-side and out of scope for this Analyzer issue.
- Decrypted secrets are redacted by default in Extracts; disclosure still requires the existing `--include-secrets` opt-in.