### PR TITLE
feat(web-data): parse Web Data autofill form and address evidence

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -9,11 +9,14 @@ import {
   analyseCase,
   exportCase,
   ingestSource,
+  queryAutofill,
   queryCookies,
   queryCredentials,
   queryHistory,
   queryTopSites,
   renderReport,
+  type AutofillDirection,
+  type AutofillSort,
   type CommitState,
   type CookieDirection,
   type CookieSort,
@@ -59,6 +62,12 @@ const USAGE = `Usage:
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <rank|url|title|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix autofill --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--sort <created-time|last-used-time|field-name|value|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix serve --case <case-directory> [--port <port>] [--json]
@@ -577,6 +586,53 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as TopSiteSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | TopSiteDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "autofill") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The autofill command accepts no positional values.",
+      );
+    }
+    const result = queryAutofill({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      sort: enumOption(parsed, "--sort", [
+        "created-time",
+        "last-used-time",
+        "field-name",
+        "value",
+        "profile",
+      ] as const) as AutofillSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | AutofillDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -65,6 +65,30 @@ export interface LoginDataArtifactWrite {
   readonly recoveredCredentialCount: number;
 }
 
+export interface PersistedAutofillFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortCreated: string | null;
+  readonly sortLastUsed: string | null;
+  readonly sortName: string | null;
+  readonly sortValue: string | null;
+}
+
+export interface WebDataArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedAutofillFinding[];
+  readonly committedFieldCount: number;
+  readonly recoveredFieldCount: number;
+}
+
 export interface PersistedCookieFinding {
   readonly finding: Finding;
   readonly searchText: string;
@@ -126,6 +150,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly cookieArtifacts?: readonly CookieArtifactWrite[];
   readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
   readonly topSitesArtifacts?: readonly TopSitesArtifactWrite[];
+  readonly webDataArtifacts?: readonly WebDataArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -301,6 +326,66 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON login_data_findings(finding_kind, COALESCE(sort_username, ''), finding_id);
     CREATE INDEX IF NOT EXISTS login_data_findings_profile_query
       ON login_data_findings(finding_kind, profile_path, finding_id);
+
+    CREATE TABLE IF NOT EXISTS web_data_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Web Data'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS web_data_one_active_result
+      ON web_data_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS web_data_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES web_data_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_created TEXT,
+      sort_last_used TEXT,
+      sort_name TEXT,
+      sort_value TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS web_data_findings_created_query
+      ON web_data_findings(finding_kind, COALESCE(sort_created, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS web_data_findings_last_used_query
+      ON web_data_findings(finding_kind, COALESCE(sort_last_used, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS web_data_findings_name_query
+      ON web_data_findings(finding_kind, COALESCE(sort_name, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS web_data_findings_value_query
+      ON web_data_findings(finding_kind, COALESCE(sort_value, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS web_data_findings_profile_query
+      ON web_data_findings(finding_kind, profile_path, finding_id);
 
     CREATE TABLE IF NOT EXISTS cookie_artifact_results (
       artifact_result_id INTEGER PRIMARY KEY,
@@ -501,6 +586,32 @@ function insertLoginFinding(
   );
 }
 
+function insertAutofillFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedAutofillFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortCreated,
+    row.sortLastUsed,
+    row.sortName,
+    row.sortValue,
+  );
+}
+
 function insertCookieFinding(
   statement: ReturnType<DatabaseSync["prepare"]>,
   artifactResultId: bigint,
@@ -644,6 +755,30 @@ export function storeHistoryAnalysis(
       );
       const activateCurrentLogin = database.prepare(
         "UPDATE login_data_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
+      const insertWebDataArtifact = database.prepare(
+        `INSERT INTO web_data_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Web Data', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertWebDataFindingStatement = database.prepare(
+        `INSERT INTO web_data_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_created,
+            sort_last_used, sort_name, sort_value)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousWebData = database.prepare(
+        `UPDATE web_data_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Web Data'
+            AND active = 1`,
+      );
+      const activateCurrentWebData = database.prepare(
+        "UPDATE web_data_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
       const insertCookieArtifact = database.prepare(
         `INSERT INTO cookie_artifact_results
@@ -814,11 +949,40 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of options.webDataArtifacts ?? []) {
+        const insertion = insertWebDataArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertAutofillFinding(
+            insertWebDataFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousWebData.run(artifact.sourceId, artifact.profile);
+          activateCurrentWebData.run(artifactResultId);
+        }
+      }
+
       const combinedArtifacts = [
         ...options.artifacts,
         ...cookieArtifacts,
         ...(options.loginDataArtifacts ?? []),
         ...(options.topSitesArtifacts ?? []),
+        ...(options.webDataArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -9,14 +9,15 @@ import { ForensixError } from "./errors.js";
  * Read-only Case overview surface. It powers the loopback dashboard's
  * Completeness Statements and Profile filters. It interprets no artifact rows
  * and writes nothing: every function opens the Case immutable and read-only,
- * mirroring the History/Cookies/Login Data query contracts.
+ * mirroring the History/Cookies/Login Data/Web Data query contracts.
  */
 
 export type OverviewArtifact =
   | "History"
   | "Cookies"
   | "Login Data"
-  | "Top Sites";
+  | "Top Sites"
+  | "Web Data";
 export type CompletenessOutcome = "produced" | "absent" | "unavailable";
 
 export interface CompletenessArtifact {
@@ -78,6 +79,7 @@ const ARTIFACT_TABLES: readonly ArtifactTable[] = [
   { artifact: "Cookies", resultsTable: "cookie_artifact_results" },
   { artifact: "Login Data", resultsTable: "login_data_artifact_results" },
   { artifact: "Top Sites", resultsTable: "top_sites_artifact_results" },
+  { artifact: "Web Data", resultsTable: "web_data_artifact_results" },
 ];
 
 function openCase(caseDirectory: string): DatabaseSync {

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -9,10 +9,12 @@ import {
   type LoginDataArtifactWrite,
   type PersistedFinding,
   type TopSitesArtifactWrite,
+  type WebDataArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseLoginDataProfile } from "./login-data.js";
 import { analyseSourceTopSites } from "./top-sites.js";
+import { analyseWebDataProfile } from "./web-data.js";
 import {
   loadAuthorizedKeyMaterial,
   type KeyMaterialIssue,
@@ -158,6 +160,17 @@ export interface TopSitesAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface WebDataAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly committedFieldCount: number;
+  readonly recoveredFieldCount: number;
+  readonly findingCount: number;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -168,6 +181,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly cookies: CookieAnalysisSummary;
   readonly loginData: LoginDataAnalysisSummary;
   readonly topSites: TopSitesAnalysisSummary;
+  readonly webData: WebDataAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
 
@@ -1227,6 +1241,7 @@ export async function analyseCase(
   const cookieArtifacts: CookieArtifactWrite[] = [];
   const loginDataArtifacts: LoginDataArtifactWrite[] = [];
   const topSitesArtifacts: TopSitesArtifactWrite[] = [];
+  const webDataArtifacts: WebDataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1246,6 +1261,14 @@ export async function analyseCase(
           workingCopyPath,
           declaredTimezone,
           decryption,
+        }),
+      );
+      webDataArtifacts.push(
+        await analyseWebDataProfile({
+          source,
+          profile: profile.path,
+          workingCopyPath,
+          declaredTimezone,
         }),
       );
     }
@@ -1278,6 +1301,7 @@ export async function analyseCase(
     cookieArtifacts,
     loginDataArtifacts,
     topSitesArtifacts,
+    webDataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1321,6 +1345,15 @@ export async function analyseCase(
   const topSitesUnavailable = topSitesArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const webAnalysed = webDataArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const webAbsent = webDataArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const webUnavailable = webDataArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   return {
     ...verification,
     command: "analyse",
@@ -1329,7 +1362,8 @@ export async function analyseCase(
       analysed.length +
       cookiesAnalysed.length +
       loginAnalysed.length +
-      topSitesAnalysed.length,
+      topSitesAnalysed.length +
+      webAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
     cookies: {
@@ -1432,6 +1466,28 @@ export async function analyseCase(
         0,
       ),
       findingCount: topSitesAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+    },
+    webData: {
+      status: webUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: webAnalysed.length,
+      absentProfileCount: webAbsent.length,
+      unavailableProfileCount: webUnavailable.length,
+      committedFieldCount: webAnalysed.reduce(
+        (count, artifact) => count + artifact.committedFieldCount,
+        0,
+      ),
+      recoveredFieldCount: webAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredFieldCount,
+        0,
+      ),
+      findingCount: webAnalysed.reduce(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -99,6 +99,7 @@ export {
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
   type TopSitesAnalysisSummary,
+  type WebDataAnalysisSummary,
 } from "./history.js";
 export {
   DECRYPTION_DISABLED,
@@ -182,6 +183,13 @@ export {
   type TopSiteQuery,
   type TopSiteSort,
 } from "./top-sites-query.js";
+export {
+  queryAutofill,
+  type AutofillDirection,
+  type AutofillPage,
+  type AutofillQuery,
+  type AutofillSort,
+} from "./web-data-query.js";
 export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,

--- a/core/src/web-data-query.ts
+++ b/core/src/web-data-query.ts
@@ -1,0 +1,363 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type AutofillSort =
+  | "created-time"
+  | "last-used-time"
+  | "field-name"
+  | "value"
+  | "profile";
+export type AutofillDirection = "asc" | "desc";
+
+export interface AutofillQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly sort?: AutofillSort;
+  readonly direction?: AutofillDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface AutofillPage {
+  readonly status: "ok";
+  readonly command: "autofill";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string;
+}
+
+const AUTOFILL_SORTS = [
+  "created-time",
+  "last-used-time",
+  "field-name",
+  "value",
+  "profile",
+] as const;
+const AUTOFILL_DIRECTIONS = ["asc", "desc"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const AUTOFILL_KIND = "autofill_entry";
+
+const SORT_EXPRESSIONS: Readonly<Record<AutofillSort, string>> = {
+  "created-time": "COALESCE(f.sort_created, '')",
+  "last-used-time": "COALESCE(f.sort_last_used, '')",
+  "field-name": "COALESCE(f.sort_name, '')",
+  value: "COALESCE(f.sort_value, '')",
+  profile: "f.profile_path",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly sort: AutofillSort;
+  readonly direction: AutofillDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Autofill cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Autofill cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Autofill --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Autofill ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM web_data_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function findingSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'web_data_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Web Data Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryAutofill(input: AutofillQuery): AutofillPage {
+  const direction = enumValue(
+    input.direction,
+    "desc",
+    AUTOFILL_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "created-time", AUTOFILL_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Autofill queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!findingSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Web Data analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [AUTOFILL_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      if (findingId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Autofill cursor contains an invalid sort key.",
+        );
+      }
+      parameters.push(cursor.key, cursor.key, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM web_data_findings f
+           JOIN web_data_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "autofill",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/web-data-sqlite.ts
+++ b/core/src/web-data-sqlite.ts
@@ -1,0 +1,394 @@
+import { lstat, mkdtemp, open, rm } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import type { CommitState } from "./forensic-model.js";
+import { openDatabaseSync } from "./sqlite-open.js";
+import { readStableRegularFile } from "./stable-file.js";
+
+export type RawWebDataValue = null | string | bigint | Uint8Array;
+
+/**
+ * One row of the Chrome `autofill` table, preserved column-by-column exactly as
+ * stored. The `autofill` table has no integer primary key — its logical key is
+ * `(name, value)` — so the stable SQLite `rowid` is retained as the Provenance
+ * row identity. Values keep their raw SQLite type so the Finding layer can
+ * classify each Field State (value, absent, or unavailable) without lossy
+ * coercion.
+ */
+export interface RawAutofillRow {
+  readonly values: ReadonlyMap<string, RawWebDataValue>;
+  readonly rowId: bigint | null;
+}
+
+export interface WebDataSchema {
+  readonly version: number;
+  readonly columns: ReadonlySet<string>;
+}
+
+export interface WebDataPass {
+  readonly schema: WebDataSchema;
+  readonly rows: readonly RawAutofillRow[];
+  readonly integrity: string;
+}
+
+export interface RecoveredWebDataPass extends WebDataPass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface WebDataPasses {
+  readonly committed: WebDataPass;
+  readonly recovered: RecoveredWebDataPass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+export interface VerifiedWebDataFile {
+  readonly path: string;
+  readonly manifestPath: string;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+/**
+ * Columns the metadata pipeline preserves when present. The `name` column holds
+ * the form field type (for example `email`, `phone`, `city`, or a structured
+ * address component such as `ADDRESS_HOME_CITY`), which is how the `autofill`
+ * table captures form/phone/address/city evidence. All values are cleartext, so
+ * no decryption is involved.
+ */
+export const SUPPORTED_AUTOFILL_COLUMNS = [
+  "name",
+  "value",
+  "value_lower",
+  "date_created",
+  "date_last_used",
+  "count",
+] as const;
+
+const REQUIRED_AUTOFILL_COLUMNS = ["name", "value"] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): WebDataSchema {
+  for (const table of ["meta", "autofill"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `Web Data database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "Web Data meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const columns = tableColumns(database, "autofill");
+  const missing = REQUIRED_AUTOFILL_COLUMNS.filter(
+    (column) => !columns.has(column),
+  );
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Web Data schema version ${version} is missing required autofill columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return { version, columns };
+}
+
+function normalizeValue(value: unknown): RawWebDataValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Web Data contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): WebDataPass {
+  const schema = readSchema(database);
+  const selected = SUPPORTED_AUTOFILL_COLUMNS.filter((column) =>
+    schema.columns.has(column),
+  );
+  const projection = selected
+    .map((column) => `a."${column}" AS "${column}"`)
+    .join(",\n      ");
+  const statement = database.prepare(`
+    SELECT
+      a.rowid AS "__rowid",
+      ${projection}
+    FROM autofill a
+    ORDER BY a.rowid
+  `);
+  const rows: RawAutofillRow[] = [];
+  for (const row of statement.iterate()) {
+    const values = new Map<string, RawWebDataValue>();
+    for (const column of selected) {
+      values.set(column, normalizeValue(row[column]));
+    }
+    const rawRowId = normalizeValue(row.__rowid);
+    rows.push({
+      values,
+      rowId: typeof rawRowId === "bigint" ? rawRowId : null,
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function immutableDatabase(path: string): DatabaseSync {
+  const url = pathToFileURL(path);
+  url.searchParams.set("immutable", "1");
+  return openDatabaseSync(url.href, {
+    readOnly: true,
+    readBigInts: true,
+  });
+}
+
+function fingerprint(row: RawAutofillRow): string {
+  return JSON.stringify(
+    [...row.values.entries()].sort(([left], [right]) =>
+      left < right ? -1 : left > right ? 1 : 0,
+    ),
+    (_key, value: unknown) => {
+      if (typeof value === "bigint") {
+        return `${value.toString()}n`;
+      }
+      if (value instanceof Uint8Array) {
+        return `blob:${Buffer.from(value).toString("base64")}`;
+      }
+      return value;
+    },
+  );
+}
+
+/**
+ * Return only rows that a WAL or rollback journal adds or changes relative to
+ * the committed database, keyed by `autofill.rowid`. This keeps recovered
+ * evidence separate from committed evidence, mirroring the History recovery
+ * contract.
+ */
+function recoveredOnlyRows(
+  committed: readonly RawAutofillRow[],
+  recovered: readonly RawAutofillRow[],
+): RawAutofillRow[] {
+  const committedByRowId = new Map(
+    committed.flatMap((row) =>
+      row.rowId === null
+        ? []
+        : [[row.rowId.toString(), fingerprint(row)] as const],
+    ),
+  );
+  const rows: RawAutofillRow[] = [];
+  for (const row of recovered) {
+    const id = row.rowId === null ? null : row.rowId.toString();
+    const committedFingerprint =
+      id === null ? undefined : committedByRowId.get(id);
+    if (
+      committedFingerprint === undefined ||
+      committedFingerprint !== fingerprint(row)
+    ) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+async function writeAll(destination: FileHandle, chunk: Buffer): Promise<void> {
+  let written = 0;
+  while (written < chunk.length) {
+    const result = await destination.write(
+      chunk,
+      written,
+      chunk.length - written,
+    );
+    written += result.bytesWritten;
+  }
+}
+
+async function snapshotVerifiedFile(
+  source: VerifiedWebDataFile,
+  destinationPath: string,
+): Promise<void> {
+  let stats;
+  try {
+    stats = await lstat(source.path, { bigint: true });
+  } catch {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_missing" },
+    ]);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_not_regular_file" },
+    ]);
+  }
+
+  const destination = await open(destinationPath, "wx", 0o600);
+  let result;
+  try {
+    result = await readStableRegularFile(source.path, stats, async (chunk) =>
+      writeAll(destination, chunk),
+    );
+    await destination.sync();
+  } finally {
+    await destination.close();
+  }
+  if (result.status !== "stable") {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: source.manifestPath, reason: "entry_unreadable" },
+    ]);
+  }
+  const issues = [];
+  if (result.size !== source.size) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_size_mismatch" as const,
+      expected: source.size,
+      actual: result.size,
+    });
+  }
+  if (result.sha256 !== source.sha256) {
+    issues.push({
+      path: source.manifestPath,
+      reason: "entry_hash_mismatch" as const,
+      expected: source.sha256,
+      actual: result.sha256,
+    });
+  }
+  if (issues.length > 0) {
+    throw new WorkingCopyIntegrityRefusal(issues);
+  }
+}
+
+export async function readWebDataPasses(options: {
+  readonly database: VerifiedWebDataFile;
+  readonly sidecars: readonly VerifiedWebDataFile[];
+}): Promise<WebDataPasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-web-data-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: WebDataPass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyRows(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/web-data-sqlite.ts
+++ b/core/src/web-data-sqlite.ts
@@ -54,11 +54,15 @@ export interface VerifiedWebDataFile {
 }
 
 /**
- * Columns the metadata pipeline preserves when present. The `name` column holds
- * the form field type (for example `email`, `phone`, `city`, or a structured
- * address component such as `ADDRESS_HOME_CITY`), which is how the `autofill`
- * table captures form/phone/address/city evidence. All values are cleartext, so
- * no decryption is involved.
+ * Columns the metadata pipeline preserves when present. The `autofill` table is
+ * Chrome's form-autocomplete history: one row per distinct submitted
+ * (field, value) pair. The `name` column holds the raw HTML form field `name`
+ * (or `autocomplete`) attribute as authored by the visited site — for example
+ * `email`, `phone`, `tel`, `city`, `address`, or `postal-code` — which is how
+ * this table captures form/phone/address/city evidence. It is not Chrome's
+ * internal address-book `ServerFieldType` token, and it is not the structured
+ * address profiles stored separately in `autofill_profiles` / `contact_info` /
+ * `local_addresses`. All values are cleartext, so no decryption is involved.
  */
 export const SUPPORTED_AUTOFILL_COLUMNS = [
   "name",

--- a/core/src/web-data.ts
+++ b/core/src/web-data.ts
@@ -39,10 +39,6 @@ interface ManifestIdentity {
   readonly databasePath: string;
 }
 
-interface BuiltAutofill {
-  readonly persisted: PersistedAutofillFinding;
-}
-
 function utcFromUnixSeconds(seconds: bigint): string | null {
   const milliseconds = seconds * 1000n;
   const numericMilliseconds = Number(milliseconds);
@@ -132,7 +128,7 @@ function buildAutofillEntries(options: {
   readonly profile: string;
   readonly manifest: ManifestIdentity;
   readonly declaredTimezone: string;
-}): BuiltAutofill[] {
+}): PersistedAutofillFinding[] {
   return options.rows.map((row) => {
     if (row.rowId === null) {
       throw new ForensixError(
@@ -175,20 +171,14 @@ function buildAutofillEntries(options: {
       fields,
     });
     return {
-      persisted: {
-        finding,
-        searchText: [
-          options.profile,
-          textValue(fieldName),
-          textValue(fieldValue),
-        ]
-          .join("\n")
-          .toLocaleLowerCase("en-US"),
-        sortCreated: timeValue(dateCreated),
-        sortLastUsed: timeValue(dateLastUsed),
-        sortName: textValue(fieldName) || null,
-        sortValue: textValue(fieldValue) || null,
-      },
+      finding,
+      searchText: [options.profile, textValue(fieldName), textValue(fieldValue)]
+        .join("\n")
+        .toLocaleLowerCase("en-US"),
+      sortCreated: timeValue(dateCreated),
+      sortLastUsed: timeValue(dateLastUsed),
+      sortName: textValue(fieldName) || null,
+      sortValue: textValue(fieldValue) || null,
     };
   });
 }
@@ -368,10 +358,7 @@ export async function analyseWebDataProfile(options: {
       integrity: passes.committed.integrity,
       recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
       reason: passes.recoveryUnavailableReason,
-      findings: [
-        ...committed.map((entry) => entry.persisted),
-        ...recovered.map((entry) => entry.persisted),
-      ],
+      findings: [...committed, ...recovered],
       committedFieldCount: committed.length,
       recoveredFieldCount: recovered.length,
     };

--- a/core/src/web-data.ts
+++ b/core/src/web-data.ts
@@ -1,0 +1,395 @@
+import { join } from "node:path";
+
+import type {
+  PersistedAutofillFinding,
+  WebDataArtifactWrite,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import {
+  readWebDataPasses,
+  type RawAutofillRow,
+  type RawWebDataValue,
+  type VerifiedWebDataFile,
+  type WebDataSchema,
+} from "./web-data-sqlite.js";
+
+/**
+ * Chrome stores `autofill` timestamps with `base::Time::ToTimeT()`, i.e. whole
+ * seconds since 1970-01-01 UTC, on every platform. The epoch does not depend on
+ * the origin OS, so no Declared Origin OS is required.
+ */
+const AUTOFILL_EPOCH_FAMILY = "unix-seconds" as const;
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface BuiltAutofill {
+  readonly persisted: PersistedAutofillFinding;
+}
+
+function utcFromUnixSeconds(seconds: bigint): string | null {
+  const milliseconds = seconds * 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+function preservedString(value: RawWebDataValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(value: RawWebDataValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function timestampField(
+  raw: RawWebDataValue,
+  columnPresent: boolean,
+  schemaVersion: number,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (!columnPresent || raw === undefined || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const utc = utcFromUnixSeconds(raw);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: AUTOFILL_EPOCH_FAMILY,
+      utc,
+      declaredTimezone,
+      resolution: `verified_web_data_schema_version_${schemaVersion}`,
+    },
+    { synthetic: false },
+  );
+}
+
+function sourceRowProvenance(
+  manifest: ManifestIdentity,
+  rowId: string,
+): SourceRowProvenance {
+  return {
+    manifestEntryId: `${manifest.sourceId}:${manifest.ordinal}`,
+    sourceId: manifest.sourceId,
+    manifestEntryOrdinal: manifest.ordinal,
+    manifestPath: manifest.path,
+    database: manifest.databasePath,
+    table: "autofill",
+    rowId,
+  };
+}
+
+function textValue(field: FieldState<string>): string {
+  return field.state === "value" ? field.value : "";
+}
+
+function timeValue(field: FieldState<ForensicTimestamp>): string | null {
+  return field.state === "value" ? field.value.utc : null;
+}
+
+function buildAutofillEntries(options: {
+  readonly rows: readonly RawAutofillRow[];
+  readonly schema: WebDataSchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+}): BuiltAutofill[] {
+  return options.rows.map((row) => {
+    if (row.rowId === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Web Data autofill.rowid is not an exact integer.",
+      );
+    }
+    const rowId = row.rowId.toString();
+    const has = (column: string): boolean => options.schema.columns.has(column);
+    const get = (column: string): RawWebDataValue =>
+      row.values.get(column) ?? null;
+    const fieldName = preservedString(get("name"));
+    const fieldValue = preservedString(get("value"));
+    const dateCreated = timestampField(
+      get("date_created"),
+      has("date_created"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const dateLastUsed = timestampField(
+      get("date_last_used"),
+      has("date_last_used"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const fields = {
+      autofillId: valueField(rowId),
+      fieldName,
+      fieldValue,
+      fieldValueLower: preservedString(get("value_lower")),
+      timesUsed: preservedInteger(get("count")),
+      dateCreated,
+      dateLastUsed,
+    };
+    const finding: Finding = createFinding({
+      findingKind: "autofill_entry",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance: sourceRowProvenance(options.manifest, rowId),
+      fields,
+    });
+    return {
+      persisted: {
+        finding,
+        searchText: [
+          options.profile,
+          textValue(fieldName),
+          textValue(fieldValue),
+        ]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortCreated: timeValue(dateCreated),
+        sortLastUsed: timeValue(dateLastUsed),
+        sortName: textValue(fieldName) || null,
+        sortValue: textValue(fieldValue) || null,
+      },
+    };
+  });
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): WebDataArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedFieldCount: 0,
+    recoveredFieldCount: 0,
+  };
+}
+
+export async function analyseWebDataProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+}): Promise<WebDataArtifactWrite> {
+  const databasePath =
+    options.profile === "." ? "Web Data" : `${options.profile}/Web Data`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      null,
+      "absent",
+      "web_data_manifest_entry_missing",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "web_data_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `web_data_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "web_data_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "web_data_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedWebDataFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedWebDataFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readWebDataPasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Web Data recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const committed = buildAutofillEntries({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      declaredTimezone: options.declaredTimezone,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildAutofillEntries({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            declaredTimezone: options.declaredTimezone,
+          });
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [
+        ...committed.map((entry) => entry.persisted),
+        ...recovered.map((entry) => entry.persisted),
+      ],
+      committedFieldCount: committed.length,
+      recoveredFieldCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `web_data_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}

--- a/e2e/web-data-cli.test.ts
+++ b/e2e/web-data-cli.test.ts
@@ -284,7 +284,7 @@ describe("compiled analyzer CLI Web Data autofill metadata", () => {
     });
     expect(phone[0]?.fields.dateLastUsed).toEqual({ state: "absent" });
 
-    // A city field is recovered from the address-bearing Default Profile.
+    // The Default Profile's `city` form field is matched by a value search.
     const city = parseJson<AutofillPage>(
       runCli([
         "autofill",

--- a/e2e/web-data-cli.test.ts
+++ b/e2e/web-data-cli.test.ts
@@ -151,7 +151,7 @@ async function createSource(root: string): Promise<string> {
       count: 2n,
     },
     {
-      name: "ADDRESS_HOME_CITY",
+      name: "city",
       value: "Springfield",
       dateCreated: 1_704_300_000n,
       dateLastUsed: 1_704_400_000n,
@@ -160,7 +160,7 @@ async function createSource(root: string): Promise<string> {
   ]);
   await createWebData(join(source, "Profile 1", "Web Data"), [
     {
-      name: "ADDRESS_HOME_STREET_ADDRESS",
+      name: "address",
       value: "742 Evergreen Terrace",
       dateCreated: 1_705_000_000n,
       dateLastUsed: 1_705_100_000n,
@@ -298,7 +298,7 @@ describe("compiled analyzer CLI Web Data autofill metadata", () => {
     expect(city).toHaveLength(1);
     expect(city[0]?.fields.fieldName).toEqual({
       state: "value",
-      value: "ADDRESS_HOME_CITY",
+      value: "city",
     });
     expect(city[0]?.fields.fieldValue).toEqual({
       state: "value",
@@ -359,7 +359,7 @@ describe("compiled analyzer CLI Web Data autofill metadata", () => {
       PRAGMA wal_checkpoint(TRUNCATE);
     `);
     insertAutofill(writer, {
-      name: "ADDRESS_HOME_CITY",
+      name: "city",
       value: "Portland",
       dateCreated: 1_704_300_000n,
       dateLastUsed: 1_704_300_000n,
@@ -416,7 +416,7 @@ describe("compiled analyzer CLI Web Data autofill metadata", () => {
         table: "autofill",
       },
       fields: {
-        fieldName: { state: "value", value: "ADDRESS_HOME_CITY" },
+        fieldName: { state: "value", value: "city" },
         fieldValue: { state: "value", value: "Portland" },
       },
     });
@@ -461,5 +461,41 @@ describe("compiled analyzer CLI Web Data autofill metadata", () => {
     }>(analysis.stdout);
     expect(parsed.webData.analysedProfileCount).toBe(0);
     expect(parsed.webData.unavailableProfileCount).toBe(2);
+
+    // The two failures carry DISTINCT typed reasons in the Case: a missing
+    // autofill table is not conflated with a malformed/unreadable database.
+    const caseDatabase = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readOnly: true,
+    });
+    let reasons: Record<string, string>;
+    try {
+      const rows = caseDatabase
+        .prepare(
+          `SELECT profile_path, status, reason
+             FROM web_data_artifact_results
+            ORDER BY profile_path`,
+        )
+        .all() as unknown as readonly {
+        readonly profile_path: string;
+        readonly status: string;
+        readonly reason: string;
+      }[];
+      reasons = Object.fromEntries(
+        rows.map((row) => {
+          expect(row.status).toBe("unavailable");
+          return [row.profile_path, row.reason];
+        }),
+      );
+    } finally {
+      caseDatabase.close();
+    }
+    // Missing table: a structured ANALYSIS_FAILED reason naming the table.
+    expect(reasons.Default).toContain("missing the autofill table");
+    // Malformed database: a distinct read-failure reason, not "missing".
+    expect(reasons["Profile 1"]).not.toContain("missing the autofill table");
+    expect(reasons["Profile 1"]).toMatch(
+      /ANALYSIS_FAILED|web_data_read_failed/,
+    );
+    expect(reasons.Default).not.toBe(reasons["Profile 1"]);
   });
 });

--- a/e2e/web-data-cli.test.ts
+++ b/e2e/web-data-cli.test.ts
@@ -1,0 +1,465 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface AutofillFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "autofill_entry";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: {
+    readonly autofillId: Field<string>;
+    readonly fieldName: Field<string>;
+    readonly fieldValue: Field<string>;
+    readonly fieldValueLower: Field<string>;
+    readonly timesUsed: Field<string>;
+    readonly dateCreated: Field<{
+      readonly raw: string;
+      readonly epochFamily: string;
+      readonly utc: string;
+      readonly declaredTimezone: string;
+      readonly resolution: string;
+    }>;
+    readonly dateLastUsed: Field<unknown>;
+  };
+}
+
+interface AutofillPage {
+  readonly status: "ok";
+  readonly command: "autofill";
+  readonly items: readonly AutofillFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+interface AutofillRow {
+  readonly name: string;
+  readonly value: string;
+  readonly dateCreated: bigint;
+  readonly dateLastUsed: bigint;
+  readonly count: bigint;
+}
+
+function createWebDataSchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+    INSERT INTO meta (key, value) VALUES ('version', '133'), ('last_compatible_version', '83');
+
+    CREATE TABLE autofill (
+      name VARCHAR,
+      value VARCHAR,
+      value_lower VARCHAR,
+      date_created INTEGER DEFAULT 0,
+      date_last_used INTEGER DEFAULT 0,
+      count INTEGER DEFAULT 1,
+      PRIMARY KEY (name, value)
+    );
+  `);
+}
+
+function insertAutofill(database: DatabaseSync, row: AutofillRow): void {
+  database
+    .prepare(
+      `INSERT INTO autofill
+         (name, value, value_lower, date_created, date_last_used, count)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      row.name,
+      row.value,
+      row.value.toLocaleLowerCase("en-US"),
+      row.dateCreated,
+      row.dateLastUsed,
+      row.count,
+    );
+}
+
+async function createWebData(
+  path: string,
+  rows: readonly AutofillRow[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    createWebDataSchema(database);
+    for (const row of rows) {
+      insertAutofill(database, row);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createWebData(join(source, "Default", "Web Data"), [
+    // Unix seconds: 1704164645 -> 2024-01-02T03:04:05Z
+    {
+      name: "email",
+      value: "alice@alpha.example",
+      dateCreated: 1_704_164_645n,
+      dateLastUsed: 1_704_251_045n,
+      count: 4n,
+    },
+    {
+      name: "phone",
+      value: "+1-555-0100",
+      dateCreated: 1_704_200_000n,
+      dateLastUsed: 0n,
+      count: 2n,
+    },
+    {
+      name: "ADDRESS_HOME_CITY",
+      value: "Springfield",
+      dateCreated: 1_704_300_000n,
+      dateLastUsed: 1_704_400_000n,
+      count: 7n,
+    },
+  ]);
+  await createWebData(join(source, "Profile 1", "Web Data"), [
+    {
+      name: "ADDRESS_HOME_STREET_ADDRESS",
+      value: "742 Evergreen Terrace",
+      dateCreated: 1_705_000_000n,
+      dateLastUsed: 1_705_100_000n,
+      count: 1n,
+    },
+  ]);
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Web Data autofill metadata", () => {
+  it("parses form/phone/address/city fields across Profiles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-web-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const defaultBytes = await readFile(join(source, "Default", "Web Data"));
+    const caseDirectory = join(root, "CASE-WEB");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      webData: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        unavailableProfileCount: 0,
+        committedFieldCount: 4,
+        recoveredFieldCount: 0,
+      },
+    });
+
+    // AC5: bounded, multi-Profile keyset pagination ordered by creation time.
+    const firstPage = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "created-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage).toMatchObject({ command: "autofill", limit: 2 });
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const [email] = firstPage.items;
+    expect(email).toBeDefined();
+    // AC1 + AC2: field name/value exact vs ground truth, one Field State each,
+    // with resolvable Provenance to the exact autofill rowid.
+    expect(email).toMatchObject({
+      recordType: "finding",
+      findingKind: "autofill_entry",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Web Data",
+        database: "Default/Web Data",
+        table: "autofill",
+      },
+      fields: {
+        fieldName: { state: "value", value: "email" },
+        fieldValue: { state: "value", value: "alice@alpha.example" },
+        fieldValueLower: { state: "value", value: "alice@alpha.example" },
+        timesUsed: { state: "value", value: "4" },
+      },
+    });
+    expect(email?.provenance.rowId).toMatch(/^[0-9]+$/);
+    // AC4: timestamp keeps raw value, Epoch Family (unix-seconds), and UTC.
+    expect(email?.fields.dateCreated).toEqual({
+      state: "value",
+      synthetic: false,
+      value: {
+        raw: "1704164645",
+        epochFamily: "unix-seconds",
+        utc: "2024-01-02T03:04:05.000Z",
+        declaredTimezone: "America/New_York",
+        resolution: "verified_web_data_schema_version_133",
+      },
+    });
+
+    // A never-reused entry has date_last_used = 0: absent, not blank/unavailable.
+    const phone = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--search",
+        "555-0100",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(phone).toHaveLength(1);
+    expect(phone[0]?.fields.fieldName).toEqual({
+      state: "value",
+      value: "phone",
+    });
+    expect(phone[0]?.fields.dateLastUsed).toEqual({ state: "absent" });
+
+    // A city field is recovered from the address-bearing Default Profile.
+    const city = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--search",
+        "springfield",
+        "--json",
+      ]).stdout,
+    ).items;
+    expect(city).toHaveLength(1);
+    expect(city[0]?.fields.fieldName).toEqual({
+      state: "value",
+      value: "ADDRESS_HOME_CITY",
+    });
+    expect(city[0]?.fields.fieldValue).toEqual({
+      state: "value",
+      value: "Springfield",
+    });
+
+    const secondPage = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "created-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const allIds = [...firstPage.items, ...secondPage.items].map(
+      (item) => `${item.profile}:${item.provenance.rowId}`,
+    );
+    expect(new Set(allIds).size).toBe(4);
+    expect(
+      [...firstPage.items, ...secondPage.items].map((item) => item.profile),
+    ).toContain("Profile 1");
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(source, "Default", "Web Data"))).toEqual(
+      defaultBytes,
+    );
+  });
+
+  it("keeps committed and WAL-resident autofill entries separate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-web-wal-"));
+    temporaryRoots.push(root);
+    const source = join(root, "wal-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const webPath = join(source, "Default", "Web Data");
+    await createWebData(webPath, [
+      {
+        name: "email",
+        value: "committed@example",
+        dateCreated: 1_704_164_645n,
+        dateLastUsed: 1_704_164_645n,
+        count: 1n,
+      },
+    ]);
+
+    const writer = new DatabaseSync(webPath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    insertAutofill(writer, {
+      name: "ADDRESS_HOME_CITY",
+      value: "Portland",
+      dateCreated: 1_704_300_000n,
+      dateLastUsed: 1_704_300_000n,
+      count: 3n,
+    });
+
+    const caseDirectory = join(root, "CASE-WEB-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      webData: { committedFieldCount: 1, recoveredFieldCount: 1 },
+    });
+
+    const committed = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/Web Data" },
+      fields: { fieldValue: { state: "value", value: "committed@example" } },
+    });
+
+    const recovered = parseJson<AutofillPage>(
+      runCli([
+        "autofill",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/Web Data-wal",
+        database: "Default/Web Data",
+        table: "autofill",
+      },
+      fields: {
+        fieldName: { state: "value", value: "ADDRESS_HOME_CITY" },
+        fieldValue: { state: "value", value: "Portland" },
+      },
+    });
+  });
+
+  it("distinguishes a missing autofill table from a malformed database", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-web-bad-"));
+    temporaryRoots.push(root);
+    const source = join(root, "bad-source");
+    await mkdir(join(source, "Default"), { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    // A Web Data database with meta but no autofill table.
+    const noTablePath = join(source, "Default", "Web Data");
+    const database = new DatabaseSync(noTablePath);
+    try {
+      database.exec(`
+        CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+        INSERT INTO meta (key, value) VALUES ('version', '133');
+      `);
+    } finally {
+      database.close();
+    }
+    // Profile 1 has a malformed (non-SQLite) Web Data blob.
+    await mkdir(join(source, "Profile 1"), { recursive: true });
+    await writeFile(
+      join(source, "Profile 1", "Web Data"),
+      "this is not a sqlite database\n",
+    );
+
+    const caseDirectory = join(root, "CASE-WEB-BAD");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // Both Profiles are unavailable, so the run is failed (exit code 3) for
+    // Web Data, but distinguished by typed reasons in Completeness.
+    const parsed = parseJson<{
+      readonly webData: {
+        readonly analysedProfileCount: number;
+        readonly unavailableProfileCount: number;
+      };
+    }>(analysis.stdout);
+    expect(parsed.webData.analysedProfileCount).toBe(0);
+    expect(parsed.webData.unavailableProfileCount).toBe(2);
+  });
+});


