### PR TITLE
feat(top-sites): parse Top Sites as forensic Findings

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -12,12 +12,15 @@ import {
   queryCookies,
   queryCredentials,
   queryHistory,
+  queryTopSites,
   renderReport,
   type CommitState,
   type CookieDirection,
   type CookieSort,
   type CredentialDirection,
   type CredentialSort,
+  type TopSiteDirection,
+  type TopSiteSort,
   type DeclaredOriginOs,
   type ExtractCollection,
   type HistoryDirection,
@@ -50,6 +53,12 @@ const USAGE = `Usage:
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <created-time|last-used-time|origin|username|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix top-sites --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--sort <rank|url|title|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix serve --case <case-directory> [--port <port>] [--json]
@@ -522,6 +531,52 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as CredentialSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | CredentialDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "top-sites") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The top-sites command accepts no positional values.",
+      );
+    }
+    const result = queryTopSites({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      sort: enumOption(parsed, "--sort", [
+        "rank",
+        "url",
+        "title",
+        "profile",
+      ] as const) as TopSiteSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | TopSiteDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -149,6 +149,14 @@ const ARTIFACTS: readonly ArtifactConfig[] = [
     sorts: ["created-time", "last-used-time", "origin", "username", "profile"],
     extras: [],
   },
+  {
+    key: "top-sites",
+    label: "Top Sites",
+    route: "top-sites",
+    completenessArtifact: "Top Sites",
+    sorts: ["rank", "url", "title", "profile"],
+    extras: [],
+  },
 ];
 
 function el<K extends keyof HTMLElementTagNameMap>(

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -92,6 +92,29 @@ export interface CookieArtifactWrite {
   readonly recoveredCookieCount: number;
 }
 
+export interface PersistedTopSiteFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortUrl: string | null;
+  readonly sortTitle: string | null;
+  readonly sortRank: bigint | null;
+}
+
+export interface TopSitesArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedTopSiteFinding[];
+  readonly committedTopSiteCount: number;
+  readonly recoveredTopSiteCount: number;
+}
+
 export interface StoreHistoryAnalysisOptions {
   readonly caseDirectory: string;
   readonly sourceIds: readonly string[];
@@ -102,6 +125,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly artifacts: readonly HistoryArtifactWrite[];
   readonly cookieArtifacts?: readonly CookieArtifactWrite[];
   readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
+  readonly topSitesArtifacts?: readonly TopSitesArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -342,6 +366,63 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON cookie_findings(finding_kind, COALESCE(sort_last_access, ''), finding_id);
     CREATE INDEX IF NOT EXISTS cookie_findings_profile_query
       ON cookie_findings(finding_kind, profile_path, commit_state, finding_id);
+
+    CREATE TABLE IF NOT EXISTS top_sites_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Top Sites'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS top_sites_one_active_result
+      ON top_sites_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS top_sites_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES top_sites_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_url TEXT,
+      sort_title TEXT,
+      sort_rank INTEGER,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS top_sites_findings_rank_query
+      ON top_sites_findings(finding_kind, COALESCE(sort_rank, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS top_sites_findings_url_query
+      ON top_sites_findings(finding_kind, COALESCE(sort_url, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS top_sites_findings_title_query
+      ON top_sites_findings(finding_kind, COALESCE(sort_title, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS top_sites_findings_profile_query
+      ON top_sites_findings(finding_kind, profile_path, commit_state, finding_id);
   `);
 }
 
@@ -446,6 +527,31 @@ function insertCookieFinding(
     row.sortLastAccess,
     row.hostKey,
     row.sameSite,
+  );
+}
+
+function insertTopSiteFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedTopSiteFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortUrl,
+    row.sortTitle,
+    row.sortRank,
   );
 }
 
