### PR TITLE
chore: enforce conventional commits and harden Windows E2E flake

### DIFF
--- a/.github/workflows/commitlint-pr-title.yml
+++ b/.github/workflows/commitlint-pr-title.yml
@@ -1,0 +1,31 @@
+name: commitlint-pr-title
+
+# Squash-merge promotes the PR title to the commit that lands on v2/master, so
+# the title itself must be a valid Conventional Commit. This job lints it.
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches: [v2, master]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint-pr-title:
+    name: commitlint-pr-title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+      - name: Lint PR title as a Conventional Commit
+        env:
+          # Pass the untrusted title via env, never interpolated into the shell.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: printf '%s' "$PR_TITLE" | corepack pnpm exec commitlint

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+pnpm exec commitlint --edit "$1"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# AGENTS.md — ForensiX v2
+
+Working rules for agents and contributors in this repository.
+
+## Branching
+
+- **`v2` is the integration branch.** Open every PR against `v2`.
+- **Never merge to `master`.**
+- Keep research ancestry out of product branches: do **not** add `CONTEXT.md` or
+  other research-only scaffolding to `v2`.
+
+## Toolchain
+
+- **Node 24.15.0** (see `engines` in `package.json`).
+- pnpm workspace monorepo (`core/`, `cli/`, `server/`, `client/`, `contracts/`,
+  `collector/`, `e2e/`).
+- Run the full gate before pushing:
+
+  ```bash
+  pnpm verify
+  ```
+
+  `verify` runs `format:check`, `lint`, `typecheck`, and the vitest suite.
+
+## Conventional Commits (required)
+
+Commit messages **and** PR titles must follow
+[Conventional Commits](https://www.conventionalcommits.org/), for example:
+
+```
+feat(history): recover rollback-journal rows
+fix(cli): retry transient SQLite open on Windows
+ci: enforce conventional commits
+test: harden Windows rollback-journal flake
+chore: bump dependencies
+```
+
+Enforcement has two layers, because they cover two different things:
+
+1. **Local commit messages** — the husky `commit-msg` hook
+   (`.husky/commit-msg`) runs `commitlint` on every commit. The hook is
+   installed by the `prepare` script (`husky`) during `pnpm install`. Shared
+   config lives in `commitlint.config.cjs`
+   (extends `@commitlint/config-conventional`).
+
+2. **PR titles** — PRs are **squash-merged**, and the squash promotes the **PR
+   title** to the commit that lands on `v2`. A recent merge landed as
+   `Serve a read-only local Case dashboard (#171) (#197)`, which is **not**
+   conventional. To prevent that, the `commitlint-pr-title` CI job
+   (`.github/workflows/commitlint-pr-title.yml`) lints the PR title as a
+   Conventional Commit on open/edit/reopen/synchronize.
+
+When you rename a PR, keep the title conventional so the squash commit is valid.
+
+## Forensic invariants (do not break)
+
+- The Analyzer and Collector are **separate, offline** programs. Do not couple
+  them.
+- Do not change Analyzer behavior or output. Hardening (e.g. the bounded SQLite
+  open retry in `core/src/sqlite-open.ts`) must leave successful results
+  byte-for-byte identical; it only affects the transient-failure path.

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,10 @@
+/**
+ * Conventional Commits enforcement for ForensiX v2.
+ *
+ * Applies to local commit messages (via the husky commit-msg hook) and to PR
+ * titles (via the commitlint-pr-title CI job) because squash-merge promotes the
+ * PR title to the commit that lands on the integration branch.
+ */
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+};

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 import { CASE_FILENAME, TOOL_VERSION } from "./case.js";
+import { openDatabaseSync } from "./sqlite-open.js";
 import type { Candidate, Finding } from "./forensic-model.js";
 
 export type DeclaredOriginOs = "windows" | "macos" | "linux";