### PR DESCRIPTION
Closes #178.

Adds a Web Data analyzer that parses the Chrome `autofill` table across every Profile, mirroring the established History / Cookies / Login Data Finding contract (shared query surface: search / filter / commit-state / sort / keyset pagination, multi-Profile, Completeness before rows, TYPE-first Finding, distinct empty/absent/unavailable, committed vs sidecar separate, Epoch Family + UTC for timestamps).

### Acceptance criteria → change map

- **Parse current Web Data schemas across all Profiles for supported form/phone/address/city fields** — `core/src/web-data-sqlite.ts` reads the `autofill` table (`name`, `value`, `value_lower`, `date_created`, `date_last_used`, `count`) present-column-aware; the `name` column carries the field type (`email`, `phone`, `ADDRESS_HOME_CITY`, `ADDRESS_HOME_STREET_ADDRESS`, …). `core/src/history.ts` runs it per Profile alongside History/Cookies/Login Data.
- **Every external field exact vs ground truth with one Field State + resolvable Provenance** — `core/src/web-data.ts` emits one `autofill_entry` Finding per row with a single Field State per field and Provenance resolving to the exact `autofill.rowid` (the table has no integer PK).
- **Timestamps retain raw value + Epoch Family + UTC instant where present** — autofill dates are `base::Time::ToTimeT()` whole seconds since 1970 UTC, recorded as Epoch Family `unix-seconds` with `raw` + `utc` + `resolution`; a zero date is `absent`, never blank.
- **Committed vs sidecar separate** — committed image and WAL/rollback-journal recovery are read in separate passes; recovered rows are diffed by rowid and carry their own sidecar Provenance and Commit State.
- **Distinguish missing tables/columns from malformed/unreadable** — a missing `meta`/`autofill` table or missing required columns raises a typed `ANALYSIS_FAILED` reason; a malformed/unreadable database yields a distinct `web_data_read_failed` unavailable reason. Both stay queryable via the Completeness Statement.
- **Bounded multi-Profile query contract** — `core/src/web-data-query.ts` + the `forensix autofill` CLI command: `--profile` (≤100), `--search`, `--commit-state`, `--sort <created-time|last-used-time|field-name|value|profile>`, `--direction`, `--limit 1-100`, `--after` keyset cursor bound to the active analysis fingerprint. Web Data is also added to the Case Completeness overview.

### Tests

`e2e/web-data-cli.test.ts` (compiled-CLI): multi-Profile parse of form/phone/address/city fields with exact values + Provenance + `unix-seconds` timestamp + zero-date-absent + keyset pagination; committed vs WAL-resident separation with sidecar Provenance; missing-table vs malformed-database distinction.

`pnpm verify` (Node 24.15.0) is green: format:check, lint, typecheck, and all 72 vitest tests pass. No change to Analyzer/Collector separation or existing artifact output.