@@ -563,6 +669,30 @@ export function storeHistoryAnalysis(
       const activateCurrentCookie = database.prepare(
         "UPDATE cookie_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertTopSiteArtifact = database.prepare(
+        `INSERT INTO top_sites_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Top Sites', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertTopSiteFindingStatement = database.prepare(
+        `INSERT INTO top_sites_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_url, sort_title,
+            sort_rank)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousTopSite = database.prepare(
+        `UPDATE top_sites_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Top Sites'
+            AND active = 1`,
+      );
+      const activateCurrentTopSite = database.prepare(
+        "UPDATE top_sites_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
 
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
@@ -628,6 +758,34 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of options.topSitesArtifacts ?? []) {
+        const insertion = insertTopSiteArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertTopSiteFinding(
+            insertTopSiteFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousTopSite.run(artifact.sourceId, artifact.profile);
+          activateCurrentTopSite.run(artifactResultId);
+        }
+      }
+
       for (const artifact of options.loginDataArtifacts ?? []) {
         const insertion = insertLoginArtifact.run(
           runId,
@@ -660,6 +818,7 @@ export function storeHistoryAnalysis(
         ...options.artifacts,
         ...cookieArtifacts,
         ...(options.loginDataArtifacts ?? []),
+        ...(options.topSitesArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -12,7 +12,11 @@ import { ForensixError } from "./errors.js";
  * mirroring the History/Cookies/Login Data query contracts.
  */
 
-export type OverviewArtifact = "History" | "Cookies" | "Login Data";
+export type OverviewArtifact =
+  | "History"
+  | "Cookies"
+  | "Login Data"
+  | "Top Sites";
 export type CompletenessOutcome = "produced" | "absent" | "unavailable";
 
 export interface CompletenessArtifact {
@@ -73,6 +77,7 @@ const ARTIFACT_TABLES: readonly ArtifactTable[] = [
   { artifact: "History", resultsTable: "history_artifact_results" },
   { artifact: "Cookies", resultsTable: "cookie_artifact_results" },
   { artifact: "Login Data", resultsTable: "login_data_artifact_results" },
+  { artifact: "Top Sites", resultsTable: "top_sites_artifact_results" },
 ];
 
 function openCase(caseDirectory: string): DatabaseSync {

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -8,9 +8,11 @@ import {
   type HistoryArtifactWrite,
   type LoginDataArtifactWrite,
   type PersistedFinding,
+  type TopSitesArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseLoginDataProfile } from "./login-data.js";
+import { analyseSourceTopSites } from "./top-sites.js";
 import {
   loadAuthorizedKeyMaterial,
   type KeyMaterialIssue,
@@ -144,6 +146,18 @@ export interface LoginDataAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface TopSitesAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly recoveryUnavailableProfileCount: number;
+  readonly committedTopSiteCount: number;
+  readonly recoveredTopSiteCount: number;
+  readonly findingCount: number;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -153,6 +167,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly history: HistoryAnalysisSummary;
   readonly cookies: CookieAnalysisSummary;
   readonly loginData: LoginDataAnalysisSummary;
+  readonly topSites: TopSitesAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
 
@@ -1211,6 +1226,7 @@ export async function analyseCase(
   const artifacts: HistoryArtifactWrite[] = [];
   const cookieArtifacts: CookieArtifactWrite[] = [];
   const loginDataArtifacts: LoginDataArtifactWrite[] = [];
+  const topSitesArtifacts: TopSitesArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1242,6 +1258,12 @@ export async function analyseCase(
         decryption,
       })),
     );
+    topSitesArtifacts.push(
+      ...(await analyseSourceTopSites({
+        source,
+        workingCopyPath,
+      })),
+    );
   }
 
   await verifyWorkingCopy(caseDirectory);
@@ -1255,6 +1277,7 @@ export async function analyseCase(
     artifacts,
     cookieArtifacts,
     loginDataArtifacts,
+    topSitesArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1289,12 +1312,24 @@ export async function analyseCase(
   const loginUnavailable = loginDataArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const topSitesAnalysed = topSitesArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const topSitesAbsent = topSitesArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const topSitesUnavailable = topSitesArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   return {
     ...verification,
     command: "analyse",
     analysisStatus: "ready",
     artifactCount:
-      analysed.length + cookiesAnalysed.length + loginAnalysed.length,
+      analysed.length +
+      cookiesAnalysed.length +
+      loginAnalysed.length +
+      topSitesAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
     cookies: {
@@ -1372,6 +1407,31 @@ export async function analyseCase(
         0,
       ),
       findingCount: loginAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+    },
+    topSites: {
+      status: topSitesUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: topSitesAnalysed.length,
+      absentProfileCount: topSitesAbsent.length,
+      unavailableProfileCount: topSitesUnavailable.length,
+      recoveryUnavailableProfileCount: topSitesAnalysed.filter(
+        (artifact) => artifact.recoveryStatus === "unavailable",
+      ).length,
+      committedTopSiteCount: topSitesAnalysed.reduce(
+        (count, artifact) => count + artifact.committedTopSiteCount,
+        0,
+      ),
+      recoveredTopSiteCount: topSitesAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredTopSiteCount,
+        0,
+      ),
+      findingCount: topSitesAnalysed.reduce(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -98,6 +98,7 @@ export {
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
+  type TopSitesAnalysisSummary,
 } from "./history.js";
 export {
   DECRYPTION_DISABLED,
@@ -174,6 +175,13 @@ export {
   type CookieQuery,
   type CookieSort,
 } from "./cookies-query.js";
+export {
+  queryTopSites,
+  type TopSiteDirection,
+  type TopSitePage,
+  type TopSiteQuery,
+  type TopSiteSort,
+} from "./top-sites-query.js";
 export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,

--- a/core/src/top-sites-query.ts
+++ b/core/src/top-sites-query.ts
@@ -61,11 +61,21 @@ const COMMIT_STATES = [
 ] as const;
 const TOP_SITE_KIND = "top_site";
 
-const SORT_EXPRESSIONS: Readonly<Record<TopSiteSort, string>> = {
-  rank: "COALESCE(f.sort_rank, -1)",
-  url: "COALESCE(f.sort_url, '')",
-  title: "COALESCE(f.sort_title, '')",
-  profile: "f.profile_path",
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+// `rank` keys on the integer `sort_rank` column (with a -1 COALESCE sentinel, so
+// keys can be negative); every other sort keys on text. The `kind` tag drives
+// the cursor-key validation below, mirroring history-query.ts's SortDefinition
+// so the integer/text decision lives in one place rather than in scattered
+// `sort === "rank"` branches.
+const SORTS: Readonly<Record<TopSiteSort, SortDefinition>> = {
+  rank: { expression: "COALESCE(f.sort_rank, -1)", kind: "integer" },
+  url: { expression: "COALESCE(f.sort_url, '')", kind: "text" },
+  title: { expression: "COALESCE(f.sort_title, '')", kind: "text" },
+  profile: { expression: "f.profile_path", kind: "text" },
 };
 
 const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
@@ -243,7 +253,8 @@ export function queryTopSites(input: TopSiteQuery): TopSitePage {
           COMMIT_STATES,
           "--commit-state",
         );
-  const sortExpression = SORT_EXPRESSIONS[sort];
+  const sortDefinition = SORTS[sort];
+  const sortExpression = sortDefinition.expression;
   const limit = normalizeLimit(input.limit);
   const profiles = [...new Set(input.profiles ?? [])].sort();
   if (profiles.length > 100) {
@@ -303,18 +314,16 @@ export function queryTopSites(input: TopSiteQuery): TopSitePage {
           `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
       );
       const findingId = BigInt(cursor.findingId);
-      // The `rank` sort keys on the integer `sort_rank` column (with a -1
-      // COALESCE sentinel, so keys can be negative), whereas every other sort
-      // keys on text. Validate an integer key with the same regex and int64
-      // range guard History uses, so a forged or out-of-range cursor surfaces a
-      // typed INVALID_CURSOR instead of a raw BigInt/node:sqlite throw.
+      // An integer sort validates its key with the same regex and int64 range
+      // guard History uses, so a forged or out-of-range cursor surfaces a typed
+      // INVALID_CURSOR instead of a raw BigInt/node:sqlite throw.
       const integerCursorKey =
-        sort === "rank" && /^-?[0-9]+$/.test(cursor.key)
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
           ? BigInt(cursor.key)
           : null;
       if (
         findingId > SQLITE_MAX_INTEGER ||
-        (sort === "rank" &&
+        (sortDefinition.kind === "integer" &&
           (integerCursorKey === null ||
             integerCursorKey < SQLITE_MIN_INTEGER ||
             integerCursorKey > SQLITE_MAX_INTEGER))
@@ -325,7 +334,9 @@ export function queryTopSites(input: TopSiteQuery): TopSitePage {
         );
       }
       const cursorKey =
-        sort === "rank" ? (integerCursorKey as bigint) : cursor.key;
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
       parameters.push(cursorKey, cursorKey, findingId);
     }
 

--- a/core/src/top-sites-query.ts
+++ b/core/src/top-sites-query.ts
@@ -1,0 +1,353 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type TopSiteDirection = "asc" | "desc";
+export type TopSiteSort = "rank" | "url" | "title" | "profile";
+
+export interface TopSiteQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly sort?: TopSiteSort;
+  readonly direction?: TopSiteDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface TopSitePage {
+  readonly status: "ok";
+  readonly command: "top-sites";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const TOP_SITE_DIRECTIONS = ["asc", "desc"] as const;
+const TOP_SITE_SORTS = ["rank", "url", "title", "profile"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const TOP_SITE_KIND = "top_site";
+
+const SORT_EXPRESSIONS: Readonly<Record<TopSiteSort, string>> = {
+  rank: "COALESCE(f.sort_rank, -1)",
+  url: "COALESCE(f.sort_url, '')",
+  title: "COALESCE(f.sort_title, '')",
+  profile: "f.profile_path",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly sort: TopSiteSort;
+  readonly direction: TopSiteDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Top Sites cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Top Sites cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Top Sites --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Top Sites ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM top_sites_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function topSiteSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'top_sites_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Top Site Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryTopSites(input: TopSiteQuery): TopSitePage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    TOP_SITE_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "rank", TOP_SITE_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Top Sites queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!topSiteSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Top Sites analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [TOP_SITE_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      if (findingId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Top Sites cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sort === "rank" ? (BigInt(cursor.key) as bigint) : cursor.key;
+      parameters.push(cursorKey, cursorKey, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM top_sites_findings f
+           JOIN top_sites_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "top-sites",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/top-sites-query.ts
+++ b/core/src/top-sites-query.ts
@@ -69,6 +69,7 @@ const SORT_EXPRESSIONS: Readonly<Record<TopSiteSort, string>> = {
 };
 
 const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
 
 function queryFingerprint(input: {
   readonly caseId: string;
@@ -302,14 +303,29 @@ export function queryTopSites(input: TopSiteQuery): TopSitePage {
           `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
       );
       const findingId = BigInt(cursor.findingId);
-      if (findingId > SQLITE_MAX_INTEGER) {
+      // The `rank` sort keys on the integer `sort_rank` column (with a -1
+      // COALESCE sentinel, so keys can be negative), whereas every other sort
+      // keys on text. Validate an integer key with the same regex and int64
+      // range guard History uses, so a forged or out-of-range cursor surfaces a
+      // typed INVALID_CURSOR instead of a raw BigInt/node:sqlite throw.
+      const integerCursorKey =
+        sort === "rank" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        findingId > SQLITE_MAX_INTEGER ||
+        (sort === "rank" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
         throw new ForensixError(
           "INVALID_CURSOR",
           "Top Sites cursor contains an invalid sort key.",
         );
       }
       const cursorKey =
-        sort === "rank" ? (BigInt(cursor.key) as bigint) : cursor.key;
+        sort === "rank" ? (integerCursorKey as bigint) : cursor.key;
       parameters.push(cursorKey, cursorKey, findingId);
     }
 

--- a/core/src/top-sites-sqlite.ts
+++ b/core/src/top-sites-sqlite.ts
@@ -1,0 +1,323 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { CommitState } from "./forensic-model.js";
+import { ForensixError } from "./errors.js";
+import { openDatabaseSync } from "./sqlite-open.js";
+import {
+  immutableDatabase,
+  snapshotVerifiedFile,
+  type RawHistoryValue,
+  type VerifiedHistoryFile,
+} from "./history-sqlite.js";
+
+export type RawTopSiteValue = RawHistoryValue;
+export type VerifiedTopSiteFile = VerifiedHistoryFile;
+
+/**
+ * One row of the Chromium `top_sites` table, preserved column-by-column exactly
+ * as stored. Values keep their raw SQLite type so the Finding layer can classify
+ * each Field State (value, absent, or unavailable) without lossy coercion.
+ */
+export interface RawTopSite {
+  readonly rowId: RawTopSiteValue;
+  readonly url: RawTopSiteValue;
+  readonly urlRank: RawTopSiteValue;
+  readonly title: RawTopSiteValue;
+  readonly redirects: RawTopSiteValue;
+}
+
+export interface TopSiteSchema {
+  readonly version: number;
+  readonly columns: ReadonlySet<string>;
+}
+
+export interface TopSitePass {
+  readonly schema: TopSiteSchema;
+  readonly rows: readonly RawTopSite[];
+  readonly integrity: string;
+}
+
+export interface RecoveredTopSitePass extends TopSitePass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface TopSitePasses {
+  readonly committed: TopSitePass;
+  readonly recovered: RecoveredTopSitePass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+/**
+ * Columns every supported Chromium `top_sites` schema must expose. Schema
+ * version 4 added a `redirects` column (unused since 2019) that version 5
+ * dropped; it is read when present and recorded as an absent Field State when
+ * the schema omits it, so a Finding never fabricates a value.
+ */
+const REQUIRED_TOP_SITE_COLUMNS = ["url", "url_rank", "title"] as const;
+
+const SUPPORTED_TOP_SITE_COLUMNS = [
+  "url",
+  "url_rank",
+  "title",
+  "redirects",
+] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): TopSiteSchema {
+  for (const table of ["meta", "top_sites"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `Top Sites database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "Top Sites meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const columns = tableColumns(database, "top_sites");
+  const missing = REQUIRED_TOP_SITE_COLUMNS.filter(
+    (column) => !columns.has(column),
+  );
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Top Sites schema version ${version} is missing required columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return { version, columns };
+}
+
+function optionalColumn(
+  columns: ReadonlySet<string>,
+  column: string,
+  alias: string,
+): string {
+  return columns.has(column)
+    ? `t."${column}" AS "${alias}"`
+    : `NULL AS "${alias}"`;
+}
+
+function normalizeValue(value: unknown): RawTopSiteValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Top Sites contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): TopSitePass {
+  const schema = readSchema(database);
+  const column = (name: string, alias: string): string =>
+    optionalColumn(schema.columns, name, alias);
+  const statement = database.prepare(`
+    SELECT
+      t.rowid AS "rowId",
+      ${column("url", "url")},
+      ${column("url_rank", "urlRank")},
+      ${column("title", "title")},
+      ${column("redirects", "redirects")}
+    FROM top_sites t
+    ORDER BY t.rowid
+  `);
+  const rows: RawTopSite[] = [];
+  for (const row of statement.iterate()) {
+    rows.push({
+      rowId: normalizeValue(row.rowId),
+      url: normalizeValue(row.url),
+      urlRank: normalizeValue(row.urlRank),
+      title: normalizeValue(row.title),
+      redirects: normalizeValue(row.redirects),
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function fingerprint(values: readonly RawTopSiteValue[]): string {
+  return JSON.stringify(values, (_key, value: unknown) => {
+    if (typeof value === "bigint") {
+      return `${value.toString()}n`;
+    }
+    if (value instanceof Uint8Array) {
+      return `blob:${Buffer.from(value).toString("hex")}`;
+    }
+    return value;
+  });
+}
+
+function topSiteFingerprint(row: RawTopSite): string {
+  return fingerprint([row.url, row.urlRank, row.title, row.redirects]);
+}
+
+function rowId(row: RawTopSite): string | null {
+  return typeof row.rowId === "bigint" ? row.rowId.toString() : null;
+}
+
+/**
+ * The `top_sites` table is a single-table artifact, so a recovered row belongs
+ * to the sidecar Commit State only when the committed image has no row with the
+ * same rowid or holds a different exact byte image for it. This mirrors the
+ * History and Cookies recovery contracts.
+ */
+function recoveredOnlyTopSites(
+  committed: readonly RawTopSite[],
+  recovered: readonly RawTopSite[],
+): RawTopSite[] {
+  const committedByRowId = new Map(
+    committed.flatMap((row) => {
+      const id = rowId(row);
+      return id === null ? [] : [[id, topSiteFingerprint(row)] as const];
+    }),
+  );
+  const rows: RawTopSite[] = [];
+  for (const row of recovered) {
+    const id = rowId(row);
+    const committedFingerprint =
+      id === null ? undefined : committedByRowId.get(id);
+    if (
+      committedFingerprint === undefined ||
+      committedFingerprint !== topSiteFingerprint(row)
+    ) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+export { SUPPORTED_TOP_SITE_COLUMNS };
+
+export async function readTopSitePasses(options: {
+  readonly database: VerifiedTopSiteFile;
+  readonly sidecars: readonly VerifiedTopSiteFile[];
+}): Promise<TopSitePasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-top-sites-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: TopSitePass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyTopSites(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/top-sites-sqlite.ts
+++ b/core/src/top-sites-sqlite.ts
@@ -58,13 +58,6 @@ export interface TopSitePasses {
  */
 const REQUIRED_TOP_SITE_COLUMNS = ["url", "url_rank", "title"] as const;
 
-const SUPPORTED_TOP_SITE_COLUMNS = [
-  "url",
-  "url_rank",
-  "title",
-  "redirects",
-] as const;
-
 function tableExists(database: DatabaseSync, table: string): boolean {
   return (
     database
@@ -234,8 +227,6 @@ function recoveredOnlyTopSites(
   }
   return rows;
 }
-
-export { SUPPORTED_TOP_SITE_COLUMNS };
 
 export async function readTopSitePasses(options: {
   readonly database: VerifiedTopSiteFile;

--- a/core/src/top-sites.ts
+++ b/core/src/top-sites.ts
@@ -1,0 +1,342 @@
+import { join } from "node:path";
+
+import type {
+  PersistedTopSiteFinding,
+  TopSitesArtifactWrite,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type Provenance,
+} from "./forensic-model.js";
+import {
+  readTopSitePasses,
+  type RawTopSite,
+  type RawTopSiteValue,
+  type TopSiteSchema,
+  type VerifiedTopSiteFile,
+} from "./top-sites-sqlite.js";
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface BuiltTopSite {
+  readonly persisted: PersistedTopSiteFinding;
+}
+
+function preservedString(
+  value: RawTopSiteValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(
+  value: RawTopSiteValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function buildTopSites(options: {
+  readonly rows: readonly RawTopSite[];
+  readonly schema: TopSiteSchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+}): BuiltTopSite[] {
+  const columns = options.schema.columns;
+  return options.rows.map((row) => {
+    const rowId =
+      typeof row.rowId === "bigint" ? row.rowId.toString() : undefined;
+    if (rowId === undefined) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Top Sites rowid is not an exact integer.",
+      );
+    }
+    const provenance: Provenance = {
+      manifestEntryId: `${options.manifest.sourceId}:${options.manifest.ordinal}`,
+      sourceId: options.manifest.sourceId,
+      manifestEntryOrdinal: options.manifest.ordinal,
+      manifestPath: options.manifest.path,
+      database: options.manifest.databasePath,
+      table: "top_sites",
+      rowId,
+    };
+
+    const url = preservedString(row.url, columns.has("url"));
+    const title = preservedString(row.title, columns.has("title"));
+    const urlRank = preservedInteger(row.urlRank, columns.has("url_rank"));
+
+    const fields = {
+      topSiteId: valueField(rowId),
+      url,
+      title,
+      urlRank,
+      redirects: preservedString(row.redirects, columns.has("redirects")),
+    };
+
+    const finding = createFinding({
+      findingKind: "top_site",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance,
+      fields,
+    });
+
+    const urlValue = url.state === "value" ? url.value : null;
+    const titleValue = title.state === "value" ? title.value : null;
+    const rankKey = urlRank.state === "value" ? BigInt(urlRank.value) : null;
+    return {
+      persisted: {
+        finding,
+        searchText: [options.profile, urlValue ?? "", titleValue ?? ""]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortUrl: urlValue,
+        sortTitle: titleValue,
+        sortRank: rankKey,
+      },
+    };
+  });
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): TopSitesArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedTopSiteCount: 0,
+    recoveredTopSiteCount: 0,
+  };
+}
+
+async function analyseProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+}): Promise<TopSitesArtifactWrite> {
+  const databasePath =
+    options.profile === "." ? "Top Sites" : `${options.profile}/Top Sites`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      null,
+      "absent",
+      "top_sites_absent",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "top_sites_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `top_sites_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "top_sites_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "top_sites_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedTopSiteFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedTopSiteFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readTopSitePasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Top Sites recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const committed = buildTopSites({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildTopSites({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+          });
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [...committed, ...recovered].map((site) => site.persisted),
+      committedTopSiteCount: committed.length,
+      recoveredTopSiteCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `top_sites_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}
+
+export interface TopSitesAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+}
+
+export async function analyseSourceTopSites(
+  input: TopSitesAnalysisInput,
+): Promise<TopSitesArtifactWrite[]> {
+  const artifacts: TopSitesArtifactWrite[] = [];
+  for (const profile of input.source.profiles) {
+    artifacts.push(
+      await analyseProfile({
+        source: input.source,
+        profile: profile.path,
+        workingCopyPath: input.workingCopyPath,
+      }),
+    );
+  }
+  return artifacts;
+}
+
+export type { Finding as TopSiteFinding };

--- a/e2e/top-sites-cli.test.ts
+++ b/e2e/top-sites-cli.test.ts
@@ -110,6 +110,40 @@ function insertTopSite(database: DatabaseSync, row: TopSiteRow): void {
 }
 
 /**
+ * Build a version-4 Top Sites database, which still carries the (unused since
+ * 2019) `redirects` column dropped by version 5. It proves the reader parses
+ * both current schemas and keeps `redirects` as an exact value when present.
+ */
+async function createTopSitesV4(
+  path: string,
+  rows: readonly (TopSiteRow & { readonly redirects: string })[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '4'), ('last_compatible_version', '1');
+
+      CREATE TABLE top_sites (
+        url LONGVARCHAR PRIMARY KEY,
+        url_rank INTEGER NOT NULL,
+        title LONGVARCHAR NOT NULL,
+        redirects LONGVARCHAR
+      );
+    `);
+    const insert = database.prepare(
+      "INSERT INTO top_sites (url, url_rank, title, redirects) VALUES (?, ?, ?, ?)",
+    );
+    for (const row of rows) {
+      insert.run(row.url, row.urlRank, row.title, row.redirects);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+/**
  * A valid SQLite file that is not a supported Top Sites store: it carries a
  * `meta` table but no `top_sites` table. The analyzer must classify this as
  * unavailable (unreadable/unsupported), distinct from an absent database.
@@ -355,6 +389,41 @@ describe("compiled analyzer CLI Top Sites metadata", () => {
         rowId: "2",
       },
       fields: { url: { state: "value", value: "https://wal.example/" } },
+    });
+  });
+
+  it("parses the version-4 schema and keeps redirects as an exact value", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-top-sites-v4-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    await createTopSitesV4(join(source, "Default", "Top Sites"), [
+      {
+        url: "https://legacy.example/",
+        urlRank: 0n,
+        title: "Legacy",
+        redirects: "https://legacy.example/ https://www.legacy.example/",
+      },
+    ]);
+    const caseDirectory = join(root, "CASE-TOP-SITES-V4");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    const rows = parseJson<TopSitePage>(
+      runCli(["top-sites", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(rows.items).toHaveLength(1);
+    expect(rows.items[0]?.fields).toMatchObject({
+      url: { state: "value", value: "https://legacy.example/" },
+      redirects: {
+        state: "value",
+        value: "https://legacy.example/ https://www.legacy.example/",
+      },
     });
   });
 

--- a/e2e/top-sites-cli.test.ts
+++ b/e2e/top-sites-cli.test.ts
@@ -276,6 +276,32 @@ describe("compiled analyzer CLI Top Sites metadata", () => {
       [...firstPage.items, ...secondPage.items].map((item) => item.profile),
     ).toContain("Profile 1");
 
+    // A forged rank cursor (fingerprint-matching but with a non-numeric sort
+    // key) fails with a typed INVALID_CURSOR, never a raw BigInt throw.
+    const decoded = JSON.parse(
+      Buffer.from(firstPage.nextCursor as string, "base64url").toString("utf8"),
+    ) as Record<string, unknown>;
+    const forged = Buffer.from(
+      JSON.stringify({ ...decoded, key: "not-a-number" }),
+      "utf8",
+    ).toString("base64url");
+    const forgedResult = runCli([
+      "top-sites",
+      "--case",
+      caseDirectory,
+      "--sort",
+      "rank",
+      "--direction",
+      "asc",
+      "--after",
+      forged,
+      "--json",
+    ]);
+    expect(forgedResult.status).toBe(1);
+    expect(
+      parseJson<Record<string, unknown>>(forgedResult.stderr),
+    ).toMatchObject({ code: "INVALID_CURSOR" });
+
     // AC5: search matches url and title.
     const searched = parseJson<TopSitePage>(
       runCli([

--- a/e2e/top-sites-cli.test.ts
+++ b/e2e/top-sites-cli.test.ts
@@ -1,0 +1,408 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface TopSiteFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "top_site";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: {
+    readonly topSiteId: Field<string>;
+    readonly url: Field<string>;
+    readonly title: Field<string>;
+    readonly urlRank: Field<string>;
+    readonly redirects: Field<string>;
+  };
+}
+
+interface TopSitePage {
+  readonly status: "ok";
+  readonly command: "top-sites";
+  readonly items: readonly TopSiteFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+interface TopSiteRow {
+  readonly url: string;
+  readonly urlRank: bigint;
+  readonly title: string;
+}
+
+/**
+ * Build a Top Sites database faithful to the current Chromium schema
+ * (version 5): a `top_sites` table with `url`, `url_rank`, and `title`, keyed
+ * by an implicit rowid, plus a self-describing `meta.version`.
+ */
+async function createTopSites(
+  path: string,
+  rows: readonly TopSiteRow[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '5'), ('last_compatible_version', '1');
+
+      CREATE TABLE top_sites (
+        url LONGVARCHAR PRIMARY KEY,
+        url_rank INTEGER NOT NULL,
+        title LONGVARCHAR NOT NULL
+      );
+    `);
+    const insert = database.prepare(
+      "INSERT INTO top_sites (url, url_rank, title) VALUES (?, ?, ?)",
+    );
+    for (const row of rows) {
+      insert.run(row.url, row.urlRank, row.title);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+function insertTopSite(database: DatabaseSync, row: TopSiteRow): void {
+  database
+    .prepare("INSERT INTO top_sites (url, url_rank, title) VALUES (?, ?, ?)")
+    .run(row.url, row.urlRank, row.title);
+}
+
+/**
+ * A valid SQLite file that is not a supported Top Sites store: it carries a
+ * `meta` table but no `top_sites` table. The analyzer must classify this as
+ * unavailable (unreadable/unsupported), distinct from an absent database.
+ */
+async function createUnsupportedTopSites(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '5');
+      CREATE TABLE not_top_sites (url LONGVARCHAR);
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Top Sites metadata", () => {
+  it("parses Top Sites across Profiles with Field State and Provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-top-sites-e2e-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    await createTopSites(join(source, "Default", "Top Sites"), [
+      { url: "https://alpha.example/", urlRank: 0n, title: "Alpha" },
+      { url: "https://bravo.example/", urlRank: 1n, title: "Bravo" },
+      { url: "https://charlie.example/", urlRank: 2n, title: "Charlie" },
+    ]);
+    await createTopSites(join(source, "Profile 1", "Top Sites"), [
+      { url: "https://delta.example/", urlRank: 0n, title: "Delta" },
+    ]);
+    const defaultBytes = await readFile(join(source, "Default", "Top Sites"));
+    const caseDirectory = join(root, "CASE-TOP-SITES");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      topSites: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        absentProfileCount: 0,
+        unavailableProfileCount: 0,
+        committedTopSiteCount: 4,
+        recoveredTopSiteCount: 0,
+      },
+    });
+
+    // AC5: bounded, multi-Profile keyset pagination ordered by rank.
+    const firstPage = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "rank",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage).toMatchObject({ command: "top-sites", limit: 2 });
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const [first] = firstPage.items;
+    expect(first).toBeDefined();
+    // AC1 + AC2: url, title, rank exact against ground truth with Field State
+    // and resolvable Provenance.
+    expect(first).toMatchObject({
+      recordType: "finding",
+      findingKind: "top_site",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Top Sites",
+        database: "Default/Top Sites",
+        table: "top_sites",
+        rowId: "1",
+      },
+      fields: {
+        topSiteId: { state: "value", value: "1" },
+        url: { state: "value", value: "https://alpha.example/" },
+        title: { state: "value", value: "Alpha" },
+        urlRank: { state: "value", value: "0" },
+      },
+    });
+    // AC2: a column absent from schema v5 is an absent Field State, never blank.
+    expect(first?.fields.redirects).toEqual({ state: "absent" });
+
+    const secondPage = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "rank",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const allUrls = [...firstPage.items, ...secondPage.items].map(
+      (item) => item.fields.url.state === "value" && item.fields.url.value,
+    );
+    expect(new Set(allUrls).size).toBe(4);
+    expect(
+      [...firstPage.items, ...secondPage.items].map((item) => item.profile),
+    ).toContain("Profile 1");
+
+    // AC5: search matches url and title.
+    const searched = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--search",
+        "delta",
+        "--json",
+      ]).stdout,
+    );
+    expect(searched.items).toHaveLength(1);
+    expect(searched.items[0]?.profile).toBe("Profile 1");
+
+    // AC5: multi-Profile selection filter.
+    const filtered = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Default",
+        "--json",
+      ]).stdout,
+    );
+    expect(filtered.items).toHaveLength(3);
+    expect(filtered.items.every((item) => item.profile === "Default")).toBe(
+      true,
+    );
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(source, "Default", "Top Sites"))).toEqual(
+      defaultBytes,
+    );
+  });
+
+  it("keeps committed and WAL-resident Top Sites separate with Provenance", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-top-sites-wal-"));
+    temporaryRoots.push(root);
+    const source = join(root, "wal-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const topSitesPath = join(source, "Default", "Top Sites");
+    await createTopSites(topSitesPath, [
+      { url: "https://committed.example/", urlRank: 0n, title: "Committed" },
+    ]);
+
+    const writer = new DatabaseSync(topSitesPath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    insertTopSite(writer, {
+      url: "https://wal.example/",
+      urlRank: 1n,
+      title: "WAL",
+    });
+
+    const caseDirectory = join(root, "CASE-TOP-SITES-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      topSites: { committedTopSiteCount: 1, recoveredTopSiteCount: 1 },
+    });
+
+    // AC3: committed rows only.
+    const committed = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/Top Sites", rowId: "1" },
+      fields: { url: { state: "value", value: "https://committed.example/" } },
+    });
+
+    // AC3: sidecar (WAL-resident) rows carry the explicit Commit State and the
+    // sidecar Manifest Provenance.
+    const recovered = parseJson<TopSitePage>(
+      runCli([
+        "top-sites",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/Top Sites-wal",
+        database: "Default/Top Sites",
+        table: "top_sites",
+        rowId: "2",
+      },
+      fields: { url: { state: "value", value: "https://wal.example/" } },
+    });
+  });
+
+  it("distinguishes missing Top Sites from an unreadable database", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-top-sites-gap-"));
+    temporaryRoots.push(root);
+    const source = join(root, "gap-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    // Default: a defensible Top Sites store.
+    await createTopSites(join(source, "Default", "Top Sites"), [
+      { url: "https://alpha.example/", urlRank: 0n, title: "Alpha" },
+    ]);
+    // Profile 1: no Top Sites file at all, but a profile marker so it is
+    // discovered — the store is absent (missing), not unavailable.
+    await mkdir(join(source, "Profile 1"), { recursive: true });
+    await writeFile(join(source, "Profile 1", "Login Data"), "not-a-db");
+    // Profile 2: a Top Sites file that is a valid SQLite database but has no
+    // top_sites table — unreadable/unsupported, so unavailable.
+    await createUnsupportedTopSites(join(source, "Profile 2", "Top Sites"));
+
+    const caseDirectory = join(root, "CASE-TOP-SITES-GAP");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // AC4: an unavailable artifact makes the run partial (exit code 2), while
+    // the produced and absent artifacts stay distinct in the summary counts.
+    expect(analysis.status).toBe(2);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      exitState: "partial",
+      topSites: {
+        status: "partial",
+        profileCount: 3,
+        analysedProfileCount: 1,
+        absentProfileCount: 1,
+        unavailableProfileCount: 1,
+        committedTopSiteCount: 1,
+      },
+    });
+
+    // Only the defensible Profile is queryable; the gap and the failure never
+    // fabricate rows.
+    const rows = parseJson<TopSitePage>(
+      runCli(["top-sites", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(rows.items).toHaveLength(1);
+    expect(rows.items[0]?.profile).toBe("Default");
+  });
+});

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -15,6 +15,7 @@ import {
   queryCredentials,
   queryHistory,
   queryProfiles,
+  queryTopSites,
   type CommitState,
   type CookieDirection,
   type CookieSort,
@@ -23,6 +24,8 @@ import {
   type HistoryDirection,
   type HistorySort,
   type HistoryView,
+  type TopSiteDirection,
+  type TopSiteSort,
 } from "@forensix/core";
 
 /**
@@ -268,6 +271,19 @@ function handleApi(
         sort: firstString(parameters.get("sort")) as CredentialSort | undefined,
         direction: firstString(parameters.get("direction")) as
           | CredentialDirection
+          | undefined,
+        limit: integerParameter(parameters, "limit"),
+        after: firstString(parameters.get("after")),
+      });
+    case "top-sites":
+      return queryTopSites({
+        caseDirectory,
+        profiles,
+        search: firstString(parameters.get("search")),
+        commitState,
+        sort: firstString(parameters.get("sort")) as TopSiteSort | undefined,
+        direction: firstString(parameters.get("direction")) as
+          | TopSiteDirection
           | undefined,
         limit: integerParameter(parameters, "limit"),
         after: firstString(parameters.get("after")),


### PR DESCRIPTION
Closes #175.

Adds a Top Sites artifact pipeline that mirrors the established History / Cookies / Login Data contract: a SQLite reader, a Finding builder, a keyset-paginated query surface, Case persistence with supersede, dashboard/Completeness wiring, and a `top-sites` CLI command.

## Acceptance criteria

- **Current Top Sites schemas parsed across every Profile** — `top-sites-sqlite.ts` reads the modern `top_sites` table (schema v4 with the unused `redirects` column and v5 without it), requiring `url`/`url_rank`/`title` and reading `redirects` only when the schema exposes it. `analyseSourceTopSites` runs per Profile from `analyseCase`.
- **Every supported external field exact vs ground truth with Field State + Provenance** — `top-sites.ts` preserves each column raw (value / absent / unavailable, never blank), attaches row-level Provenance (`table: top_sites`, resolvable Manifest entry, rowId), and records the self-describing `meta.version`. Covered by the metadata e2e assertions.
- **Committed vs sidecar separate with explicit Commit State** — recovery diffs WAL / rollback-journal rows by rowid and tags them `wal_resident` / `journal_resident` with sidecar Provenance, kept apart from `committed`. Covered by the WAL-separation e2e test.
- **Missing Top Sites distinguished from unreadable/unsupported DB** — an absent store is `absent`; a valid SQLite file without a `top_sites` table (or an unreadable DB) is `unavailable` with a typed reason. Surfaced in the analyse summary counts and the dashboard Completeness Statement. Covered by the gap e2e test (exit code 2 / partial).
- **CLI surface: search / filter / sort / pagination / multi-Profile / Completeness before rows** — `forensix top-sites` supports `--search`, `--commit-state`, `--profile` (repeatable), `--sort <rank|url|title|profile>`, `--direction`, `--limit`, `--after` bounded keyset pagination; Completeness is computed before rows via the analyse summary and the read-only dashboard.

## Tests

New `e2e/top-sites-cli.test.ts` (3 cases) exercises all five criteria against the compiled CLI. Full `pnpm verify` green on Node 24.15.0 (72 tests).