@@ -453,7 +454,7 @@ export function storeHistoryAnalysis(
 ): StoredHistoryAnalysis {
   const cookieArtifacts = options.cookieArtifacts ?? [];
   const runId = randomUUID();
-  const database = new DatabaseSync(
+  const database = openDatabaseSync(
     join(resolve(options.caseDirectory), CASE_FILENAME),
     { readBigInts: true },
   );

--- a/core/src/case.ts
+++ b/core/src/case.ts
@@ -8,6 +8,7 @@ import type {
   AcquisitionVerificationOutcome,
 } from "./acquisition-bundle.js";
 import { ForensixError } from "./errors.js";
+import { openDatabaseSync } from "./sqlite-open.js";
 import {
   SOURCE_KINDS,
   decodeManifestEntry,
@@ -313,7 +314,7 @@ function insertEntry(
 
 export function createCaseDatabase(options: CreateCaseDatabaseOptions): void {
   const databasePath = join(options.caseDirectory, CASE_FILENAME);
-  const database = new DatabaseSync(databasePath);
+  const database = openDatabaseSync(databasePath);
   try {
     createSchema(database);
     database.exec("BEGIN IMMEDIATE;");
@@ -501,7 +502,7 @@ function openCaseDatabase(caseDirectory: string): {
     const databaseUrl = pathToFileURL(databasePath);
     databaseUrl.searchParams.set("immutable", "1");
     return {
-      database: new DatabaseSync(databaseUrl.href),
+      database: openDatabaseSync(databaseUrl.href),
       databasePath,
       resolvedCaseDirectory,
     };

--- a/core/src/cookies-sqlite.ts
+++ b/core/src/cookies-sqlite.ts
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 
 import type { CommitState } from "./forensic-model.js";
 import { ForensixError } from "./errors.js";
+import { openDatabaseSync } from "./sqlite-open.js";
 import {
   immutableDatabase,
   snapshotVerifiedFile,
@@ -350,7 +351,7 @@ export async function readCookiePasses(options: {
 
     let recoveryDatabase: DatabaseSync;
     try {
-      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
         readBigInts: true,
       });
     } catch (error) {

--- a/core/src/history-sqlite.ts
+++ b/core/src/history-sqlite.ts
@@ -6,6 +6,7 @@ import { DatabaseSync } from "node:sqlite";
 import { pathToFileURL } from "node:url";
 
 import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import { openDatabaseSync } from "./sqlite-open.js";
 import type { CommitState } from "./forensic-model.js";
 import { readStableRegularFile } from "./stable-file.js";
 
@@ -331,7 +332,7 @@ function readPass(database: DatabaseSync): HistoryPass {
 export function immutableDatabase(path: string): DatabaseSync {
   const url = pathToFileURL(path);
   url.searchParams.set("immutable", "1");
-  return new DatabaseSync(url.href, {
+  return openDatabaseSync(url.href, {
     readOnly: true,
     readBigInts: true,
   });
@@ -556,7 +557,7 @@ export async function readHistoryPasses(options: {
 
     let recoveryDatabase: DatabaseSync;
     try {
-      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
         readBigInts: true,
       });
     } catch (error) {

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -178,5 +178,6 @@ export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,
 } from "./case-findings.js";
+export { openDatabaseSync, type OpenDatabaseConfig } from "./sqlite-open.js";
 
 export const MINIMUM_NODE_VERSION = "24.15.0" as const;

--- a/core/src/login-data-sqlite.ts
+++ b/core/src/login-data-sqlite.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url";
 
 import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
 import type { CommitState } from "./forensic-model.js";
+import { openDatabaseSync } from "./sqlite-open.js";
 import { readStableRegularFile } from "./stable-file.js";
 
 export type RawLoginValue = null | string | bigint | Uint8Array;
@@ -200,7 +201,7 @@ function readPass(database: DatabaseSync): LoginPass {
 function immutableDatabase(path: string): DatabaseSync {
   const url = pathToFileURL(path);
   url.searchParams.set("immutable", "1");
-  return new DatabaseSync(url.href, {
+  return openDatabaseSync(url.href, {
     readOnly: true,
     readBigInts: true,
   });
@@ -369,7 +370,7 @@ export async function readLoginPasses(options: {
 
     let recoveryDatabase: DatabaseSync;
     try {
-      recoveryDatabase = new DatabaseSync(temporaryDatabasePath, {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
         readBigInts: true,
       });
     } catch (error) {

--- a/core/src/sqlite-open.ts
+++ b/core/src/sqlite-open.ts
@@ -48,7 +48,12 @@ const TRANSIENT_PRIMARY_CODES = new Set([
   SQLITE_CANTOPEN,
 ]);
 
-function isTransientOpenError(error: unknown): boolean {
+/**
+ * Classify an error thrown while opening a SQLite database as transient
+ * (worth a bounded retry) or not. Exported for unit testing; not re-exported
+ * from the package index.
+ */
+export function isTransientOpenError(error: unknown): boolean {
   if (typeof error !== "object" || error === null) {
     return false;
   }

--- a/core/src/sqlite-open.ts
+++ b/core/src/sqlite-open.ts
@@ -1,0 +1,118 @@
+import { DatabaseSync } from "node:sqlite";
+
+/**
+ * Bounded, honest hardening for SQLite `open` on contended files.
+ *
+ * On Windows CI the compiled CLI can transiently fail to open a Chrome
+ * SQLite file (or a just-copied working snapshot that still carries a hot
+ * rollback journal) while another process holds a share/lock on it. SQLite
+ * surfaces this as `SQLITE_BUSY`, `SQLITE_LOCKED`, or
+ * `SQLITE_CANTOPEN` ("unable to open database file").
+ *
+ * These helpers add two guardrails and nothing else:
+ *
+ *   1. A finite `busy_timeout` so a lock contended DURING an open/rollback is
+ *      waited on for a few seconds instead of failing instantly.
+ *   2. A small, fixed-budget retry that ONLY re-attempts the transient open
+ *      errors above. It is never infinite and never retries a genuine error
+ *      (corruption, missing file with no writer, schema faults).
+ *
+ * A successful open behaves exactly as before: same options, same handle,
+ * same reads. Only the failure path changes.
+ */
+
+type DatabaseSyncOptions = NonNullable<
+  ConstructorParameters<typeof DatabaseSync>[1]
+>;
+
+export interface OpenDatabaseConfig {
+  /** Connection `busy_timeout` in milliseconds. Default 5000. */
+  readonly busyTimeoutMs?: number;
+  /** Maximum open attempts, including the first. Default 6. */
+  readonly maxAttempts?: number;
+  /** Total wall-clock budget for retries in milliseconds. Default 2500. */
+  readonly maxTotalMs?: number;
+}
+
+const DEFAULT_BUSY_TIMEOUT_MS = 5000;
+const DEFAULT_MAX_ATTEMPTS = 6;
+const DEFAULT_MAX_TOTAL_MS = 2500;
+
+/** SQLite primary result codes we treat as transient (retryable). */
+const SQLITE_BUSY = 5;
+const SQLITE_LOCKED = 6;
+const SQLITE_CANTOPEN = 14;
+const TRANSIENT_PRIMARY_CODES = new Set([
+  SQLITE_BUSY,
+  SQLITE_LOCKED,
+  SQLITE_CANTOPEN,
+]);
+
+function isTransientOpenError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+  const errcode = (error as { errcode?: unknown }).errcode;
+  if (typeof errcode === "number") {
+    // Mask to the primary result code; the high bits are extended codes
+    // (e.g. SQLITE_CANTOPEN_ISDIR) that share the same transient class.
+    return TRANSIENT_PRIMARY_CODES.has(errcode & 0xff);
+  }
+  const message = (error as { message?: unknown }).message;
+  return (
+    typeof message === "string" &&
+    (message.includes("unable to open database file") ||
+      message.includes("database is locked"))
+  );
+}
+
+/** Sleep synchronously without spinning the CPU. */
+function sleepSync(milliseconds: number): void {
+  if (milliseconds <= 0) {
+    return;
+  }
+  const shared = new Int32Array(new SharedArrayBuffer(4));
+  Atomics.wait(shared, 0, 0, milliseconds);
+}
+
+/**
+ * Open a SQLite database with a finite `busy_timeout` and a bounded retry on
+ * transient open/lock errors. Drop-in for `new DatabaseSync(location, options)`.
+ */
+export function openDatabaseSync(
+  location: string | URL,
+  options?: DatabaseSyncOptions,
+  config?: OpenDatabaseConfig,
+): DatabaseSync {
+  const busyTimeoutMs = config?.busyTimeoutMs ?? DEFAULT_BUSY_TIMEOUT_MS;
+  const maxAttempts = config?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const maxTotalMs = config?.maxTotalMs ?? DEFAULT_MAX_TOTAL_MS;
+
+  const start = Date.now();
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    try {
+      const database =
+        options === undefined
+          ? new DatabaseSync(location)
+          : new DatabaseSync(location, options);
+      // Finite lock wait for any contention hit while opening/rolling back.
+      // Never changes query results; only affects contended-lock timing.
+      database.exec(`PRAGMA busy_timeout = ${busyTimeoutMs};`);
+      return database;
+    } catch (error) {
+      const elapsed = Date.now() - start;
+      if (
+        !isTransientOpenError(error) ||
+        attempt >= maxAttempts ||
+        elapsed >= maxTotalMs
+      ) {
+        throw error;
+      }
+      // Linear backoff, capped by the remaining budget. Bounded by construction.
+      const backoff = Math.min(attempt * 100, maxTotalMs - elapsed);
+      sleepSync(backoff);
+    }
+  }
+}

--- a/core/test/sqlite-open.test.ts
+++ b/core/test/sqlite-open.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { openDatabaseSync } from "../src/index.js";
+import { isTransientOpenError } from "../src/sqlite-open.js";
+
+const temporaryRoots: string[] = [];
+
+async function makeRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "forensix-sqlite-open-"));
+  temporaryRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("isTransientOpenError", () => {
+  it("treats SQLITE_BUSY, SQLITE_LOCKED, and SQLITE_CANTOPEN as transient", () => {
+    expect(isTransientOpenError({ errcode: 5 })).toBe(true);
+    expect(isTransientOpenError({ errcode: 6 })).toBe(true);
+    expect(isTransientOpenError({ errcode: 14 })).toBe(true);
+  });
+
+  it("masks extended result codes to their primary code", () => {
+    // SQLITE_CANTOPEN with an extended high byte still classifies as transient.
+    expect(isTransientOpenError({ errcode: 14 + (1 << 8) })).toBe(true);
+    // SQLITE_BUSY_SNAPSHOT (0x205) masks to SQLITE_BUSY.
+    expect(isTransientOpenError({ errcode: 0x205 })).toBe(true);
+  });
+
+  it("does not retry genuine, non-transient errors", () => {
+    expect(isTransientOpenError({ errcode: 1 })).toBe(false); // SQLITE_ERROR
+    expect(isTransientOpenError({ errcode: 26 })).toBe(false); // SQLITE_NOTADB
+    expect(isTransientOpenError({ errcode: 11 })).toBe(false); // SQLITE_CORRUPT
+  });
+
+  it("falls back to message matching only when no errcode is present", () => {
+    expect(
+      isTransientOpenError({ message: "unable to open database file" }),
+    ).toBe(true);
+    expect(isTransientOpenError({ message: "database is locked" })).toBe(true);
+    expect(isTransientOpenError({ message: 'near "x": syntax error' })).toBe(
+      false,
+    );
+  });
+
+  it("rejects non-object inputs", () => {
+    expect(isTransientOpenError(null)).toBe(false);
+    expect(isTransientOpenError(undefined)).toBe(false);
+    expect(isTransientOpenError("unable to open database file")).toBe(false);
+  });
+});
+
+describe("openDatabaseSync", () => {
+  it("opens successfully and applies the configured busy_timeout", async () => {
+    const root = await makeRoot();
+    const database = openDatabaseSync(join(root, "case.db"), undefined, {
+      busyTimeoutMs: 3000,
+    });
+    try {
+      database.exec("CREATE TABLE t (a INTEGER); INSERT INTO t VALUES (1);");
+      expect(database.prepare("SELECT a FROM t").get()).toEqual({ a: 1 });
+      expect(database.prepare("PRAGMA busy_timeout").get()).toEqual({
+        timeout: 3000,
+      });
+    } finally {
+      database.close();
+    }
+  });
+
+  it("passes constructor options through unchanged on the success path", async () => {
+    const root = await makeRoot();
+    const seed = openDatabaseSync(join(root, "case.db"));
+    seed.exec("CREATE TABLE t (a INTEGER); INSERT INTO t VALUES (9);");
+    seed.close();
+
+    const database = openDatabaseSync(join(root, "case.db"), {
+      readBigInts: true,
+    });
+    try {
+      // readBigInts option honored → integer comes back as bigint.
+      expect(database.prepare("SELECT a FROM t").get()).toEqual({ a: 9n });
+    } finally {
+      database.close();
+    }
+  });
+
+  it("retries a transient open error but stays bounded, then throws", () => {
+    // A path under a missing directory yields SQLITE_CANTOPEN (transient), so
+    // every attempt fails. The call must give up within the configured budget.
+    const doomedPath = join(tmpdir(), "forensix-missing-dir", "nope.db");
+    const start = Date.now();
+    let thrown: unknown;
+    try {
+      openDatabaseSync(doomedPath, undefined, {
+        maxAttempts: 3,
+        maxTotalMs: 1000,
+        busyTimeoutMs: 1000,
+      });
+    } catch (error) {
+      thrown = error;
+    }
+    const elapsed = Date.now() - start;
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as { errcode?: number }).errcode).toBe(14);
+    // Retried at least once (backoff of ~100ms after the first failure)...
+    expect(elapsed).toBeGreaterThanOrEqual(100);
+    // ...but never ran away: 3 attempts with 100ms + 200ms backoff ≈ 300ms.
+    expect(elapsed).toBeLessThan(1500);
+  });
+});

--- a/e2e/history-cli.test.ts
+++ b/e2e/history-cli.test.ts
@@ -1210,7 +1210,12 @@ describe("compiled analyzer CLI History Finding pipeline", () => {
         },
       },
     });
-  }, 30_000);
+    // Finite (not disabled): the compiled CLI opens a freshly-copied working
+    // snapshot that still carries a hot rollback journal while a live writer
+    // holds the source. On Windows CI the open can be transiently refused and
+    // retried (see openDatabaseSync), so allow more headroom than the 30s
+    // default while still failing a genuine hang.
+  }, 60_000);
 
   it("requires Declared Origin OS for version-16 epochs without creating Candidates", async () => {
     const root = await mkdtemp(join(tmpdir(), "forensix-history-origin-"));

--- a/package.json
+++ b/package.json
@@ -13,14 +13,18 @@
     "lint": "eslint core/src core/test cli/src server/src client/src e2e eslint.config.mjs vitest.config.ts && depcruise core/src cli/src server/src client/src --config .dependency-cruiser.cjs",
     "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
     "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
+    "prepare": "husky",
     "test": "pnpm build && vitest run",
     "verify": "pnpm format:check && pnpm lint && pnpm typecheck && vitest run"
   },
   "devDependencies": {
+    "@commitlint/cli": "^21.2.2",
+    "@commitlint/config-conventional": "^21.2.2",
     "@eslint/js": "9.39.2",
     "@types/node": "24.10.9",
     "dependency-cruiser": "17.3.8",
     "eslint": "9.39.2",
+    "husky": "^9.1.7",
     "prettier": "3.8.2",
     "typescript": "5.9.3",
     "typescript-eslint": "8.54.0",

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "build": "pnpm -r --if-present build",
     "typecheck": "pnpm build && pnpm -r --if-present typecheck && tsc -p tsconfig.contracts.json",
     "lint": "eslint core/src core/test cli/src server/src client/src e2e eslint.config.mjs vitest.config.ts && depcruise core/src cli/src server/src client/src --config .dependency-cruiser.cjs",
-    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
-    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs core cli server client contracts e2e",
+    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e",
+    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e",
     "prepare": "husky",
     "test": "pnpm build && vitest run",
     "verify": "pnpm format:check && pnpm lint && pnpm typecheck && vitest run"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^21.2.2
+        version: 21.2.2(@types/node@24.10.9)(conventional-commits-parser@7.1.2)(typescript@5.9.3)
+      '@commitlint/config-conventional':
+        specifier: ^21.2.2
+        version: 21.2.2
       '@eslint/js':
         specifier: 9.39.2
         version: 9.39.2
@@ -19,7 +25,10 @@ importers:
         version: 17.3.8
       eslint:
         specifier: 9.39.2
-        version: 9.39.2
+        version: 9.39.2(jiti@2.6.1)
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       prettier:
         specifier: 3.8.2
         version: 3.8.2
@@ -28,10 +37,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: 8.54.0
-        version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+        version: 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       vitest:
         specifier: 4.0.18
-        version: 4.0.18(@types/node@24.10.9)
+        version: 4.0.18(@types/node@24.10.9)(jiti@2.6.1)
 
   cli:
     dependencies:
@@ -56,6 +65,99 @@ importers:
         version: link:../core
 
 packages:
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@commitlint/cli@21.2.2':
+    resolution: {integrity: sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==}
+    engines: {node: '>=22.12.0'}
+    hasBin: true
+
+  '@commitlint/config-conventional@21.2.2':
+    resolution: {integrity: sha512-NxA37SZviusFUEYOQZ5hNnZ1h7O/KiemPkxjOlpzKJNnWxThiwc6/SaZhaPa8fyLvfRBAywhQhJJk8XESHWlpQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/config-validator@21.2.0':
+    resolution: {integrity: sha512-t7AzNHAKeIdo/3NRGwzpufKHsKkPHmFs/56N2Fnsh0/r0rGtnQzTxk6vnFgjaGr4hdSQKNB50/KAhR9Yk4LJKA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/ensure@21.2.0':
+    resolution: {integrity: sha512-76IF9vDNS13lAzEEik9eKwzt8f9hYhWiwVXZ2AnyLCz5/f511FsEQ3pw1X3/zSQpdRLQU7i5qDMVKyXi1GWjSg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/execute-rule@21.0.1':
+    resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/format@21.2.2':
+    resolution: {integrity: sha512-v6fvxZSc/AvVMROlr3H34+1766bZSYApRUSCAMjWamStPjKMvZ8GdvVA5YW/VQNgbFTmcMz6OYmSTJEvIjPrfA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/is-ignored@21.2.2':
+    resolution: {integrity: sha512-9UoKNgfFE3LU7FrzierCvk3CdDfMDeVGC86qZiT/n0TIjfq/dmZ9MHuXd45OTNRa26ZanmJRxEtmiXk/lEJihg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/lint@21.2.2':
+    resolution: {integrity: sha512-Fy8JxEBzdmsYWFude/61GxXu5O+wEymwiRK2z9GL9R8mCsXphCoGxAFc5iHn5mjlfcSrhiiONE+ksf4KOjnaPg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/load@21.2.2':
+    resolution: {integrity: sha512-0Tt6wDPX167cjKC5D4zhm0+20wJJG+TN/TKovMOspfSe78rOnKX+MNzlVNiu6HyQPZChPJ8QBH31MVt6Bb8fCg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/message@21.2.0':
+    resolution: {integrity: sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/parse@21.2.2':
+    resolution: {integrity: sha512-MEkobPfvRp+z06Wro8HMG1BDGHzZmj82A1LH1nWeG3ipHpg/x4m6v3wEDvMBIKjRFUnfR3nBeFs3MVCr7UdAmg==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/read@21.2.1':
+    resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/resolve-extends@21.2.2':
+    resolution: {integrity: sha512-RPkJ/IFi7sMUUVbZLqwWFtWw/zRDcfFsmrPSiTMrt5wb7AdxOr86EGQFvmGzef5QKV5IPBWWCujqVTw1RWX44A==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/rules@21.2.2':
+    resolution: {integrity: sha512-eplQzyYkBjYB1HyyRj8hkcK11Y9DU9nuBz7uOKEd6NpE9NGDytLFCAnlRE+OoiK/5sHEJsaz2RGhuWBvYzIbNA==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/to-lines@21.0.1':
+    resolution: {integrity: sha512-bd1BFII7p1EQZre9Kaj+kKaMFP3cFCdt21K7DItVux9XP5WjLgJ0/Uy1pJJh9aPwVJ6SKg62PxqlZaHI8hQAXw==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/top-level@21.2.0':
+    resolution: {integrity: sha512-Y5gmQ+KxzqCrBFJfLvFEPvvwD3LDiNZoTT2yeFBm96M8qhmqSzQc5DvX3rheAaAMjyIvMXOCLS/mWfdpONsjyQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@commitlint/types@21.2.0':
+    resolution: {integrity: sha512-7zVFCDB2reMvJH5dmbKnOQPjZEvjdJTH8jc0U/PIPU1r3/+vf5pD1HlfitV2MWsWXrvu7u39iY1lyLUPOaN0Gw==}
+    engines: {node: '>=22.12.0'}
+
+  '@conventional-changelog/git-client@3.1.2':
+    resolution: {integrity: sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      conventional-commits-filter: ^6.0.1
+      conventional-commits-parser: ^7.1.2
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
+
+  '@conventional-changelog/template@1.3.0':
+    resolution: {integrity: sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==}
+    engines: {node: '>=22'}
 
   '@esbuild/aix-ppc64@0.28.2':
     resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
@@ -419,6 +521,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@simple-libs/child-process-utils@2.0.0':
+    resolution: {integrity: sha512-dvNoRKLijXnD0XoJAz94pbNuB5GQgDr55UhpSPhffDkTT0Cmcqh9jSCOtwfT2d4H6MI9E7c4SgtMuJXZ6F3c6A==}
+    engines: {node: '>=22'}
+
+  '@simple-libs/stream-utils@2.0.0':
+    resolution: {integrity: sha512-fCTuZK4QBa+39Oz9l4OGfJfz+GpwCp3AqO7Zch3to99xHPgstVsRFpeQ8LNd2o1Gv8raL2mCFwiaHh7bFSp5DQ==}
+    engines: {node: '>=22'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -554,12 +664,27 @@ packages:
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  argue-cli@3.1.0:
+    resolution: {integrity: sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw==}
+    engines: {node: '>=22'}
 
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
@@ -586,6 +711,10 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -599,6 +728,36 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  conventional-changelog-angular@9.3.0:
+    resolution: {integrity: sha512-0MWQLVUT1oVCsUGs9aAWteBVxPlLwJTn5VbQH7B0B3fDizZgrJ9QGnKl/2mp1+5P7153GCBCjO/v1aKJ6eysCg==}
+    engines: {node: '>=22'}
+
+  conventional-changelog-conventionalcommits@10.3.0:
+    resolution: {integrity: sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==}
+    engines: {node: '>=22'}
+
+  conventional-commits-parser@7.1.2:
+    resolution: {integrity: sha512-O+x4N2yH+ijvqWlIyTHsXTAP+algNWgGbjY2duCe8w2vUMvUB95cLRslCPfTMQyLAKlet3bhZTdu6ozn4M+QJQ==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  cosmiconfig-typescript-loader@6.3.0:
+    resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
+  cosmiconfig@9.0.2:
+    resolution: {integrity: sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -621,9 +780,19 @@ packages:
     engines: {node: ^20.12||^22||>=24}
     hasBin: true
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   enhanced-resolve@5.19.0:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
+  error-ex@1.3.4:
+    resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
@@ -632,10 +801,17 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-toolkit@1.50.0:
+    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+
   esbuild@0.28.2:
     resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -699,6 +875,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -731,6 +910,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -738,6 +925,10 @@ packages:
   global-directory@4.0.1:
     resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
     engines: {node: '>=18'}
+
+  global-directory@5.0.0:
+    resolution: {integrity: sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w==}
+    engines: {node: '>=20'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -753,6 +944,11 @@ packages:
   hasown@2.0.4:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -778,9 +974,16 @@ packages:
     resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  ini@6.0.0:
+    resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+
+  is-arrayish@0.2.1:
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
 
   is-core-module@2.16.2:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
@@ -802,8 +1005,19 @@ packages:
     resolution: {integrity: sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==}
     engines: {node: '>=12'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
   js-yaml@4.3.1:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
@@ -812,8 +1026,14 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-parse-even-better-errors@2.3.1:
+    resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -833,6 +1053,9 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -884,6 +1107,10 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-json@5.2.0:
+    resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
+    engines: {node: '>=8'}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -939,9 +1166,17 @@ packages:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
 
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -989,6 +1224,18 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -1154,11 +1401,154 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@commitlint/cli@21.2.2(@types/node@24.10.9)(conventional-commits-parser@7.1.2)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-conventional': 21.2.2
+      '@commitlint/format': 21.2.2
+      '@commitlint/lint': 21.2.2
+      '@commitlint/load': 21.2.2(@types/node@24.10.9)(typescript@5.9.3)
+      '@commitlint/read': 21.2.1(conventional-commits-parser@7.1.2)
+      '@commitlint/types': 21.2.0
+      tinyexec: 1.3.0
+      yargs: 18.1.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@21.2.2':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      conventional-changelog-conventionalcommits: 10.3.0
+
+  '@commitlint/config-validator@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      ajv: 8.20.0
+
+  '@commitlint/ensure@21.2.0':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
+
+  '@commitlint/execute-rule@21.0.1': {}
+
+  '@commitlint/format@21.2.2':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@21.2.2':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      semver: 7.8.5
+
+  '@commitlint/lint@21.2.2':
+    dependencies:
+      '@commitlint/is-ignored': 21.2.2
+      '@commitlint/parse': 21.2.2
+      '@commitlint/rules': 21.2.2
+      '@commitlint/types': 21.2.0
+
+  '@commitlint/load@21.2.2(@types/node@24.10.9)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 21.2.0
+      '@commitlint/execute-rule': 21.0.1
+      '@commitlint/resolve-extends': 21.2.2
+      '@commitlint/types': 21.2.0
+      cosmiconfig: 9.0.2(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@24.10.9)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3)
+      es-toolkit: 1.50.0
+      is-plain-obj: 4.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@21.2.0': {}
+
+  '@commitlint/parse@21.2.2':
+    dependencies:
+      '@commitlint/types': 21.2.0
+      conventional-changelog-angular: 9.3.0
+      conventional-commits-parser: 7.1.2
+
+  '@commitlint/read@21.2.1(conventional-commits-parser@7.1.2)':
+    dependencies:
+      '@commitlint/top-level': 21.2.0
+      '@commitlint/types': 21.2.0
+      '@conventional-changelog/git-client': 3.1.2(conventional-commits-parser@7.1.2)
+      tinyexec: 1.3.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@21.2.2':
+    dependencies:
+      '@commitlint/config-validator': 21.2.0
+      '@commitlint/types': 21.2.0
+      es-toolkit: 1.50.0
+      global-directory: 5.0.0
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@21.2.2':
+    dependencies:
+      '@commitlint/ensure': 21.2.0
+      '@commitlint/message': 21.2.0
+      '@commitlint/to-lines': 21.0.1
+      '@commitlint/types': 21.2.0
+
+  '@commitlint/to-lines@21.0.1': {}
+
+  '@commitlint/top-level@21.2.0':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@21.2.0':
+    dependencies:
+      conventional-commits-parser: 7.1.2
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@3.1.2(conventional-commits-parser@7.1.2)':
+    dependencies:
+      '@simple-libs/child-process-utils': 2.0.0
+      '@simple-libs/stream-utils': 2.0.0
+      semver: 7.8.5
+    optionalDependencies:
+      conventional-commits-parser: 7.1.2
+
+  '@conventional-changelog/template@1.3.0': {}
 
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
@@ -1238,9 +1628,9 @@ snapshots:
   '@esbuild/win32-x64@0.28.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.2)':
+  '@eslint-community/eslint-utils@4.10.1(eslint@9.39.2(jiti@2.6.1))':
     dependencies:
-      eslint: 9.39.2
+      eslint: 9.39.2(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
@@ -1380,6 +1770,12 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.4':
     optional: true
 
+  '@simple-libs/child-process-utils@2.0.0':
+    dependencies:
+      '@simple-libs/stream-utils': 2.0.0
+
+  '@simple-libs/stream-utils@2.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -1397,15 +1793,15 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
-  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.54.0
-      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
-      eslint: 9.39.2
+      eslint: 9.39.2(jiti@2.6.1)
       ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -1413,14 +1809,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.54.0
       debug: 4.4.3
-      eslint: 9.39.2
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1443,13 +1839,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.2
+      eslint: 9.39.2(jiti@2.6.1)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -1472,13 +1868,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.54.0(eslint@9.39.2)(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.2(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.54.0
       '@typescript-eslint/types': 8.54.0
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      eslint: 9.39.2
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -1497,13 +1893,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.1
 
-  '@vitest/mocker@4.0.18(vite@7.3.6(@types/node@24.10.9))':
+  '@vitest/mocker@4.0.18(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.10.9)
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -1556,11 +1952,24 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@6.3.0: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@6.2.3: {}
+
   argparse@2.0.1: {}
+
+  argue-cli@3.1.0: {}
 
   assertion-error@2.0.1: {}
 
@@ -1584,6 +1993,12 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1593,6 +2008,35 @@ snapshots:
   commander@14.0.3: {}
 
   concat-map@0.0.1: {}
+
+  conventional-changelog-angular@9.3.0:
+    dependencies:
+      '@conventional-changelog/template': 1.3.0
+
+  conventional-changelog-conventionalcommits@10.3.0:
+    dependencies:
+      '@conventional-changelog/template': 1.3.0
+
+  conventional-commits-parser@7.1.2:
+    dependencies:
+      '@simple-libs/stream-utils': 2.0.0
+      argue-cli: 3.1.0
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@24.10.9)(cosmiconfig@9.0.2(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 24.10.9
+      cosmiconfig: 9.0.2(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
+  cosmiconfig@9.0.2(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.3.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1627,14 +2071,24 @@ snapshots:
       tsconfig-paths-webpack-plugin: 4.2.0
       watskeburt: 5.0.2
 
+  emoji-regex@10.6.0: {}
+
   enhanced-resolve@5.19.0:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  env-paths@2.2.1: {}
+
+  error-ex@1.3.4:
+    dependencies:
+      is-arrayish: 0.2.1
+
   es-errors@1.3.0: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-toolkit@1.50.0: {}
 
   esbuild@0.28.2:
     optionalDependencies:
@@ -1665,6 +2119,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.28.2
       '@esbuild/win32-x64': 0.28.2
 
+  escalade@3.2.0: {}
+
   escape-string-regexp@4.0.0: {}
 
   eslint-scope@8.4.0:
@@ -1676,9 +2132,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.2:
+  eslint@9.39.2(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.2)
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.2(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
@@ -1712,6 +2168,8 @@ snapshots:
       minimatch: 3.1.5
       natural-compare: 1.4.0
       optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -1745,6 +2203,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.5: {}
+
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
       picomatch: 4.0.5
@@ -1770,6 +2230,10 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -1777,6 +2241,10 @@ snapshots:
   global-directory@4.0.1:
     dependencies:
       ini: 4.1.1
+
+  global-directory@5.0.0:
+    dependencies:
+      ini: 6.0.0
 
   globals@14.0.0: {}
 
@@ -1787,6 +2255,8 @@ snapshots:
   hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
+
+  husky@9.1.7: {}
 
   ignore@5.3.2: {}
 
@@ -1803,7 +2273,11 @@ snapshots:
 
   ini@4.1.1: {}
 
+  ini@6.0.0: {}
+
   interpret@3.1.1: {}
+
+  is-arrayish@0.2.1: {}
 
   is-core-module@2.16.2:
     dependencies:
@@ -1822,7 +2296,13 @@ snapshots:
 
   is-path-inside@4.0.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   isexe@2.0.0: {}
+
+  jiti@2.6.1: {}
+
+  js-tokens@4.0.0: {}
 
   js-yaml@4.3.1:
     dependencies:
@@ -1830,7 +2310,11 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-parse-even-better-errors@2.3.1: {}
+
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -1846,6 +2330,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lines-and-columns@1.2.4: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -1896,6 +2382,13 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-json@5.2.0:
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      error-ex: 1.3.4
+      json-parse-even-better-errors: 2.3.1
+      lines-and-columns: 1.2.4
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -1933,7 +2426,11 @@ snapshots:
 
   regexp-tree@0.1.27: {}
 
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -1998,6 +2495,21 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -2042,13 +2554,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.54.0(eslint@9.39.2)(typescript@5.9.3):
+  typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.54.0(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.54.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2)(typescript@5.9.3)
-      eslint: 9.39.2
+      '@typescript-eslint/utils': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -2061,7 +2573,7 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@7.3.6(@types/node@24.10.9):
+  vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1):
     dependencies:
       esbuild: 0.28.2
       fdir: 6.5.0(picomatch@4.0.5)
@@ -2072,11 +2584,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.9
       fsevents: 2.3.3
+      jiti: 2.6.1
 
-  vitest@4.0.18(@types/node@24.10.9):
+  vitest@4.0.18(@types/node@24.10.9)(jiti@2.6.1):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.6(@types/node@24.10.9))
+      '@vitest/mocker': 4.0.18(vite@7.3.6(@types/node@24.10.9)(jiti@2.6.1))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -2093,7 +2606,7 @@ snapshots:
       tinyexec: 1.3.0
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.1
-      vite: 7.3.6(@types/node@24.10.9)
+      vite: 7.3.6(@types/node@24.10.9)(jiti@2.6.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.10.9
@@ -2122,5 +2635,24 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  y18n@5.0.8: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
 
   yocto-queue@0.1.0: {}


### PR DESCRIPTION
## What

Two related repo-hygiene deliverables in one PR into `v2`.

### 1. Harden the Windows-only rollback-journal E2E flake (without masking hangs)

`e2e/history-cli.test.ts` → "recovers rollback-journal rows without merging their Commit State" intermittently failed **only on Windows CI** with `Error: unable to open database file` (SQLITE_CANTOPEN) and then tripped the 30s timeout. Root cause: a live hot-journal writer holds the source DB while the compiled CLI opens a freshly-copied working snapshot that still carries a hot rollback journal; Windows file-sharing/locking makes the SQLite open transiently fail.

Bounded, honest fix:

- **`core/src/sqlite-open.ts`** — new `openDatabaseSync()` helper: sets a finite `busy_timeout` (5s) and retries **only** transient open/lock errors (`SQLITE_BUSY` / `SQLITE_LOCKED` / `SQLITE_CANTOPEN`) within a fixed budget (≤6 attempts, ≤~2.5s total). Never infinite; genuine errors rethrow immediately.
- Wired into the ingest/analyse SQLite open paths (`case.ts`, `case-findings.ts`, `history-sqlite.ts`, `login-data-sqlite.ts`, `cookies-sqlite.ts`).
- Only the rollback-journal test gets a **finite 60s** timeout — a real hang still fails.
- Successful behavior and analyzer output are **unchanged** (only the failure path changes). `vitest.config.ts` `fileParallelism: !isWindows` left as-is.

Validated on Node 24.15.0: full `pnpm verify` green (61 tests); looped the rollback test 5×, all green.

### 2. Enforce Conventional Commits

- Root devDeps: `husky`, `@commitlint/cli`, `@commitlint/config-conventional` (+ lockfile).
- `commitlint.config.cjs` extends `@commitlint/config-conventional`.
- `.husky/commit-msg` runs commitlint; `prepare: husky` installs the hook (hook verified — it rejected an over-long commit body during this PR's own commits).
- `.github/workflows/commitlint-pr-title.yml` — lints the **PR title** as a Conventional Commit, because squash-merge promotes the title to the commit that lands on `v2` (a recent merge landed as `Serve a read-only local Case dashboard (#171) (#197)`, which is not conventional). Actions pinned by SHA, matching the repo's existing workflows.
- `AGENTS.md` documents: Conventional Commits for commits + PR titles, the husky hook, the PR-title CI check, Node 24.15.0, `pnpm verify`, `v2` as the integration branch (never `master`), keep research ancestry out.

## Notes

- Analyzer/Collector remain separate offline programs; no forensic semantics changed.
- No `CONTEXT.md` / research ancestry added.
