### PR TITLE
feat(metadata): parse Preferences and profile metadata as Findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Login Data yields credential metadata: origin, username, timestamps, and the enc
 The metadata is available independently of secret decryption.
 An encrypted secret without authorized key material is `unavailable` with a typed reason, never absent or blank.
 
+The analyzer also parses `Local State` and each Profile's `Preferences` JSON into metadata Findings.
+Browser-level metadata (Chrome version, variations country, OSCrypt key presence) is scoped to the Source; Profile-level metadata (account data, demographics, screen resolution, and avatars) is scoped to its Profile.
+Avatar and demographic values that live in the browser-level `profile.info_cache` slice are attributed to the owning Profile through a supporting Provenance row.
+Every value is verified against the current schema and carries a Field State: a removed or inapplicable key is `absent`, while a malformed or unreadable input is `unavailable` with a typed reason.
+
 ## Requirements
 
 - Node.js 24.15.0 or newer

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -13,6 +13,7 @@ import {
   queryCookies,
   queryCredentials,
   queryHistory,
+  queryMetadata,
   queryTopSites,
   renderReport,
   type AutofillDirection,
@@ -31,6 +32,9 @@ import {
   type HistoryView,
   type IngestProgress,
   type IngestResult,
+  type MetadataDirection,
+  type MetadataSort,
+  type MetadataType,
   type SourceKind,
 } from "@forensix/core";
 import { startDashboardServer } from "@forensix/server";
@@ -69,6 +73,12 @@ const USAGE = `Usage:
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <created-time|last-used-time|field-name|value|profile>]
                    [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix metadata --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--type <browser_metadata|profile_metadata>]
+                   [--sort <type|profile>] [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix serve --case <case-directory> [--port <port>] [--json]
   forensix export --case <case-directory> --out <output-directory>
@@ -118,6 +128,7 @@ const VALUE_OPTIONS = new Set([
   "--to",
   "--host",
   "--same-site",
+  "--type",
   "--sort",
   "--direction",
   "--limit",
@@ -493,6 +504,54 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as CookieSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | CookieDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "metadata") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--type",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The metadata command accepts no positional values.",
+      );
+    }
+    const result = queryMetadata({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      type: enumOption(parsed, "--type", [
+        "browser_metadata",
+        "profile_metadata",
+      ] as const) as MetadataType | undefined,
+      sort: enumOption(parsed, "--sort", ["type", "profile"] as const) as
+        | MetadataSort
+        | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | MetadataDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -139,6 +139,31 @@ export interface TopSitesArtifactWrite {
   readonly recoveredTopSiteCount: number;
 }
 
+export interface PersistedMetadataFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortType: string;
+  readonly sortProfile: string;
+}
+
+export interface MetadataArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  /**
+   * The evidence file backing this metadata scope. `Local State` is
+   * browser-level, `Preferences` is Profile-level. It keeps the two scopes
+   * distinct in storage even when a single-Profile Source reports both under
+   * the `.` Profile path.
+   */
+  readonly artifact: "Local State" | "Preferences";
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly reason: string | null;
+  readonly findings: readonly PersistedMetadataFinding[];
+  readonly metadataFindingCount: number;
+}
+
 export interface StoreHistoryAnalysisOptions {
   readonly caseDirectory: string;
   readonly sourceIds: readonly string[];
@@ -151,6 +176,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
   readonly topSitesArtifacts?: readonly TopSitesArtifactWrite[];
   readonly webDataArtifacts?: readonly WebDataArtifactWrite[];
+  readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -508,6 +534,53 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON top_sites_findings(finding_kind, COALESCE(sort_title, ''), finding_id);
     CREATE INDEX IF NOT EXISTS top_sites_findings_profile_query
       ON top_sites_findings(finding_kind, profile_path, commit_state, finding_id);
+
+    CREATE TABLE IF NOT EXISTS preferences_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact IN ('Local State', 'Preferences')),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS preferences_one_active_result
+      ON preferences_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS preferences_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES preferences_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_type TEXT NOT NULL,
+      sort_profile TEXT NOT NULL,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS preferences_findings_type_query
+      ON preferences_findings(finding_kind, sort_type, finding_id);
+    CREATE INDEX IF NOT EXISTS preferences_findings_profile_query
+      ON preferences_findings(finding_kind, sort_profile, finding_id);
   `);
 }
 
@@ -666,10 +739,35 @@ function insertTopSiteFinding(
   );
 }
 
+function insertMetadataFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedMetadataFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortType,
+    row.sortProfile,
+  );
+}
+
 export function storeHistoryAnalysis(
   options: StoreHistoryAnalysisOptions,
 ): StoredHistoryAnalysis {
   const cookieArtifacts = options.cookieArtifacts ?? [];
+  const metadataArtifacts = options.metadataArtifacts ?? [];
   const runId = randomUUID();
   const database = openDatabaseSync(
     join(resolve(options.caseDirectory), CASE_FILENAME),
@@ -828,6 +926,28 @@ export function storeHistoryAnalysis(
       const activateCurrentTopSite = database.prepare(
         "UPDATE top_sites_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertMetadataArtifact = database.prepare(
+        `INSERT INTO preferences_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, status, reason, active)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertMetadataFindingStatement = database.prepare(
+        `INSERT INTO preferences_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_type, sort_profile)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousMetadata = database.prepare(
+        `UPDATE preferences_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = ?
+            AND active = 1`,
+      );
+      const activateCurrentMetadata = database.prepare(
+        "UPDATE preferences_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
 
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
@@ -977,6 +1097,41 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of metadataArtifacts) {
+        const insertion = insertMetadataArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.artifact,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertMetadataFinding(
+            insertMetadataFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousMetadata.run(
+            artifact.sourceId,
+            artifact.profile,
+            artifact.artifact,
+          );
+          activateCurrentMetadata.run(artifactResultId);
+        }
+      }
+
+      // Metadata artifacts are recorded and queryable but deliberately excluded
+      // from the Analysis Run exit-state aggregation: `Local State` and
+      // `Preferences` are contextual scaffolding, and their presence must not
+      // change the History/Cookies/Login exit-code semantics an operator relies
+      // on. Metadata health is surfaced separately in the analyse summary.
       const combinedArtifacts = [
         ...options.artifacts,
         ...cookieArtifacts,

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -161,7 +161,6 @@ export interface MetadataArtifactWrite {
   readonly databasePath: string;
   readonly reason: string | null;
   readonly findings: readonly PersistedMetadataFinding[];
-  readonly metadataFindingCount: number;
 }
 
 export interface StoreHistoryAnalysisOptions {

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -7,12 +7,14 @@ import {
   type DeclaredOriginOs,
   type HistoryArtifactWrite,
   type LoginDataArtifactWrite,
+  type MetadataArtifactWrite,
   type PersistedFinding,
   type TopSitesArtifactWrite,
   type WebDataArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseLoginDataProfile } from "./login-data.js";
+import { analyseSourcePreferences } from "./preferences.js";
 import { analyseSourceTopSites } from "./top-sites.js";
 import { analyseWebDataProfile } from "./web-data.js";
 import {
@@ -171,6 +173,17 @@ export interface WebDataAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface PreferencesAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly artifactCount: number;
+  readonly analysedArtifactCount: number;
+  readonly absentArtifactCount: number;
+  readonly unavailableArtifactCount: number;
+  readonly browserMetadataCount: number;
+  readonly profileMetadataCount: number;
+  readonly findingCount: number;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -182,6 +195,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly loginData: LoginDataAnalysisSummary;
   readonly topSites: TopSitesAnalysisSummary;
   readonly webData: WebDataAnalysisSummary;
+  readonly preferences: PreferencesAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
 
@@ -1242,6 +1256,7 @@ export async function analyseCase(
   const loginDataArtifacts: LoginDataArtifactWrite[] = [];
   const topSitesArtifacts: TopSitesArtifactWrite[] = [];
   const webDataArtifacts: WebDataArtifactWrite[] = [];
+  const metadataArtifacts: MetadataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1287,6 +1302,9 @@ export async function analyseCase(
         workingCopyPath,
       })),
     );
+    metadataArtifacts.push(
+      ...(await analyseSourcePreferences({ source, workingCopyPath })),
+    );
   }
 
   await verifyWorkingCopy(caseDirectory);
@@ -1302,6 +1320,7 @@ export async function analyseCase(
     loginDataArtifacts,
     topSitesArtifacts,
     webDataArtifacts,
+    metadataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1352,6 +1371,15 @@ export async function analyseCase(
     (artifact) => artifact.status === "absent",
   );
   const webUnavailable = webDataArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
+  const metadataAnalysed = metadataArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const metadataAbsent = metadataArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const metadataUnavailable = metadataArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
   return {
@@ -1488,6 +1516,23 @@ export async function analyseCase(
         0,
       ),
       findingCount: webAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+    },
+    preferences: {
+      status: metadataUnavailable.length === 0 ? "complete" : "partial",
+      artifactCount: metadataArtifacts.length,
+      analysedArtifactCount: metadataAnalysed.length,
+      absentArtifactCount: metadataAbsent.length,
+      unavailableArtifactCount: metadataUnavailable.length,
+      browserMetadataCount: metadataAnalysed.filter(
+        (artifact) => artifact.artifact === "Local State",
+      ).length,
+      profileMetadataCount: metadataAnalysed.filter(
+        (artifact) => artifact.artifact === "Preferences",
+      ).length,
+      findingCount: metadataAnalysed.reduce(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -98,6 +98,7 @@ export {
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
+  type PreferencesAnalysisSummary,
   type TopSitesAnalysisSummary,
   type WebDataAnalysisSummary,
 } from "./history.js";
@@ -190,6 +191,14 @@ export {
   type AutofillQuery,
   type AutofillSort,
 } from "./web-data-query.js";
+export {
+  queryMetadata,
+  type MetadataDirection,
+  type MetadataPage,
+  type MetadataQuery,
+  type MetadataSort,
+  type MetadataType,
+} from "./preferences-query.js";
 export {
   type AnalysisRunExitState,
   type DeclaredOriginOs,

--- a/core/src/preferences-json.ts
+++ b/core/src/preferences-json.ts
@@ -1,0 +1,96 @@
+import { lstat } from "node:fs/promises";
+
+import { WorkingCopyIntegrityRefusal } from "./errors.js";
+import { readStableRegularFile } from "./stable-file.js";
+
+/**
+ * A Working Copy JSON file (Chrome `Preferences` or `Local State`) pinned to the
+ * exact Manifest representation recorded at ingest. The reader re-verifies the
+ * bytes against this identity before it parses anything, so analysis never
+ * trusts content that drifted from the recorded evidence.
+ */
+export interface VerifiedJsonFile {
+  readonly path: string;
+  readonly manifestPath: string;
+  readonly size: number;
+  readonly sha256: string;
+}
+
+/**
+ * The outcome of reading a verified JSON file. A byte-stable, hash-matching file
+ * that still fails to parse is `unreadable` with a typed reason rather than an
+ * integrity refusal: the evidence is intact, the content is simply malformed.
+ */
+export type JsonReadResult =
+  | { readonly status: "parsed"; readonly value: unknown }
+  | { readonly status: "unreadable"; readonly reason: string };
+
+/**
+ * Read a verified JSON Working Copy file into memory and parse it. Any drift
+ * from the recorded Manifest representation (missing file, non-regular file,
+ * unstable read, size or hash mismatch) is a Working Copy integrity refusal and
+ * aborts the analysis. A malformed document or an oversized file is reported as
+ * `unreadable` so the caller can record a typed `unavailable` reason.
+ */
+export async function readVerifiedJsonFile(
+  file: VerifiedJsonFile,
+): Promise<JsonReadResult> {
+  let stats;
+  try {
+    stats = await lstat(file.path, { bigint: true });
+  } catch {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: file.manifestPath, reason: "entry_missing" },
+    ]);
+  }
+  if (!stats.isFile() || stats.isSymbolicLink()) {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: file.manifestPath, reason: "entry_not_regular_file" },
+    ]);
+  }
+
+  const chunks: Buffer[] = [];
+  const result = await readStableRegularFile(
+    file.path,
+    stats,
+    async (chunk) => {
+      chunks.push(Buffer.from(chunk));
+    },
+  );
+  if (result.status === "too_large") {
+    return { status: "unreadable", reason: "file_too_large" };
+  }
+  if (result.status !== "stable") {
+    throw new WorkingCopyIntegrityRefusal([
+      { path: file.manifestPath, reason: "entry_unreadable" },
+    ]);
+  }
+  const issues = [];
+  if (result.size !== file.size) {
+    issues.push({
+      path: file.manifestPath,
+      reason: "entry_size_mismatch" as const,
+      expected: file.size,
+      actual: result.size,
+    });
+  }
+  if (result.sha256 !== file.sha256) {
+    issues.push({
+      path: file.manifestPath,
+      reason: "entry_hash_mismatch" as const,
+      expected: file.sha256,
+      actual: result.sha256,
+    });
+  }
+  if (issues.length > 0) {
+    throw new WorkingCopyIntegrityRefusal(issues);
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return { status: "unreadable", reason: "malformed_json" };
+  }
+  return { status: "parsed", value };
+}

--- a/core/src/preferences-query.ts
+++ b/core/src/preferences-query.ts
@@ -1,0 +1,357 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type MetadataDirection = "asc" | "desc";
+export type MetadataSort = "type" | "profile";
+export type MetadataType = "browser_metadata" | "profile_metadata";
+
+export interface MetadataQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly type?: MetadataType;
+  readonly sort?: MetadataSort;
+  readonly direction?: MetadataDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface MetadataPage {
+  readonly status: "ok";
+  readonly command: "metadata";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string;
+}
+
+const METADATA_DIRECTIONS = ["asc", "desc"] as const;
+const METADATA_SORTS = ["type", "profile"] as const;
+const METADATA_TYPES = ["browser_metadata", "profile_metadata"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+
+const SORT_EXPRESSIONS: Readonly<Record<MetadataSort, string>> = {
+  type: "f.sort_type",
+  profile: "f.sort_profile",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly type: MetadataType | null;
+  readonly sort: MetadataSort;
+  readonly direction: MetadataDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Metadata cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Metadata cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Metadata --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Metadata ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM preferences_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function metadataSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'preferences_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Metadata Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryMetadata(input: MetadataQuery): MetadataPage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    METADATA_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "profile", METADATA_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const type =
+    input.type === undefined
+      ? null
+      : enumValue(input.type, "browser_metadata", METADATA_TYPES, "--type");
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Metadata queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!metadataSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Metadata analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      type,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = ["r.active = 1", "f.record_type = 'finding'"];
+    const parameters: (string | bigint)[] = [];
+    if (type !== null) {
+      conditions.push("f.finding_kind = ?");
+      parameters.push(type);
+    }
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      if (findingId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Metadata cursor contains an invalid sort key.",
+        );
+      }
+      parameters.push(cursor.key, cursor.key, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM preferences_findings f
+           JOIN preferences_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "metadata",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -1,0 +1,665 @@
+import { join } from "node:path";
+
+import type {
+  MetadataArtifactWrite,
+  PersistedMetadataFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type FieldState,
+  type Finding,
+  type Provenance,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import {
+  readVerifiedJsonFile,
+  type VerifiedJsonFile,
+} from "./preferences-json.js";
+
+export const BROWSER_METADATA_KIND = "browser_metadata";
+export const PROFILE_METADATA_KIND = "profile_metadata";
+
+/**
+ * Chrome writes profile and browser metadata as JSON, not SQLite. A `Local
+ * State` document is browser-level (one per User Data Dir); a `Preferences`
+ * document is Profile-level (one per Profile). This module keeps those two
+ * scopes distinct even though the browser file also holds a per-Profile
+ * `profile.info_cache` slice: the slice is Profile-scoped data that merely lives
+ * in a browser-level file, so it is attached to the owning Profile Finding as a
+ * supporting Provenance row.
+ */
+
+type Lookup =
+  | { readonly kind: "value"; readonly value: unknown }
+  | { readonly kind: "absent" }
+  | { readonly kind: "malformed" };
+
+/**
+ * Navigate a JSON document by key path. A missing key or an explicit `null`
+ * (Chrome's cleared-value convention) is `absent`; a non-object encountered
+ * mid-path is `malformed`. This is what lets removed or inapplicable keys stay
+ * absent while a wrong-shaped document surfaces as unavailable.
+ */
+function lookup(root: unknown, keys: readonly string[]): Lookup {
+  let current: unknown = root;
+  for (const key of keys) {
+    if (current === undefined || current === null) {
+      return { kind: "absent" };
+    }
+    if (typeof current !== "object" || Array.isArray(current)) {
+      return { kind: "malformed" };
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  if (current === undefined || current === null) {
+    return { kind: "absent" };
+  }
+  return { kind: "value", value: current };
+}
+
+function stringField(result: Lookup): FieldState<string> {
+  if (result.kind === "absent") {
+    return absentField();
+  }
+  if (result.kind === "malformed") {
+    return unavailableField("unsupported_value");
+  }
+  return typeof result.value === "string"
+    ? valueField(result.value)
+    : unavailableField("unsupported_value");
+}
+
+function integerField(result: Lookup): FieldState<string> {
+  if (result.kind === "absent") {
+    return absentField();
+  }
+  if (result.kind === "malformed") {
+    return unavailableField("unsupported_value");
+  }
+  return typeof result.value === "number" && Number.isInteger(result.value)
+    ? valueField(result.value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function booleanField(result: Lookup): FieldState<boolean> {
+  if (result.kind === "absent") {
+    return absentField();
+  }
+  if (result.kind === "malformed") {
+    return unavailableField("unsupported_value");
+  }
+  return typeof result.value === "boolean"
+    ? valueField(result.value)
+    : unavailableField("unsupported_value");
+}
+
+/**
+ * The browser-level Chrome version recorded in the current `Local State` schema
+ * as the first element of `variations_permanent_consistency_country`
+ * (`[version, country]`). A present-but-wrong shape is unavailable, never blank.
+ */
+function chromeVersionField(localState: unknown): FieldState<string> {
+  const result = lookup(localState, [
+    "variations_permanent_consistency_country",
+  ]);
+  if (result.kind === "absent") {
+    return absentField();
+  }
+  if (result.kind === "malformed" || !Array.isArray(result.value)) {
+    return unavailableField("unsupported_value");
+  }
+  const version = result.value[0];
+  return typeof version === "string" && version.length > 0
+    ? valueField(version)
+    : unavailableField("unsupported_value");
+}
+
+function arrayLengthField(result: Lookup): FieldState<string> {
+  if (result.kind === "absent") {
+    return absentField();
+  }
+  if (result.kind === "malformed" || !Array.isArray(result.value)) {
+    return unavailableField("unsupported_value");
+  }
+  return valueField(result.value.length.toString());
+}
+
+/**
+ * A synthetic screen-resolution string derived from the Profile window
+ * placement work area. It is emitted only when every bound is an integer, and it
+ * is always marked `synthetic` so an examiner never mistakes a derived value for
+ * a stored one.
+ */
+function screenResolutionField(
+  left: FieldState<string>,
+  top: FieldState<string>,
+  right: FieldState<string>,
+  bottom: FieldState<string>,
+): FieldState<string> {
+  const bounds = [left, top, right, bottom];
+  if (bounds.some((bound) => bound.state === "unavailable")) {
+    return unavailableField("unsupported_value");
+  }
+  if (bounds.some((bound) => bound.state === "absent")) {
+    return absentField();
+  }
+  const numbers = bounds.map((bound) =>
+    Number((bound as { readonly value: string }).value),
+  );
+  const [l, t, r, b] = numbers as [number, number, number, number];
+  const width = r - l;
+  const height = b - t;
+  if (width <= 0 || height <= 0) {
+    return unavailableField("unsupported_value");
+  }
+  return valueField(`${width}x${height}`, { synthetic: true });
+}
+
+function firstAccount(preferences: unknown): {
+  readonly count: FieldState<string>;
+  readonly account: unknown;
+} {
+  const result = lookup(preferences, ["account_info"]);
+  const count = arrayLengthField(result);
+  if (
+    result.kind === "value" &&
+    Array.isArray(result.value) &&
+    result.value.length > 0
+  ) {
+    return { count, account: result.value[0] ?? null };
+  }
+  return { count, account: null };
+}
+
+type FileResolution =
+  | {
+      readonly kind: "ready";
+      readonly file: VerifiedJsonFile;
+      readonly ordinal: number;
+    }
+  | {
+      readonly kind: "absent" | "unavailable";
+      readonly reason: string;
+      readonly ordinal: number | null;
+    };
+
+function resolveJsonFile(
+  source: CaseSourceRecord,
+  workingCopyPath: string,
+  path: string,
+  label: string,
+): FileResolution {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  if (ordinal < 0) {
+    return {
+      kind: "absent",
+      reason: `${label}_manifest_entry_missing`,
+      ordinal: null,
+    };
+  }
+  const entry = source.entries[ordinal];
+  if (entry === undefined) {
+    return {
+      kind: "absent",
+      reason: `${label}_manifest_entry_missing`,
+      ordinal: null,
+    };
+  }
+  if (entry.state === "absent") {
+    return { kind: "absent", reason: `${label}_absent`, ordinal };
+  }
+  if (entry.state === "unavailable") {
+    return {
+      kind: "unavailable",
+      reason: `${label}_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+      ordinal,
+    };
+  }
+  if (!entry.copied) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_not_in_working_copy`,
+      ordinal,
+    };
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_manifest_representation_incomplete`,
+      ordinal,
+    };
+  }
+  return {
+    kind: "ready",
+    ordinal,
+    file: {
+      path: join(workingCopyPath, ...path.split("/")),
+      manifestPath: path,
+      size: entry.size,
+      sha256: entry.sha256,
+    },
+  };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  artifact: "Local State" | "Preferences",
+  databasePath: string,
+  ordinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): MetadataArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    artifact,
+    status,
+    manifestEntryOrdinal: ordinal,
+    databasePath,
+    reason,
+    findings: [],
+    metadataFindingCount: 0,
+  };
+}
+
+function browserProvenance(sourceId: string, ordinal: number): Provenance {
+  return {
+    manifestEntryId: `${sourceId}:${ordinal}`,
+    sourceId,
+    manifestEntryOrdinal: ordinal,
+    manifestPath: "Local State",
+    database: "Local State",
+    table: "local_state",
+    rowId: "local_state",
+  };
+}
+
+function textValue(field: FieldState<string>): string {
+  return field.state === "value" ? field.value : "";
+}
+
+function buildBrowserFinding(options: {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly ordinal: number;
+  readonly localState: unknown;
+}): PersistedMetadataFinding {
+  const chromeVersion = chromeVersionField(options.localState);
+  const lastUsedProfile = stringField(
+    lookup(options.localState, ["profile", "last_used"]),
+  );
+  const variationsCountry = stringField(
+    lookup(options.localState, ["variations_country"]),
+  );
+  const fields = {
+    scope: valueField("browser"),
+    chromeVersion,
+    variationsCountry,
+    lastUsedProfile,
+    profileCount: arrayLengthField(
+      lookup(options.localState, ["profile", "profiles_order"]),
+    ),
+    osCryptKeyPresent: booleanField(
+      (() => {
+        const result = lookup(options.localState, [
+          "os_crypt",
+          "encrypted_key",
+        ]);
+        if (result.kind === "value") {
+          return { kind: "value", value: typeof result.value === "string" };
+        }
+        return result;
+      })(),
+    ),
+    osCryptAppBoundKeyPresent: booleanField(
+      (() => {
+        const result = lookup(options.localState, [
+          "os_crypt",
+          "app_bound_encrypted_key",
+        ]);
+        if (result.kind === "value") {
+          return { kind: "value", value: typeof result.value === "string" };
+        }
+        return result;
+      })(),
+    ),
+  };
+  const finding: Finding = createFinding({
+    findingKind: BROWSER_METADATA_KIND,
+    profile: options.profile,
+    commitState: "committed",
+    provenance: browserProvenance(options.sourceId, options.ordinal),
+    fields,
+  });
+  return {
+    finding,
+    searchText: [
+      "browser",
+      textValue(chromeVersion),
+      textValue(variationsCountry),
+      textValue(lastUsedProfile),
+    ]
+      .join("\n")
+      .toLocaleLowerCase("en-US"),
+    sortType: BROWSER_METADATA_KIND,
+    sortProfile: options.profile,
+  };
+}
+
+function buildProfileFinding(options: {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly ordinal: number;
+  readonly preferences: unknown;
+  readonly localState: unknown;
+  readonly localStateOrdinal: number | null;
+  readonly preferencesPath: string;
+}): PersistedMetadataFinding {
+  const profileName = stringField(
+    lookup(options.preferences, ["profile", "name"]),
+  );
+  const createdByVersion = stringField(
+    lookup(options.preferences, ["profile", "created_by_version"]),
+  );
+  const exitType = stringField(
+    lookup(options.preferences, ["profile", "exit_type"]),
+  );
+  const { count: accountCount, account } = firstAccount(options.preferences);
+  const accountEmail = stringField(lookup(account, ["email"]));
+  const accountGaiaId = stringField(lookup(account, ["gaia"]));
+  const accountFullName = stringField(lookup(account, ["full_name"]));
+  const accountGivenName = stringField(lookup(account, ["given_name"]));
+  const accountLocale = stringField(lookup(account, ["locale"]));
+  const accountHostedDomain = stringField(lookup(account, ["hd"]));
+
+  const placement = [
+    "work_area_left",
+    "work_area_top",
+    "work_area_right",
+    "work_area_bottom",
+  ].map((key) =>
+    integerField(
+      lookup(options.preferences, ["browser", "window_placement", key]),
+    ),
+  );
+  const [workAreaLeft, workAreaTop, workAreaRight, workAreaBottom] =
+    placement as [
+      FieldState<string>,
+      FieldState<string>,
+      FieldState<string>,
+      FieldState<string>,
+    ];
+  const screenResolution = screenResolutionField(
+    workAreaLeft,
+    workAreaTop,
+    workAreaRight,
+    workAreaBottom,
+  );
+
+  // Profile-scoped demographics and avatar data live in the browser-level
+  // Local State `profile.info_cache` slice keyed by Profile directory. When the
+  // browser file could not be read they are unavailable (the related row is
+  // missing), never silently absent.
+  const infoCacheAvailable =
+    options.localStateOrdinal !== null && options.localState !== null;
+  const profileDir = options.profile === "." ? null : options.profile;
+  const sliceKeys =
+    profileDir === null ? null : ["profile", "info_cache", profileDir];
+
+  function infoCacheField(
+    key: string,
+    builder: (result: Lookup) => FieldState<unknown>,
+  ): FieldState<unknown> {
+    if (!infoCacheAvailable) {
+      return unavailableField("related_row_missing");
+    }
+    if (sliceKeys === null) {
+      return absentField();
+    }
+    return builder(lookup(options.localState, [...sliceKeys, key]));
+  }
+
+  const avatarIcon = infoCacheField("avatar_icon", stringField);
+  const gaiaName = infoCacheField("gaia_name", stringField);
+  const gaiaGivenName = infoCacheField("gaia_given_name", stringField);
+  const gaiaId = infoCacheField("gaia_id", stringField);
+  const gaiaPictureFileName = infoCacheField(
+    "gaia_picture_file_name",
+    stringField,
+  );
+  const infoCacheUserName = infoCacheField("user_name", stringField);
+  const isUsingDefaultAvatar = infoCacheField(
+    "is_using_default_avatar",
+    booleanField,
+  );
+  const isUsingDefaultName = infoCacheField(
+    "is_using_default_name",
+    booleanField,
+  );
+
+  const supportingRows: SourceRowProvenance[] =
+    infoCacheAvailable && options.localStateOrdinal !== null
+      ? [
+          {
+            manifestEntryId: `${options.sourceId}:${options.localStateOrdinal}`,
+            sourceId: options.sourceId,
+            manifestEntryOrdinal: options.localStateOrdinal,
+            manifestPath: "Local State",
+            database: "Local State",
+            table: "local_state",
+            rowId:
+              profileDir === null
+                ? "profile.info_cache"
+                : `profile.info_cache/${profileDir}`,
+          },
+        ]
+      : [];
+
+  const provenance: Provenance = {
+    manifestEntryId: `${options.sourceId}:${options.ordinal}`,
+    sourceId: options.sourceId,
+    manifestEntryOrdinal: options.ordinal,
+    manifestPath: options.preferencesPath,
+    database: options.preferencesPath,
+    table: "preferences",
+    rowId: options.profile,
+    ...(supportingRows.length > 0 ? { supportingRows } : {}),
+  };
+
+  const fields = {
+    scope: valueField("profile"),
+    profileName,
+    createdByVersion,
+    exitType,
+    accountCount,
+    accountEmail,
+    accountGaiaId,
+    accountFullName,
+    accountGivenName,
+    accountLocale,
+    accountHostedDomain,
+    workAreaLeft,
+    workAreaTop,
+    workAreaRight,
+    workAreaBottom,
+    screenResolution,
+    avatarIcon,
+    gaiaName,
+    gaiaGivenName,
+    gaiaId,
+    gaiaPictureFileName,
+    infoCacheUserName,
+    isUsingDefaultAvatar,
+    isUsingDefaultName,
+  };
+
+  const finding: Finding = createFinding({
+    findingKind: PROFILE_METADATA_KIND,
+    profile: options.profile,
+    commitState: "committed",
+    provenance,
+    fields,
+  });
+
+  return {
+    finding,
+    searchText: [
+      options.profile,
+      textValue(profileName),
+      textValue(accountEmail),
+      avatarIcon.state === "value" ? String(avatarIcon.value) : "",
+      gaiaName.state === "value" ? String(gaiaName.value) : "",
+    ]
+      .join("\n")
+      .toLocaleLowerCase("en-US"),
+    sortType: PROFILE_METADATA_KIND,
+    sortProfile: options.profile,
+  };
+}
+
+export interface PreferencesAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+}
+
+/**
+ * Parse browser-level `Local State` and each Profile's `Preferences` into
+ * metadata Findings. Emits one browser-scoped artifact per Source plus one
+ * Profile-scoped artifact per Profile. Byte drift from the recorded Manifest is
+ * an integrity refusal and propagates; a malformed or unreadable document is a
+ * typed `unavailable` artifact so the rest of the Case stays queryable.
+ */
+export async function analyseSourcePreferences(
+  input: PreferencesAnalysisInput,
+): Promise<MetadataArtifactWrite[]> {
+  const { source, workingCopyPath } = input;
+  const artifacts: MetadataArtifactWrite[] = [];
+
+  // Browser-level Local State, read once and reused by every Profile.
+  const localStateResolution = resolveJsonFile(
+    source,
+    workingCopyPath,
+    "Local State",
+    "local_state",
+  );
+  let localStateValue: unknown = null;
+  let localStateOrdinal: number | null = null;
+  if (localStateResolution.kind === "ready") {
+    const read = await readVerifiedJsonFile(localStateResolution.file);
+    if (read.status === "parsed") {
+      localStateValue = read.value;
+      localStateOrdinal = localStateResolution.ordinal;
+      artifacts.push({
+        sourceId: source.sourceId,
+        profile: ".",
+        artifact: "Local State",
+        status: "complete",
+        manifestEntryOrdinal: localStateResolution.ordinal,
+        databasePath: "Local State",
+        reason: null,
+        findings: [
+          buildBrowserFinding({
+            sourceId: source.sourceId,
+            profile: ".",
+            ordinal: localStateResolution.ordinal,
+            localState: read.value,
+          }),
+        ],
+        metadataFindingCount: 1,
+      });
+    } else {
+      artifacts.push(
+        unavailableArtifact(
+          source.sourceId,
+          ".",
+          "Local State",
+          "Local State",
+          localStateResolution.ordinal,
+          "unavailable",
+          `local_state_${read.reason}`,
+        ),
+      );
+    }
+  } else {
+    artifacts.push(
+      unavailableArtifact(
+        source.sourceId,
+        ".",
+        "Local State",
+        "Local State",
+        localStateResolution.ordinal,
+        localStateResolution.kind,
+        localStateResolution.reason,
+      ),
+    );
+  }
+
+  // Profile-level Preferences, one artifact per Profile.
+  for (const profile of source.profiles) {
+    const preferencesPath =
+      profile.path === "." ? "Preferences" : `${profile.path}/Preferences`;
+    const resolution = resolveJsonFile(
+      source,
+      workingCopyPath,
+      preferencesPath,
+      "preferences",
+    );
+    if (resolution.kind !== "ready") {
+      artifacts.push(
+        unavailableArtifact(
+          source.sourceId,
+          profile.path,
+          "Preferences",
+          preferencesPath,
+          resolution.ordinal,
+          resolution.kind,
+          resolution.reason,
+        ),
+      );
+      continue;
+    }
+    const read = await readVerifiedJsonFile(resolution.file);
+    if (read.status !== "parsed") {
+      artifacts.push(
+        unavailableArtifact(
+          source.sourceId,
+          profile.path,
+          "Preferences",
+          preferencesPath,
+          resolution.ordinal,
+          "unavailable",
+          `preferences_${read.reason}`,
+        ),
+      );
+      continue;
+    }
+    artifacts.push({
+      sourceId: source.sourceId,
+      profile: profile.path,
+      artifact: "Preferences",
+      status: "complete",
+      manifestEntryOrdinal: resolution.ordinal,
+      databasePath: preferencesPath,
+      reason: null,
+      findings: [
+        buildProfileFinding({
+          sourceId: source.sourceId,
+          profile: profile.path,
+          ordinal: resolution.ordinal,
+          preferences: read.value,
+          localState: localStateValue,
+          localStateOrdinal,
+          preferencesPath,
+        }),
+      ],
+      metadataFindingCount: 1,
+    });
+  }
+
+  return artifacts;
+}

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -33,7 +33,7 @@ export const PROFILE_METADATA_KIND = "profile_metadata";
  * supporting Provenance row.
  */
 
-type Lookup =
+export type Lookup =
   | { readonly kind: "value"; readonly value: unknown }
   | { readonly kind: "absent" }
   | { readonly kind: "malformed" };
@@ -44,7 +44,7 @@ type Lookup =
  * mid-path is `malformed`. This is what lets removed or inapplicable keys stay
  * absent while a wrong-shaped document surfaces as unavailable.
  */
-function lookup(root: unknown, keys: readonly string[]): Lookup {
+export function lookup(root: unknown, keys: readonly string[]): Lookup {
   let current: unknown = root;
   for (const key of keys) {
     if (current === undefined || current === null) {
@@ -61,7 +61,7 @@ function lookup(root: unknown, keys: readonly string[]): Lookup {
   return { kind: "value", value: current };
 }
 
-function stringField(result: Lookup): FieldState<string> {
+export function stringField(result: Lookup): FieldState<string> {
   if (result.kind === "absent") {
     return absentField();
   }
@@ -73,7 +73,7 @@ function stringField(result: Lookup): FieldState<string> {
     : unavailableField("unsupported_value");
 }
 
-function integerField(result: Lookup): FieldState<string> {
+export function integerField(result: Lookup): FieldState<string> {
   if (result.kind === "absent") {
     return absentField();
   }
@@ -102,7 +102,7 @@ function booleanField(result: Lookup): FieldState<boolean> {
  * as the first element of `variations_permanent_consistency_country`
  * (`[version, country]`). A present-but-wrong shape is unavailable, never blank.
  */
-function chromeVersionField(localState: unknown): FieldState<string> {
+export function chromeVersionField(localState: unknown): FieldState<string> {
   const result = lookup(localState, [
     "variations_permanent_consistency_country",
   ]);
@@ -151,7 +151,7 @@ function presenceField(
  * area and always marked `synthetic` so an examiner never mistakes a derived
  * value for a stored one.
  */
-function screenWorkAreaField(
+export function screenWorkAreaField(
   left: FieldState<string>,
   top: FieldState<string>,
   right: FieldState<string>,
@@ -280,7 +280,6 @@ function unavailableArtifact(
     databasePath,
     reason,
     findings: [],
-    metadataFindingCount: 0,
   };
 }
 
@@ -571,7 +570,6 @@ export async function analyseSourcePreferences(
             localState: read.value,
           }),
         ],
-        metadataFindingCount: 1,
       });
     } else {
       artifacts.push(
@@ -658,7 +656,6 @@ export async function analyseSourcePreferences(
           preferencesPath,
         }),
       ],
-      metadataFindingCount: 1,
     });
   }
 

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -129,12 +129,29 @@ function arrayLengthField(result: Lookup): FieldState<string> {
 }
 
 /**
- * A synthetic screen-resolution string derived from the Profile window
- * placement work area. It is emitted only when every bound is an integer, and it
- * is always marked `synthetic` so an examiner never mistakes a derived value for
- * a stored one.
+ * Presence-only classification of an OSCrypt key blob. The key material itself
+ * is never disclosed here; only whether the current `Local State` schema records
+ * a string value at the given path.
  */
-function screenResolutionField(
+function presenceField(
+  localState: unknown,
+  keys: readonly string[],
+): FieldState<boolean> {
+  const result = lookup(localState, keys);
+  if (result.kind === "value") {
+    return valueField(typeof result.value === "string");
+  }
+  return booleanField(result);
+}
+
+/**
+ * A synthetic `WxH` string for the Profile window-placement work area. This is
+ * the display work area Chrome records (it excludes OS chrome such as a taskbar
+ * or dock), not the full physical screen resolution, so it is named for the work
+ * area and always marked `synthetic` so an examiner never mistakes a derived
+ * value for a stored one.
+ */
+function screenWorkAreaField(
   left: FieldState<string>,
   top: FieldState<string>,
   right: FieldState<string>,
@@ -304,30 +321,14 @@ function buildBrowserFinding(options: {
     profileCount: arrayLengthField(
       lookup(options.localState, ["profile", "profiles_order"]),
     ),
-    osCryptKeyPresent: booleanField(
-      (() => {
-        const result = lookup(options.localState, [
-          "os_crypt",
-          "encrypted_key",
-        ]);
-        if (result.kind === "value") {
-          return { kind: "value", value: typeof result.value === "string" };
-        }
-        return result;
-      })(),
-    ),
-    osCryptAppBoundKeyPresent: booleanField(
-      (() => {
-        const result = lookup(options.localState, [
-          "os_crypt",
-          "app_bound_encrypted_key",
-        ]);
-        if (result.kind === "value") {
-          return { kind: "value", value: typeof result.value === "string" };
-        }
-        return result;
-      })(),
-    ),
+    osCryptKeyPresent: presenceField(options.localState, [
+      "os_crypt",
+      "encrypted_key",
+    ]),
+    osCryptAppBoundKeyPresent: presenceField(options.localState, [
+      "os_crypt",
+      "app_bound_encrypted_key",
+    ]),
   };
   const finding: Finding = createFinding({
     findingKind: BROWSER_METADATA_KIND,
@@ -394,7 +395,7 @@ function buildProfileFinding(options: {
       FieldState<string>,
       FieldState<string>,
     ];
-  const screenResolution = screenResolutionField(
+  const screenWorkArea = screenWorkAreaField(
     workAreaLeft,
     workAreaTop,
     workAreaRight,
@@ -487,7 +488,7 @@ function buildProfileFinding(options: {
     workAreaTop,
     workAreaRight,
     workAreaBottom,
-    screenResolution,
+    screenWorkArea,
     avatarIcon,
     gaiaName,
     gaiaGivenName,

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -101,6 +101,11 @@ function booleanField(result: Lookup): FieldState<boolean> {
  * The browser-level Chrome version recorded in the current `Local State` schema
  * as the first element of `variations_permanent_consistency_country`
  * (`[version, country]`). A present-but-wrong shape is unavailable, never blank.
+ *
+ * Caveat for examiners: this element is the version at which the variations
+ * consistency country was last persisted, not necessarily the currently
+ * installed or last-run build. `Local State` has no dedicated version key, so
+ * this is the best in-file proxy; the Provenance points at the exact source.
  */
 export function chromeVersionField(localState: unknown): FieldState<string> {
   const result = lookup(localState, [
@@ -176,6 +181,12 @@ export function screenWorkAreaField(
   return valueField(`${width}x${height}`, { synthetic: true });
 }
 
+/**
+ * Resolve the primary account from `account_info` plus the total account count.
+ * Only the first entry (`account_info[0]`) is detailed; a Profile signed into
+ * multiple accounts reports the rest only through `count`, so the per-account
+ * fields describe the primary account and `accountCount` bounds the remainder.
+ */
 function firstAccount(preferences: unknown): {
   readonly count: FieldState<string>;
   readonly account: unknown;
@@ -442,8 +453,16 @@ function buildProfileFinding(options: {
     booleanField,
   );
 
+  // A supporting Provenance row is attached only when the browser `info_cache`
+  // slice was actually consulted for this Finding: the file was readable and a
+  // Profile directory key exists to locate the slice. A single-Profile Source
+  // (`profile === "."`) has no directory key, so its info_cache fields are
+  // absent and no supporting row is claimed — Provenance never asserts a source
+  // that did not contribute.
   const supportingRows: SourceRowProvenance[] =
-    infoCacheAvailable && options.localStateOrdinal !== null
+    infoCacheAvailable &&
+    options.localStateOrdinal !== null &&
+    profileDir !== null
       ? [
           {
             manifestEntryId: `${options.sourceId}:${options.localStateOrdinal}`,
@@ -452,10 +471,7 @@ function buildProfileFinding(options: {
             manifestPath: "Local State",
             database: "Local State",
             table: "local_state",
-            rowId:
-              profileDir === null
-                ? "profile.info_cache"
-                : `profile.info_cache/${profileDir}`,
+            rowId: `profile.info_cache/${profileDir}`,
           },
         ]
       : [];

--- a/core/test/preferences-json.test.ts
+++ b/core/test/preferences-json.test.ts
@@ -1,0 +1,96 @@
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { WorkingCopyIntegrityRefusal } from "../src/errors.js";
+import { readVerifiedJsonFile } from "../src/preferences-json.js";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+async function writeFixture(contents: string): Promise<{
+  readonly path: string;
+  readonly size: number;
+  readonly sha256: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "forensix-prefs-json-"));
+  roots.push(root);
+  const path = join(root, "Preferences");
+  await writeFile(path, contents);
+  const bytes = Buffer.from(contents);
+  return {
+    path,
+    size: bytes.length,
+    sha256: createHash("sha256").update(bytes).digest("hex"),
+  };
+}
+
+describe("readVerifiedJsonFile", () => {
+  it("parses a JSON document that matches its recorded representation", async () => {
+    const fixture = await writeFixture('{"profile":{"name":"Ada"}}');
+    const result = await readVerifiedJsonFile({
+      path: fixture.path,
+      manifestPath: "Default/Preferences",
+      size: fixture.size,
+      sha256: fixture.sha256,
+    });
+    expect(result).toEqual({
+      status: "parsed",
+      value: { profile: { name: "Ada" } },
+    });
+  });
+
+  it("reports a byte-intact but unparseable document as unreadable", async () => {
+    const fixture = await writeFixture("{ not json ,,");
+    const result = await readVerifiedJsonFile({
+      path: fixture.path,
+      manifestPath: "Local State",
+      size: fixture.size,
+      sha256: fixture.sha256,
+    });
+    expect(result).toEqual({ status: "unreadable", reason: "malformed_json" });
+  });
+
+  it("refuses content whose hash drifted from the Manifest", async () => {
+    const fixture = await writeFixture('{"a":1}');
+    await expect(
+      readVerifiedJsonFile({
+        path: fixture.path,
+        manifestPath: "Local State",
+        size: fixture.size,
+        sha256: "0".repeat(64),
+      }),
+    ).rejects.toBeInstanceOf(WorkingCopyIntegrityRefusal);
+  });
+
+  it("refuses content whose size drifted from the Manifest", async () => {
+    const fixture = await writeFixture('{"a":1}');
+    await expect(
+      readVerifiedJsonFile({
+        path: fixture.path,
+        manifestPath: "Local State",
+        size: fixture.size + 1,
+        sha256: fixture.sha256,
+      }),
+    ).rejects.toBeInstanceOf(WorkingCopyIntegrityRefusal);
+  });
+
+  it("refuses a missing Working Copy file", async () => {
+    await expect(
+      readVerifiedJsonFile({
+        path: join(tmpdir(), "forensix-does-not-exist", "Preferences"),
+        manifestPath: "Default/Preferences",
+        size: 2,
+        sha256: "0".repeat(64),
+      }),
+    ).rejects.toBeInstanceOf(WorkingCopyIntegrityRefusal);
+  });
+});

--- a/core/test/preferences.test.ts
+++ b/core/test/preferences.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  absentField,
+  unavailableField,
+  valueField,
+  type FieldState,
+} from "../src/forensic-model.js";
+import {
+  chromeVersionField,
+  integerField,
+  lookup,
+  screenWorkAreaField,
+  stringField,
+  type Lookup,
+} from "../src/preferences.js";
+
+describe("lookup", () => {
+  const document = {
+    profile: { name: "Ada", nested: { deep: 1 } },
+    cleared: null,
+    scalar: "leaf",
+  };
+
+  const cases: ReadonlyArray<{
+    readonly label: string;
+    readonly keys: readonly string[];
+    readonly expected: Lookup;
+  }> = [
+    {
+      label: "resolves a nested value",
+      keys: ["profile", "name"],
+      expected: { kind: "value", value: "Ada" },
+    },
+    {
+      label: "treats a missing key as absent",
+      keys: ["profile", "missing"],
+      expected: { kind: "absent" },
+    },
+    {
+      label: "treats an explicit null as absent",
+      keys: ["cleared"],
+      expected: { kind: "absent" },
+    },
+    {
+      label: "treats a scalar mid-path as malformed",
+      keys: ["scalar", "deeper"],
+      expected: { kind: "malformed" },
+    },
+    {
+      label: "treats descending into null as absent",
+      keys: ["cleared", "child"],
+      expected: { kind: "absent" },
+    },
+  ];
+
+  for (const testCase of cases) {
+    it(testCase.label, () => {
+      expect(lookup(document, testCase.keys)).toEqual(testCase.expected);
+    });
+  }
+
+  it("treats an array as a non-navigable, malformed container", () => {
+    expect(lookup({ list: [1, 2] }, ["list", "0"])).toEqual({
+      kind: "malformed",
+    });
+  });
+});
+
+describe("stringField", () => {
+  it("keeps a string value", () => {
+    expect(stringField({ kind: "value", value: "x" })).toEqual(valueField("x"));
+  });
+
+  it("maps a missing key to absent", () => {
+    expect(stringField({ kind: "absent" })).toEqual(absentField());
+  });
+
+  it("maps a wrong-shaped document to unavailable", () => {
+    expect(stringField({ kind: "malformed" })).toEqual(
+      unavailableField("unsupported_value"),
+    );
+  });
+
+  it("maps a wrong-typed value to unavailable", () => {
+    expect(stringField({ kind: "value", value: 42 })).toEqual(
+      unavailableField("unsupported_value"),
+    );
+  });
+});
+
+describe("integerField", () => {
+  it("stringifies an integer", () => {
+    expect(integerField({ kind: "value", value: 1920 })).toEqual(
+      valueField("1920"),
+    );
+  });
+
+  it("rejects a non-integer number", () => {
+    expect(integerField({ kind: "value", value: 1.5 })).toEqual(
+      unavailableField("unsupported_value"),
+    );
+  });
+
+  it("rejects a numeric string", () => {
+    expect(integerField({ kind: "value", value: "1920" })).toEqual(
+      unavailableField("unsupported_value"),
+    );
+  });
+});
+
+describe("chromeVersionField", () => {
+  it("reads the version from the variations consistency tuple", () => {
+    expect(
+      chromeVersionField({
+        variations_permanent_consistency_country: ["142.0.7444.0", "us"],
+      }),
+    ).toEqual(valueField("142.0.7444.0"));
+  });
+
+  it("is absent when the key is not recorded", () => {
+    expect(chromeVersionField({})).toEqual(absentField());
+  });
+
+  it("is unavailable when the tuple is not an array", () => {
+    expect(
+      chromeVersionField({ variations_permanent_consistency_country: "142" }),
+    ).toEqual(unavailableField("unsupported_value"));
+  });
+
+  it("is unavailable when the first element is not a string", () => {
+    expect(
+      chromeVersionField({
+        variations_permanent_consistency_country: [142, "us"],
+      }),
+    ).toEqual(unavailableField("unsupported_value"));
+  });
+});
+
+describe("screenWorkAreaField", () => {
+  const bound = (value: number): FieldState<string> =>
+    valueField(value.toString());
+
+  it("derives a synthetic WxH from the four bounds", () => {
+    expect(
+      screenWorkAreaField(bound(0), bound(0), bound(1920), bound(1080)),
+    ).toEqual(valueField("1920x1080", { synthetic: true }));
+  });
+
+  it("subtracts a non-zero origin", () => {
+    expect(
+      screenWorkAreaField(bound(100), bound(50), bound(1380), bound(818)),
+    ).toEqual(valueField("1280x768", { synthetic: true }));
+  });
+
+  it("is absent when any bound is absent", () => {
+    expect(
+      screenWorkAreaField(bound(0), absentField(), bound(1920), bound(1080)),
+    ).toEqual(absentField());
+  });
+
+  it("is unavailable when any bound is unavailable", () => {
+    expect(
+      screenWorkAreaField(
+        bound(0),
+        bound(0),
+        unavailableField("unsupported_value"),
+        bound(1080),
+      ),
+    ).toEqual(unavailableField("unsupported_value"));
+  });
+
+  it("rejects a degenerate (non-positive) area", () => {
+    expect(
+      screenWorkAreaField(bound(1920), bound(0), bound(1920), bound(1080)),
+    ).toEqual(unavailableField("unsupported_value"));
+  });
+
+  it("prefers unavailable over absent when both are present", () => {
+    expect(
+      screenWorkAreaField(
+        absentField(),
+        bound(0),
+        unavailableField("unsupported_value"),
+        bound(1080),
+      ),
+    ).toEqual(unavailableField("unsupported_value"));
+  });
+});

--- a/e2e/metadata-cli.test.ts
+++ b/e2e/metadata-cli.test.ts
@@ -254,8 +254,8 @@ describe("compiled analyzer CLI Metadata Finding pipeline", () => {
         accountCount: { state: "value", value: "1" },
         accountEmail: { state: "value", value: "ada@example.com" },
         accountLocale: { state: "value", value: "en-US" },
-        // AC1: screen resolution derived from the work area, marked synthetic.
-        screenResolution: {
+        // AC1: screen work area derived from the window placement, synthetic.
+        screenWorkArea: {
           state: "value",
           value: "1920x1080",
           synthetic: true,
@@ -284,7 +284,7 @@ describe("compiled analyzer CLI Metadata Finding pipeline", () => {
       state: "unavailable",
       reason: "unsupported_value",
     });
-    expect(workProfile?.fields.screenResolution).toEqual({
+    expect(workProfile?.fields.screenWorkArea).toEqual({
       state: "unavailable",
       reason: "unsupported_value",
     });

--- a/e2e/metadata-cli.test.ts
+++ b/e2e/metadata-cli.test.ts
@@ -1,0 +1,471 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface FieldValue<T> {
+  readonly state: "value";
+  readonly value: T;
+  readonly synthetic?: boolean;
+}
+
+interface Unavailable {
+  readonly state: "unavailable";
+  readonly reason: string;
+}
+
+interface Absent {
+  readonly state: "absent";
+}
+
+type Field<T> = FieldValue<T> | Unavailable | Absent;
+
+interface MetadataFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "browser_metadata" | "profile_metadata";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestEntryId: string;
+    readonly manifestEntryOrdinal: number;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+    readonly supportingRows?: readonly {
+      readonly manifestPath: string;
+      readonly table: string;
+      readonly rowId: string;
+    }[];
+  };
+  readonly fields: Record<string, Field<unknown>>;
+}
+
+interface MetadataPage {
+  readonly status: "ok";
+  readonly command: "metadata";
+  readonly items: readonly MetadataFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+const LOCAL_STATE = {
+  os_crypt: { encrypted_key: "QVBQTAABBBB" },
+  variations_country: "us",
+  variations_permanent_consistency_country: ["142.0.7444.0", "us"],
+  profile: {
+    last_used: "Default",
+    profiles_order: ["Default", "Profile 1"],
+    info_cache: {
+      Default: {
+        avatar_icon: "chrome://theme/IDR_PROFILE_AVATAR_26",
+        gaia_name: "Ada Lovelace",
+        gaia_given_name: "Ada",
+        gaia_id: "1122334455",
+        gaia_picture_file_name: "Google Profile Picture.png",
+        user_name: "ada@example.com",
+        is_using_default_avatar: false,
+        is_using_default_name: false,
+      },
+      "Profile 1": {
+        avatar_icon: "chrome://theme/IDR_PROFILE_AVATAR_5",
+        user_name: "",
+        is_using_default_avatar: true,
+      },
+    },
+  },
+};
+
+const DEFAULT_PREFERENCES = {
+  profile: {
+    name: "Ada",
+    created_by_version: "141.0.7390.55",
+    exit_type: "Normal",
+  },
+  account_info: [
+    {
+      email: "ada@example.com",
+      gaia: "1122334455",
+      full_name: "Ada Lovelace",
+      given_name: "Ada",
+      locale: "en-US",
+      hd: "example.com",
+    },
+  ],
+  browser: {
+    window_placement: {
+      work_area_left: 0,
+      work_area_top: 0,
+      work_area_right: 1920,
+      work_area_bottom: 1080,
+    },
+  },
+};
+
+// Profile 1 exercises the uncertainty contract: account_info is the wrong shape
+// (unavailable, not absent), a window bound is non-numeric (unavailable), and
+// created_by_version is simply not present (absent).
+const PROFILE_ONE_PREFERENCES = {
+  profile: { name: "Work" },
+  account_info: "not-an-array",
+  browser: {
+    window_placement: {
+      work_area_left: 0,
+      work_area_top: 0,
+      work_area_right: "wide",
+      work_area_bottom: 1200,
+    },
+  },
+};
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(join(source, "Default"), { recursive: true });
+  await mkdir(join(source, "Profile 1"), { recursive: true });
+  await writeJson(join(source, "Local State"), LOCAL_STATE);
+  await writeJson(join(source, "Default", "Preferences"), DEFAULT_PREFERENCES);
+  await writeJson(
+    join(source, "Profile 1", "Preferences"),
+    PROFILE_ONE_PREFERENCES,
+  );
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Metadata Finding pipeline", () => {
+  it("parses browser and Profile metadata with correct scoping", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-metadata-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const localStateBytes = await readFile(join(source, "Local State"));
+    const caseDirectory = join(root, "CASE-METADATA");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    // AC1/AC4: one browser-level artifact plus one artifact per Profile.
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      preferences: {
+        status: "complete",
+        analysedArtifactCount: 3,
+        browserMetadataCount: 1,
+        profileMetadataCount: 2,
+        findingCount: 3,
+      },
+    });
+
+    // AC5/AC6: sorted by Profile ascending, "." (browser) sorts first.
+    const all = parseJson<MetadataPage>(
+      runCli(["metadata", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(all.items.map((row) => row.profile)).toEqual([
+      ".",
+      "Default",
+      "Profile 1",
+    ]);
+
+    // AC2: browser-level values verified against current Local State schema.
+    const browser = all.items[0];
+    expect(browser).toMatchObject({
+      findingKind: "browser_metadata",
+      profile: ".",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Local State",
+        database: "Local State",
+        table: "local_state",
+        rowId: "local_state",
+      },
+      fields: {
+        scope: { state: "value", value: "browser" },
+        chromeVersion: { state: "value", value: "142.0.7444.0" },
+        variationsCountry: { state: "value", value: "us" },
+        lastUsedProfile: { state: "value", value: "Default" },
+        profileCount: { state: "value", value: "2" },
+        osCryptKeyPresent: { state: "value", value: true },
+        osCryptAppBoundKeyPresent: { state: "absent" },
+      },
+    });
+
+    // AC2/AC4: Profile-level values, with avatar and demographics drawn from the
+    // browser file's info_cache slice and attributed via a supporting row.
+    const defaultProfile = all.items[1];
+    expect(defaultProfile).toMatchObject({
+      findingKind: "profile_metadata",
+      profile: "Default",
+      provenance: {
+        manifestPath: "Default/Preferences",
+        database: "Default/Preferences",
+        table: "preferences",
+        rowId: "Default",
+        supportingRows: [
+          {
+            manifestPath: "Local State",
+            table: "local_state",
+            rowId: "profile.info_cache/Default",
+          },
+        ],
+      },
+      fields: {
+        profileName: { state: "value", value: "Ada" },
+        createdByVersion: { state: "value", value: "141.0.7390.55" },
+        accountCount: { state: "value", value: "1" },
+        accountEmail: { state: "value", value: "ada@example.com" },
+        accountLocale: { state: "value", value: "en-US" },
+        // AC1: screen resolution derived from the work area, marked synthetic.
+        screenResolution: {
+          state: "value",
+          value: "1920x1080",
+          synthetic: true,
+        },
+        avatarIcon: {
+          state: "value",
+          value: "chrome://theme/IDR_PROFILE_AVATAR_26",
+        },
+        gaiaName: { state: "value", value: "Ada Lovelace" },
+      },
+    });
+
+    // AC3: malformed and absent inputs are distinct, typed, and never blank.
+    const workProfile = all.items[2];
+    expect(workProfile?.fields.profileName).toEqual({
+      state: "value",
+      value: "Work",
+    });
+    expect(workProfile?.fields.createdByVersion).toEqual({ state: "absent" });
+    expect(workProfile?.fields.accountCount).toEqual({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    expect(workProfile?.fields.accountEmail).toEqual({ state: "absent" });
+    expect(workProfile?.fields.workAreaRight).toEqual({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    expect(workProfile?.fields.screenResolution).toEqual({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    // Profile 1 has an info_cache slice, so its avatar is present but its
+    // gaia_name simply is not recorded there (absent, not unavailable).
+    expect(workProfile?.fields.avatarIcon).toEqual({
+      state: "value",
+      value: "chrome://theme/IDR_PROFILE_AVATAR_5",
+    });
+    expect(workProfile?.fields.gaiaName).toEqual({ state: "absent" });
+
+    // AC6: type filter narrows to a single scope.
+    const browserOnly = parseJson<MetadataPage>(
+      runCli([
+        "metadata",
+        "--case",
+        caseDirectory,
+        "--type",
+        "browser_metadata",
+        "--json",
+      ]).stdout,
+    );
+    expect(browserOnly.items).toHaveLength(1);
+    expect(browserOnly.items[0]?.profile).toBe(".");
+
+    // AC6: Profile filter, search, keyset pagination, and cursor rejection.
+    const paged = parseJson<MetadataPage>(
+      runCli([
+        "metadata",
+        "--case",
+        caseDirectory,
+        "--type",
+        "profile_metadata",
+        "--sort",
+        "profile",
+        "--direction",
+        "asc",
+        "--limit",
+        "1",
+        "--json",
+      ]).stdout,
+    );
+    expect(paged.items).toHaveLength(1);
+    expect(paged.items[0]?.profile).toBe("Default");
+    expect(paged.nextCursor).not.toBeNull();
+
+    const next = parseJson<MetadataPage>(
+      runCli([
+        "metadata",
+        "--case",
+        caseDirectory,
+        "--type",
+        "profile_metadata",
+        "--sort",
+        "profile",
+        "--direction",
+        "asc",
+        "--limit",
+        "1",
+        "--after",
+        paged.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    expect(next.items).toHaveLength(1);
+    expect(next.items[0]?.profile).toBe("Profile 1");
+    expect(next.nextCursor).toBeNull();
+
+    const searched = parseJson<MetadataPage>(
+      runCli([
+        "metadata",
+        "--case",
+        caseDirectory,
+        "--search",
+        "ada@example.com",
+        "--json",
+      ]).stdout,
+    );
+    expect(searched.items).toHaveLength(1);
+    expect(searched.items[0]?.profile).toBe("Default");
+
+    // AC6: broken input rejected.
+    const badLimit = runCli([
+      "metadata",
+      "--case",
+      caseDirectory,
+      "--limit",
+      "0",
+      "--json",
+    ]);
+    expect(badLimit.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(badLimit.stderr)).toMatchObject({
+      code: "INVALID_ARGUMENT",
+    });
+
+    // AC6: a stale cursor after re-analysis is rejected.
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const stale = runCli([
+      "metadata",
+      "--case",
+      caseDirectory,
+      "--type",
+      "profile_metadata",
+      "--sort",
+      "profile",
+      "--direction",
+      "asc",
+      "--limit",
+      "1",
+      "--after",
+      paged.nextCursor as string,
+      "--json",
+    ]);
+    expect(stale.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(stale.stderr)).toMatchObject({
+      code: "INVALID_CURSOR",
+    });
+
+    // AC1: analysis never mutates the Source bytes.
+    expect(await readFile(join(source, "Local State"))).toEqual(
+      localStateBytes,
+    );
+  });
+
+  it("reports malformed and missing JSON as typed unavailable metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-metadata-bad-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(join(source, "Default"), { recursive: true });
+    await mkdir(join(source, "Profile 1"), { recursive: true });
+    // A byte-intact but unparseable browser file, and one good Profile file.
+    await writeFile(join(source, "Local State"), "{ not valid json ,,");
+    await writeJson(
+      join(source, "Default", "Preferences"),
+      DEFAULT_PREFERENCES,
+    );
+    await writeFile(join(source, "Profile 1", "Preferences"), "{ broken");
+    const caseDirectory = join(root, "CASE-METADATA-BAD");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    // Metadata does not drive the Analysis Run exit state, but its own summary
+    // reports the malformed inputs as a partial metadata result while the
+    // defensible Default Profile metadata stays queryable.
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      preferences: {
+        status: "partial",
+        analysedArtifactCount: 1,
+        unavailableArtifactCount: 2,
+      },
+    });
+
+    // AC3/AC4: the browser file is unreadable, so a Profile that depends on its
+    // info_cache reports those fields as unavailable, never silently absent.
+    const results = parseJson<MetadataPage>(
+      runCli([
+        "metadata",
+        "--case",
+        caseDirectory,
+        "--type",
+        "profile_metadata",
+        "--json",
+      ]).stdout,
+    );
+    expect(results.items).toHaveLength(1);
+    const defaultProfile = results.items[0];
+    expect(defaultProfile?.profile).toBe("Default");
+    expect(defaultProfile?.fields.profileName).toEqual({
+      state: "value",
+      value: "Ada",
+    });
+    expect(defaultProfile?.fields.avatarIcon).toEqual({
+      state: "unavailable",
+      reason: "related_row_missing",
+    });
+    expect(defaultProfile?.provenance.supportingRows).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #176.

Parses current Chrome `Preferences` (Profile-level) and `Local State`
(browser-level) JSON into forensic metadata Findings, mirroring the
established History/Cookies/Login-Data contract.

## Acceptance criteria

- **Parse current Preferences + browser-level metadata (Chrome version, screen
  resolution, supported account data, demographics, avatars).**
  - `browser_metadata` (Source scope, from `Local State`): Chrome version
    (`variations_permanent_consistency_country[0]`), variations country, last
    used Profile, Profile count, OSCrypt key presence.
  - `profile_metadata` (Profile scope, from `Preferences`): profile name,
    created-by version, exit type, supported account data (`account_info`),
    demographics (locale, gaia names), window work-area screen resolution
    (emitted as a `synthetic` `WxH` string), plus avatars and gaia demographics
    read from the browser-level `profile.info_cache` slice.
- **Every value verified vs current schema with Field State + Provenance.**
  Values are read by explicit key path and typed; each Finding carries full
  `Provenance`.
- **Removed/inapplicable keys are absent; malformed/unreadable inputs are
  unavailable with typed reasons.** Missing or `null` keys → `absent`;
  wrong-shaped values → `unavailable(unsupported_value)`; a malformed JSON
  document → an `unavailable` artifact with a typed reason; byte drift from the
  recorded Manifest is a Working Copy integrity refusal.
- **Browser-level vs Profile-level metadata correctly scoped in a multi-Profile
  Case.** Browser scope is stored under the `Local State` artifact; each Profile
  under the `Preferences` artifact. Profile-scoped data that lives in the
  browser file's `info_cache` is attributed to the owning Profile via a
  supporting Provenance row, and is `unavailable(related_row_missing)` when the
  browser file cannot be read.
- **CLI follows the bounded query + uncertainty-presentation contract.** New
  `forensix metadata` command: `--type`, `--profile`, `--commit-state`,
  `--search`, `--sort <type|profile>`, `--direction`, `--limit`, `--after`
  keyset pagination with cursor fingerprinting.

## Notes

- Metadata is **additive**: recorded and queryable, but excluded from the
  Analysis Run exit-state aggregation so History/Cookies/Login exit-code
  semantics stay byte-for-byte identical. Metadata health is reported in the
  analyse summary (`preferences`).
- Tests: `e2e/metadata-cli.test.ts` (scoping, uncertainty, pagination, integrity)
  and `core/test/preferences-json.test.ts` (verified JSON reader). `pnpm verify`
  is green (Node 24.15.0).