### PR TITLE
feat(favicons): parse Favicons and page associations as Findings

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -12,6 +12,7 @@ import {
   queryAutofill,
   queryCookies,
   queryCredentials,
+  queryFavicons,
   queryHistory,
   queryMetadata,
   queryTopSites,
@@ -23,6 +24,8 @@ import {
   type CookieSort,
   type CredentialDirection,
   type CredentialSort,
+  type FaviconDirection,
+  type FaviconSort,
   type TopSiteDirection,
   type TopSiteSort,
   type DeclaredOriginOs,
@@ -72,6 +75,12 @@ const USAGE = `Usage:
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <created-time|last-used-time|field-name|value|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix favicons --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--sort <icon-url|page-url|last-updated|width|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix metadata --case <case-directory>
@@ -645,6 +654,53 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as TopSiteSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | TopSiteDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "favicons") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The favicons command accepts no positional values.",
+      );
+    }
+    const result = queryFavicons({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      sort: enumOption(parsed, "--sort", [
+        "icon-url",
+        "page-url",
+        "last-updated",
+        "width",
+        "profile",
+      ] as const) as FaviconSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | FaviconDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -139,6 +139,31 @@ export interface TopSitesArtifactWrite {
   readonly recoveredTopSiteCount: number;
 }
 
+export interface PersistedFaviconFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortIconUrl: string | null;
+  readonly sortPageUrl: string | null;
+  readonly sortLastUpdated: string | null;
+  readonly sortWidth: bigint | null;
+}
+
+export interface FaviconArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedFaviconFinding[];
+  readonly committedFaviconCount: number;
+  readonly recoveredFaviconCount: number;
+  readonly payloadFileCount: number;
+}
+
 export interface PersistedMetadataFinding {
   readonly finding: Finding;
   readonly searchText: string;
@@ -175,6 +200,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly loginDataArtifacts?: readonly LoginDataArtifactWrite[];
   readonly topSitesArtifacts?: readonly TopSitesArtifactWrite[];
   readonly webDataArtifacts?: readonly WebDataArtifactWrite[];
+  readonly faviconArtifacts?: readonly FaviconArtifactWrite[];
   readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
 }
 
@@ -534,6 +560,66 @@ export function initializeFindingSchema(database: DatabaseSync): void {
     CREATE INDEX IF NOT EXISTS top_sites_findings_profile_query
       ON top_sites_findings(finding_kind, profile_path, commit_state, finding_id);
 
+    CREATE TABLE IF NOT EXISTS favicon_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Favicons'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS favicon_one_active_result
+      ON favicon_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS favicon_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES favicon_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_icon_url TEXT,
+      sort_page_url TEXT,
+      sort_last_updated TEXT,
+      sort_width INTEGER,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS favicon_findings_icon_url_query
+      ON favicon_findings(finding_kind, COALESCE(sort_icon_url, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS favicon_findings_page_url_query
+      ON favicon_findings(finding_kind, COALESCE(sort_page_url, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS favicon_findings_last_updated_query
+      ON favicon_findings(finding_kind, COALESCE(sort_last_updated, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS favicon_findings_width_query
+      ON favicon_findings(finding_kind, COALESCE(sort_width, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS favicon_findings_profile_query
+      ON favicon_findings(finding_kind, profile_path, commit_state, finding_id);
+
     CREATE TABLE IF NOT EXISTS preferences_artifact_results (
       artifact_result_id INTEGER PRIMARY KEY,
       run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
@@ -738,6 +824,32 @@ function insertTopSiteFinding(
   );
 }
 
+function insertFaviconFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedFaviconFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortIconUrl,
+    row.sortPageUrl,
+    row.sortLastUpdated,
+    row.sortWidth,
+  );
+}
+
 function insertMetadataFinding(
   statement: ReturnType<DatabaseSync["prepare"]>,
   artifactResultId: bigint,
@@ -925,6 +1037,30 @@ export function storeHistoryAnalysis(
       const activateCurrentTopSite = database.prepare(
         "UPDATE top_sites_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertFaviconArtifact = database.prepare(
+        `INSERT INTO favicon_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Favicons', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertFaviconFindingStatement = database.prepare(
+        `INSERT INTO favicon_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_icon_url,
+            sort_page_url, sort_last_updated, sort_width)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousFavicon = database.prepare(
+        `UPDATE favicon_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Favicons'
+            AND active = 1`,
+      );
+      const activateCurrentFavicon = database.prepare(
+        "UPDATE favicon_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
       const insertMetadataArtifact = database.prepare(
         `INSERT INTO preferences_artifact_results
            (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
@@ -1040,6 +1176,34 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of options.faviconArtifacts ?? []) {
+        const insertion = insertFaviconArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertFaviconFinding(
+            insertFaviconFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousFavicon.run(artifact.sourceId, artifact.profile);
+          activateCurrentFavicon.run(artifactResultId);
+        }
+      }
+
       for (const artifact of options.loginDataArtifacts ?? []) {
         const insertion = insertLoginArtifact.run(
           runId,
@@ -1137,6 +1301,7 @@ export function storeHistoryAnalysis(
         ...(options.loginDataArtifacts ?? []),
         ...(options.topSitesArtifacts ?? []),
         ...(options.webDataArtifacts ?? []),
+        ...(options.faviconArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -17,7 +17,8 @@ export type OverviewArtifact =
   | "Cookies"
   | "Login Data"
   | "Top Sites"
-  | "Web Data";
+  | "Web Data"
+  | "Favicons";
 export type CompletenessOutcome = "produced" | "absent" | "unavailable";
 
 export interface CompletenessArtifact {
@@ -80,6 +81,7 @@ const ARTIFACT_TABLES: readonly ArtifactTable[] = [
   { artifact: "Login Data", resultsTable: "login_data_artifact_results" },
   { artifact: "Top Sites", resultsTable: "top_sites_artifact_results" },
   { artifact: "Web Data", resultsTable: "web_data_artifact_results" },
+  { artifact: "Favicons", resultsTable: "favicon_artifact_results" },
 ];
 
 function openCase(caseDirectory: string): DatabaseSync {

--- a/core/src/favicons-query.ts
+++ b/core/src/favicons-query.ts
@@ -1,0 +1,395 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type FaviconDirection = "asc" | "desc";
+export type FaviconSort =
+  | "icon-url"
+  | "page-url"
+  | "last-updated"
+  | "width"
+  | "profile";
+
+export interface FaviconQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly sort?: FaviconSort;
+  readonly direction?: FaviconDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface FaviconPage {
+  readonly status: "ok";
+  readonly command: "favicons";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const FAVICON_DIRECTIONS = ["asc", "desc"] as const;
+const FAVICON_SORTS = [
+  "icon-url",
+  "page-url",
+  "last-updated",
+  "width",
+  "profile",
+] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const FAVICON_KIND = "favicon";
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+// `width` keys on the integer `sort_width` column (with a -1 COALESCE sentinel,
+// so keys can be negative); every other sort keys on text. The `kind` tag drives
+// cursor-key validation below, mirroring top-sites-query.ts so the integer/text
+// decision lives in one place rather than in scattered `sort === "width"`
+// branches.
+const SORTS: Readonly<Record<FaviconSort, SortDefinition>> = {
+  "icon-url": { expression: "COALESCE(f.sort_icon_url, '')", kind: "text" },
+  "page-url": { expression: "COALESCE(f.sort_page_url, '')", kind: "text" },
+  "last-updated": {
+    expression: "COALESCE(f.sort_last_updated, '')",
+    kind: "text",
+  },
+  width: { expression: "COALESCE(f.sort_width, -1)", kind: "integer" },
+  profile: { expression: "f.profile_path", kind: "text" },
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly sort: FaviconSort;
+  readonly direction: FaviconDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Favicons cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Favicons cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Favicons --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Favicons ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM favicon_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function faviconSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'favicon_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Favicon Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryFavicons(input: FaviconQuery): FaviconPage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    FAVICON_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "icon-url", FAVICON_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortDefinition = SORTS[sort];
+  const sortExpression = sortDefinition.expression;
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Favicons queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!faviconSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Favicons analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [FAVICON_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      // An integer sort validates its key with the same regex and int64 range
+      // guard Top Sites uses, so a forged or out-of-range cursor surfaces a
+      // typed INVALID_CURSOR instead of a raw BigInt/node:sqlite throw.
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        findingId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Favicons cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM favicon_findings f
+           JOIN favicon_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "favicons",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/favicons-sqlite.ts
+++ b/core/src/favicons-sqlite.ts
@@ -1,0 +1,328 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import type { CommitState } from "./forensic-model.js";
+import { ForensixError } from "./errors.js";
+import { openDatabaseSync } from "./sqlite-open.js";
+import {
+  immutableDatabase,
+  snapshotVerifiedFile,
+  type RawHistoryValue,
+  type VerifiedHistoryFile,
+} from "./history-sqlite.js";
+
+export type RawFaviconValue = RawHistoryValue;
+export type VerifiedFaviconFile = VerifiedHistoryFile;
+
+/**
+ * One `favicon_bitmaps` row: a single stored icon payload at one pixel size,
+ * with its raw SQLite values preserved so the Finding layer classifies each
+ * Field State without lossy coercion. `imageData` stays a `Uint8Array` when the
+ * blob is present so the analyzer can hash it into a separate payload file.
+ */
+export interface RawFaviconBitmap {
+  readonly rowId: RawFaviconValue;
+  readonly iconId: RawFaviconValue;
+  readonly imageData: RawFaviconValue;
+  readonly width: RawFaviconValue;
+  readonly height: RawFaviconValue;
+  readonly lastUpdated: RawFaviconValue;
+  readonly lastRequested: RawFaviconValue;
+}
+
+/** One `favicons` row: the icon URL and its type, keyed by `id`. */
+export interface RawFaviconRecord {
+  readonly rowId: RawFaviconValue;
+  readonly url: RawFaviconValue;
+  readonly iconType: RawFaviconValue;
+}
+
+/** One `icon_mapping` row: a page URL bound to an icon `id`. */
+export interface RawIconMapping {
+  readonly rowId: RawFaviconValue;
+  readonly pageUrl: RawFaviconValue;
+  readonly iconId: RawFaviconValue;
+}
+
+export interface FaviconSchema {
+  readonly version: number;
+  readonly bitmapColumns: ReadonlySet<string>;
+  readonly faviconColumns: ReadonlySet<string>;
+  readonly mappingColumns: ReadonlySet<string>;
+}
+
+export interface FaviconPass {
+  readonly schema: FaviconSchema;
+  readonly bitmaps: readonly RawFaviconBitmap[];
+  readonly favicons: readonly RawFaviconRecord[];
+  readonly iconMappings: readonly RawIconMapping[];
+  readonly integrity: string;
+}
+
+export interface RecoveredFaviconPass extends FaviconPass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface FaviconPasses {
+  readonly committed: FaviconPass;
+  readonly recovered: RecoveredFaviconPass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+/**
+ * Columns every supported Chromium Favicons schema (versions 7 and 8) must
+ * expose. `favicon_bitmaps.last_requested` arrived in version 7 and is read
+ * when present, recorded as an absent Field State when a schema omits it so a
+ * Finding never fabricates a value.
+ */
+const REQUIRED_BITMAP_COLUMNS = [
+  "icon_id",
+  "image_data",
+  "width",
+  "height",
+  "last_updated",
+] as const;
+const REQUIRED_FAVICON_COLUMNS = ["url", "icon_type"] as const;
+const REQUIRED_MAPPING_COLUMNS = ["page_url", "icon_id"] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): FaviconSchema {
+  for (const table of ["meta", "favicons", "favicon_bitmaps", "icon_mapping"]) {
+    if (!tableExists(database, table)) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        `Favicons database is missing the ${table} table.`,
+        { table },
+      );
+    }
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "Favicons meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const bitmapColumns = tableColumns(database, "favicon_bitmaps");
+  const faviconColumns = tableColumns(database, "favicons");
+  const mappingColumns = tableColumns(database, "icon_mapping");
+  const missing = [
+    ...REQUIRED_BITMAP_COLUMNS.filter((column) => !bitmapColumns.has(column)),
+    ...REQUIRED_FAVICON_COLUMNS.filter((column) => !faviconColumns.has(column)),
+    ...REQUIRED_MAPPING_COLUMNS.filter((column) => !mappingColumns.has(column)),
+  ];
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Favicons schema version ${version} is missing required columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return { version, bitmapColumns, faviconColumns, mappingColumns };
+}
+
+function optionalColumn(
+  columns: ReadonlySet<string>,
+  column: string,
+  alias: string,
+): string {
+  return columns.has(column)
+    ? `"${column}" AS "${alias}"`
+    : `NULL AS "${alias}"`;
+}
+
+function normalizeValue(value: unknown): RawFaviconValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Favicons contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readPass(database: DatabaseSync): FaviconPass {
+  const schema = readSchema(database);
+  const bitmapStatement = database.prepare(`
+    SELECT
+      rowid AS "rowId",
+      ${optionalColumn(schema.bitmapColumns, "icon_id", "iconId")},
+      ${optionalColumn(schema.bitmapColumns, "image_data", "imageData")},
+      ${optionalColumn(schema.bitmapColumns, "width", "width")},
+      ${optionalColumn(schema.bitmapColumns, "height", "height")},
+      ${optionalColumn(schema.bitmapColumns, "last_updated", "lastUpdated")},
+      ${optionalColumn(schema.bitmapColumns, "last_requested", "lastRequested")}
+    FROM favicon_bitmaps
+    ORDER BY rowid
+  `);
+  const bitmaps: RawFaviconBitmap[] = [];
+  for (const row of bitmapStatement.iterate()) {
+    bitmaps.push({
+      rowId: normalizeValue(row.rowId),
+      iconId: normalizeValue(row.iconId),
+      imageData: normalizeValue(row.imageData),
+      width: normalizeValue(row.width),
+      height: normalizeValue(row.height),
+      lastUpdated: normalizeValue(row.lastUpdated),
+      lastRequested: normalizeValue(row.lastRequested),
+    });
+  }
+
+  const faviconStatement = database.prepare(`
+    SELECT
+      rowid AS "rowId",
+      ${optionalColumn(schema.faviconColumns, "url", "url")},
+      ${optionalColumn(schema.faviconColumns, "icon_type", "iconType")}
+    FROM favicons
+    ORDER BY rowid
+  `);
+  const favicons: RawFaviconRecord[] = [];
+  for (const row of faviconStatement.iterate()) {
+    favicons.push({
+      rowId: normalizeValue(row.rowId),
+      url: normalizeValue(row.url),
+      iconType: normalizeValue(row.iconType),
+    });
+  }
+
+  const mappingStatement = database.prepare(`
+    SELECT
+      rowid AS "rowId",
+      ${optionalColumn(schema.mappingColumns, "page_url", "pageUrl")},
+      ${optionalColumn(schema.mappingColumns, "icon_id", "iconId")}
+    FROM icon_mapping
+    ORDER BY rowid
+  `);
+  const iconMappings: RawIconMapping[] = [];
+  for (const row of mappingStatement.iterate()) {
+    iconMappings.push({
+      rowId: normalizeValue(row.rowId),
+      pageUrl: normalizeValue(row.pageUrl),
+      iconId: normalizeValue(row.iconId),
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, bitmaps, favicons, iconMappings, integrity };
+}
+
+export async function readFaviconPasses(options: {
+  readonly database: VerifiedFaviconFile;
+  readonly sidecars: readonly VerifiedFaviconFile[];
+}): Promise<FaviconPasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-favicons-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: FaviconPass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: { ...fullRecoveryPass, commitState },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/favicons.ts
+++ b/core/src/favicons.ts
@@ -1,0 +1,660 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type {
+  FaviconArtifactWrite,
+  PersistedFaviconFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Provenance,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import {
+  readFaviconPasses,
+  type FaviconPass,
+  type RawFaviconBitmap,
+  type RawFaviconValue,
+  type VerifiedFaviconFile,
+} from "./favicons-sqlite.js";
+
+/**
+ * The Case-relative directory that holds icon payloads as separately hashed
+ * files. Payloads are content-addressed by their SHA-256, so identical bytes
+ * across bitmaps, Profiles, or Commit States are stored once and every Finding
+ * references the file by digest instead of inlining base64 into a row.
+ */
+export const FAVICON_PAYLOAD_DIRECTORY = "favicon-payloads";
+
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+// favicon_base::IconType values as persisted in `favicons.icon_type`.
+const ICON_TYPES = new Map<bigint, string>([
+  [0n, "invalid"],
+  [1n, "favicon"],
+  [2n, "touch_icon"],
+  [4n, "touch_precomposed_icon"],
+  [8n, "web_manifest_icon"],
+]);
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+interface PayloadFile {
+  readonly sha256: string;
+  readonly bytes: number;
+  readonly data: Uint8Array;
+}
+
+interface BuiltFavicon {
+  readonly signature: string;
+  readonly persisted: PersistedFaviconFinding;
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+/**
+ * Favicon `last_updated` / `last_requested` are `base::Time` internal values:
+ * microseconds since the 1601-01-01 UTC Windows epoch on every platform. The
+ * epoch is therefore fixed and needs no declared origin OS, unlike History.
+ */
+function faviconTimestamp(
+  raw: RawFaviconValue,
+  columnPresent: boolean,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (!columnPresent || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const utc = utcFromUnixMicros(raw - WINDOWS_EPOCH_OFFSET_MICROS);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: "1601-us",
+      utc,
+      declaredTimezone,
+      resolution: "chromium_base_time_internal_value",
+    },
+    { synthetic: false },
+  );
+}
+
+function preservedString(
+  value: RawFaviconValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(
+  value: RawFaviconValue,
+  columnPresent: boolean,
+): FieldState<string> {
+  if (!columnPresent || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function iconTypeField(value: RawFaviconValue): FieldState<string> {
+  if (value === null) {
+    return absentField();
+  }
+  if (typeof value !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const name = ICON_TYPES.get(value);
+  return name === undefined
+    ? unavailableField("unsupported_value")
+    : valueField(name);
+}
+
+/**
+ * Classify an icon payload into three distinct Field States:
+ * - a present, non-empty blob becomes a `value` referencing a hashed file;
+ * - a missing payload (absent column, NULL, or an empty blob Chromium stores to
+ *   record a known-absent icon) becomes `absent`;
+ * - a value that is not a blob (a read/representation failure) becomes
+ *   `unavailable`, so a corrupt payload is never confused with a missing one.
+ */
+function classifyPayload(
+  value: RawFaviconValue,
+  columnPresent: boolean,
+):
+  | { readonly state: "value"; readonly payload: PayloadFile }
+  | { readonly state: "absent" }
+  | {
+      readonly state: "unavailable";
+    } {
+  if (!columnPresent || value === null) {
+    return { state: "absent" };
+  }
+  if (!(value instanceof Uint8Array)) {
+    return { state: "unavailable" };
+  }
+  if (value.byteLength === 0) {
+    return { state: "absent" };
+  }
+  const sha256 = createHash("sha256").update(value).digest("hex");
+  return {
+    state: "value",
+    payload: { sha256, bytes: value.byteLength, data: value },
+  };
+}
+
+function bigintText(value: RawFaviconValue): string | null {
+  return typeof value === "bigint" ? value.toString() : null;
+}
+
+function faviconRecords(
+  pass: FaviconPass,
+): ReadonlyMap<
+  string,
+  { readonly url: RawFaviconValue; readonly iconType: RawFaviconValue }
+> {
+  return new Map(
+    pass.favicons.flatMap((record) => {
+      const id = bigintText(record.rowId);
+      return id === null
+        ? []
+        : [[id, { url: record.url, iconType: record.iconType }] as const];
+    }),
+  );
+}
+
+interface PageAssociation {
+  readonly pageUrl: string | null;
+  readonly rowId: string;
+}
+
+function iconMappingsByIcon(
+  pass: FaviconPass,
+): ReadonlyMap<string, readonly PageAssociation[]> {
+  const grouped = new Map<string, PageAssociation[]>();
+  for (const mapping of pass.iconMappings) {
+    const iconId = bigintText(mapping.iconId);
+    const rowId = bigintText(mapping.rowId);
+    if (iconId === null || rowId === null) {
+      continue;
+    }
+    const pageUrl =
+      typeof mapping.pageUrl === "string" ? mapping.pageUrl : null;
+    const list = grouped.get(iconId) ?? [];
+    list.push({ pageUrl, rowId });
+    grouped.set(iconId, list);
+  }
+  for (const list of grouped.values()) {
+    list.sort((left, right) =>
+      BigInt(left.rowId) < BigInt(right.rowId) ? -1 : 1,
+    );
+  }
+  return grouped;
+}
+
+function buildFavicons(options: {
+  readonly pass: FaviconPass;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+  readonly payloads: Map<string, PayloadFile>;
+}): BuiltFavicon[] {
+  const records = faviconRecords(options.pass);
+  const mappings = iconMappingsByIcon(options.pass);
+  return options.pass.bitmaps.map((bitmap: RawFaviconBitmap) => {
+    const bitmapId = bigintText(bitmap.rowId);
+    if (bitmapId === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Favicons favicon_bitmaps rowid is not an exact integer.",
+      );
+    }
+    const iconId = bigintText(bitmap.iconId);
+    const record = iconId === null ? undefined : records.get(iconId);
+    const associations = iconId === null ? [] : (mappings.get(iconId) ?? []);
+
+    const provenance: Provenance = {
+      manifestEntryId: `${options.manifest.sourceId}:${options.manifest.ordinal}`,
+      sourceId: options.manifest.sourceId,
+      manifestEntryOrdinal: options.manifest.ordinal,
+      manifestPath: options.manifest.path,
+      database: options.manifest.databasePath,
+      table: "favicon_bitmaps",
+      rowId: bitmapId,
+    };
+    const supportingRows: SourceRowProvenance[] = [];
+    if (iconId !== null && record !== undefined) {
+      supportingRows.push({ ...provenance, table: "favicons", rowId: iconId });
+    }
+    for (const association of associations) {
+      supportingRows.push({
+        ...provenance,
+        table: "icon_mapping",
+        rowId: association.rowId,
+      });
+    }
+    const fullProvenance: Provenance =
+      supportingRows.length === 0
+        ? provenance
+        : { ...provenance, supportingRows };
+
+    const payload = classifyPayload(
+      bitmap.imageData,
+      options.pass.schema.bitmapColumns.has("image_data"),
+    );
+    if (payload.state === "value") {
+      options.payloads.set(payload.payload.sha256, payload.payload);
+    }
+    const iconUrl = preservedString(record?.url ?? null, record !== undefined);
+    const iconType = iconTypeField(record?.iconType ?? null);
+    const lastUpdated = faviconTimestamp(
+      bitmap.lastUpdated,
+      options.pass.schema.bitmapColumns.has("last_updated"),
+      options.declaredTimezone,
+    );
+    const pageUrls = associations
+      .map((association) => association.pageUrl)
+      .filter((value): value is string => value !== null);
+
+    const fields = {
+      bitmapId: valueField(bitmapId),
+      iconId:
+        iconId === null
+          ? unavailableField("related_row_missing")
+          : valueField(iconId),
+      iconUrl:
+        record === undefined && iconId !== null
+          ? unavailableField("related_row_missing")
+          : iconUrl,
+      iconType:
+        record === undefined && iconId !== null
+          ? unavailableField("related_row_missing")
+          : iconType,
+      iconTypeRaw: preservedInteger(
+        record?.iconType ?? null,
+        record !== undefined,
+      ),
+      width: preservedInteger(
+        bitmap.width,
+        options.pass.schema.bitmapColumns.has("width"),
+      ),
+      height: preservedInteger(
+        bitmap.height,
+        options.pass.schema.bitmapColumns.has("height"),
+      ),
+      lastUpdated,
+      lastRequested: faviconTimestamp(
+        bitmap.lastRequested,
+        options.pass.schema.bitmapColumns.has("last_requested"),
+        options.declaredTimezone,
+      ),
+      payloadSha256:
+        payload.state === "value"
+          ? valueField(payload.payload.sha256)
+          : payload.state === "absent"
+            ? absentField()
+            : unavailableField("unsupported_value"),
+      payloadBytes:
+        payload.state === "value"
+          ? valueField(payload.payload.bytes.toString())
+          : payload.state === "absent"
+            ? absentField()
+            : unavailableField("unsupported_value"),
+      payloadPath:
+        payload.state === "value"
+          ? valueField(`${FAVICON_PAYLOAD_DIRECTORY}/${payload.payload.sha256}`)
+          : payload.state === "absent"
+            ? absentField()
+            : unavailableField("unsupported_value"),
+      pageUrls: valueField(pageUrls),
+      pageAssociationCount: valueField(associations.length.toString()),
+    };
+
+    const finding = createFinding({
+      findingKind: "favicon",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance: fullProvenance,
+      fields,
+    });
+
+    const iconUrlValue = iconUrl.state === "value" ? iconUrl.value : null;
+    const firstPageUrl =
+      pageUrls.length > 0 ? ([...pageUrls].sort()[0] ?? null) : null;
+    const widthKey = typeof bitmap.width === "bigint" ? bitmap.width : null;
+    const lastUpdatedUtc =
+      lastUpdated.state === "value" ? lastUpdated.value.utc : null;
+
+    const signature = JSON.stringify({
+      bitmapId,
+      iconId,
+      iconUrl: iconUrlValue,
+      iconType: record?.iconType?.toString() ?? null,
+      width: bigintText(bitmap.width),
+      height: bigintText(bitmap.height),
+      lastUpdated: bigintText(bitmap.lastUpdated),
+      lastRequested: bigintText(bitmap.lastRequested),
+      payload:
+        payload.state === "value" ? payload.payload.sha256 : payload.state,
+      pageUrls: [...pageUrls].sort(),
+    });
+
+    return {
+      signature,
+      persisted: {
+        finding,
+        searchText: [options.profile, iconUrlValue ?? "", ...pageUrls]
+          .join("\n")
+          .toLocaleLowerCase("en-US"),
+        sortIconUrl: iconUrlValue,
+        sortPageUrl: firstPageUrl,
+        sortLastUpdated: lastUpdatedUtc,
+        sortWidth: widthKey,
+      },
+    };
+  });
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): FaviconArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedFaviconCount: 0,
+    recoveredFaviconCount: 0,
+    payloadFileCount: 0,
+  };
+}
+
+async function writePayloads(
+  caseDirectory: string,
+  payloads: ReadonlyMap<string, PayloadFile>,
+): Promise<void> {
+  if (payloads.size === 0) {
+    return;
+  }
+  const directory = join(caseDirectory, FAVICON_PAYLOAD_DIRECTORY);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  for (const payload of payloads.values()) {
+    // Payload files are content-addressed by SHA-256, so an identical write is
+    // idempotent; a re-analysis rewrites byte-for-byte identical content.
+    await writeFile(join(directory, payload.sha256), payload.data, {
+      mode: 0o600,
+    });
+  }
+}
+
+async function analyseProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly caseDirectory: string;
+  readonly declaredTimezone: string;
+}): Promise<FaviconArtifactWrite> {
+  const databasePath =
+    options.profile === "." ? "Favicons" : `${options.profile}/Favicons`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      null,
+      "absent",
+      "favicons_absent",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "favicons_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `favicons_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "favicons_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "favicons_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedFaviconFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedFaviconFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readFaviconPasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Favicons recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const payloads = new Map<string, PayloadFile>();
+    const committed = buildFavicons({
+      pass: passes.committed,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      declaredTimezone: options.declaredTimezone,
+      payloads,
+    });
+    const committedSignatures = new Set(
+      committed.map((favicon) => favicon.signature),
+    );
+    // A recovered bitmap belongs to the sidecar Commit State only when the
+    // committed image has no byte-identical Finding for it: the signature folds
+    // in the payload digest and the sorted page-URL associations, so a sidecar
+    // that only adds an icon-to-page mapping still surfaces as a distinct
+    // sidecar-resident Finding while committed associations stay untouched.
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildFavicons({
+            pass: passes.recovered,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            declaredTimezone: options.declaredTimezone,
+            payloads,
+          }).filter((favicon) => !committedSignatures.has(favicon.signature));
+
+    await writePayloads(options.caseDirectory, payloads);
+
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [...committed, ...recovered].map(
+        (favicon) => favicon.persisted,
+      ),
+      committedFaviconCount: committed.length,
+      recoveredFaviconCount: recovered.length,
+      payloadFileCount: payloads.size,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `favicons_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}
+
+export interface FaviconsAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+  readonly caseDirectory: string;
+  readonly declaredTimezone: string;
+}
+
+export async function analyseSourceFavicons(
+  input: FaviconsAnalysisInput,
+): Promise<FaviconArtifactWrite[]> {
+  const artifacts: FaviconArtifactWrite[] = [];
+  for (const profile of input.source.profiles) {
+    artifacts.push(
+      await analyseProfile({
+        source: input.source,
+        profile: profile.path,
+        workingCopyPath: input.workingCopyPath,
+        caseDirectory: input.caseDirectory,
+        declaredTimezone: input.declaredTimezone,
+      }),
+    );
+  }
+  return artifacts;
+}

--- a/core/src/favicons.ts
+++ b/core/src/favicons.ts
@@ -188,6 +188,8 @@ function classifyPayload(
   };
 }
 
+type PayloadClassification = ReturnType<typeof classifyPayload>;
+
 function bigintText(value: RawFaviconValue): string | null {
   return typeof value === "bigint" ? value.toString() : null;
 }
@@ -198,14 +200,21 @@ function faviconRecords(
   string,
   { readonly url: RawFaviconValue; readonly iconType: RawFaviconValue }
 > {
-  return new Map(
-    pass.favicons.flatMap((record) => {
-      const id = bigintText(record.rowId);
-      return id === null
-        ? []
-        : [[id, { url: record.url, iconType: record.iconType }] as const];
-    }),
-  );
+  const records = new Map<
+    string,
+    { readonly url: RawFaviconValue; readonly iconType: RawFaviconValue }
+  >();
+  for (const record of pass.favicons) {
+    const id = bigintText(record.rowId);
+    if (id === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Favicons favicons.id is not an exact integer.",
+      );
+    }
+    records.set(id, { url: record.url, iconType: record.iconType });
+  }
+  return records;
 }
 
 interface PageAssociation {
@@ -218,9 +227,19 @@ function iconMappingsByIcon(
 ): ReadonlyMap<string, readonly PageAssociation[]> {
   const grouped = new Map<string, PageAssociation[]>();
   for (const mapping of pass.iconMappings) {
-    const iconId = bigintText(mapping.iconId);
     const rowId = bigintText(mapping.rowId);
-    if (iconId === null || rowId === null) {
+    if (rowId === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Favicons icon_mapping.id is not an exact integer.",
+      );
+    }
+    // icon_mapping.icon_id is a NOT NULL INTEGER foreign key. A non-integer
+    // value cannot attach the mapping to any icon, so it is left ungrouped
+    // rather than guessed; its own rowid corruption fails loud above, matching
+    // the favicon_bitmaps rowid guard.
+    const iconId = bigintText(mapping.iconId);
+    if (iconId === null) {
       continue;
     }
     const pageUrl =
@@ -256,34 +275,43 @@ interface BuildFaviconContext {
   readonly bitmapColumns: ReadonlySet<string>;
 }
 
-function buildFaviconFinding(
-  context: BuildFaviconContext,
-  row: FaviconRow,
-): BuiltFavicon {
-  const base = {
-    manifestEntryId: `${context.manifest.sourceId}:${context.manifest.ordinal}`,
-    sourceId: context.manifest.sourceId,
-    manifestEntryOrdinal: context.manifest.ordinal,
-    manifestPath: context.manifest.path,
-    database: context.manifest.databasePath,
-  };
-  // The Finding grain is one favicon_bitmaps row. An icon that has no cached
-  // bitmap yet -- a known favicon Chromium recorded on a page visit but never
-  // downloaded -- still yields one bitmap-less Finding so the icon URL and its
-  // page associations are never dropped. The primary row then falls back to the
-  // favicons row, or to the first icon_mapping row when even the favicons record
-  // is missing, so every favicons and icon_mapping row stays citable.
-  const primary: SourceRowProvenance =
-    row.bitmap !== null && row.bitmapId !== null
-      ? { ...base, table: "favicon_bitmaps", rowId: row.bitmapId }
-      : row.record !== undefined && row.iconId !== null
-        ? { ...base, table: "favicons", rowId: row.iconId }
-        : {
-            ...base,
-            table: "icon_mapping",
-            rowId: row.associations[0]?.rowId ?? "",
-          };
+type ProvenanceBase = Omit<SourceRowProvenance, "table" | "rowId">;
 
+function payloadField<T>(
+  payload: PayloadClassification,
+  project: (file: PayloadFile) => T,
+): FieldState<T> {
+  return payload.state === "value"
+    ? valueField(project(payload.payload))
+    : payload.state === "absent"
+      ? absentField()
+      : unavailableField("unsupported_value");
+}
+
+/**
+ * Resolve the citable primary row plus supporting rows for one Finding. The
+ * grain is a favicon_bitmaps row; a bitmap-less icon falls back to its favicons
+ * row, or to its first icon_mapping row when even the favicons record is
+ * missing, so every favicons and icon_mapping row stays citable. An icon with no
+ * bitmap, no record, and no mapping is unreachable by construction and fails
+ * loud rather than emitting an un-citable empty rowId.
+ */
+function faviconProvenance(base: ProvenanceBase, row: FaviconRow): Provenance {
+  let primary: SourceRowProvenance;
+  if (row.bitmap !== null && row.bitmapId !== null) {
+    primary = { ...base, table: "favicon_bitmaps", rowId: row.bitmapId };
+  } else if (row.record !== undefined && row.iconId !== null) {
+    primary = { ...base, table: "favicons", rowId: row.iconId };
+  } else {
+    const first = row.associations[0];
+    if (first === undefined) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "A bitmap-less favicon has no citable favicons or icon_mapping row.",
+      );
+    }
+    primary = { ...base, table: "icon_mapping", rowId: first.rowId };
+  }
   const supportingRows: SourceRowProvenance[] = [];
   if (
     row.record !== undefined &&
@@ -305,8 +333,44 @@ function buildFaviconFinding(
       rowId: association.rowId,
     });
   }
-  const fullProvenance: Provenance =
-    supportingRows.length === 0 ? primary : { ...primary, supportingRows };
+  return supportingRows.length === 0 ? primary : { ...primary, supportingRows };
+}
+
+function faviconSignature(input: {
+  readonly row: FaviconRow;
+  readonly payload: PayloadClassification;
+  readonly iconUrl: string | null;
+  readonly pageUrls: readonly string[];
+  readonly unreadablePageAssociationCount: number;
+}): string {
+  const { row, payload } = input;
+  return JSON.stringify({
+    bitmapId: row.bitmapId,
+    iconId: row.iconId,
+    iconUrl: input.iconUrl,
+    iconType: row.record?.iconType?.toString() ?? null,
+    width: bigintText(row.bitmap?.width ?? null),
+    height: bigintText(row.bitmap?.height ?? null),
+    lastUpdated: bigintText(row.bitmap?.lastUpdated ?? null),
+    lastRequested: bigintText(row.bitmap?.lastRequested ?? null),
+    payload: payload.state === "value" ? payload.payload.sha256 : payload.state,
+    pageUrls: [...input.pageUrls].sort(),
+    unreadablePageAssociationCount: input.unreadablePageAssociationCount,
+  });
+}
+
+function buildFaviconFinding(
+  context: BuildFaviconContext,
+  row: FaviconRow,
+): BuiltFavicon {
+  const base: ProvenanceBase = {
+    manifestEntryId: `${context.manifest.sourceId}:${context.manifest.ordinal}`,
+    sourceId: context.manifest.sourceId,
+    manifestEntryOrdinal: context.manifest.ordinal,
+    manifestPath: context.manifest.path,
+    database: context.manifest.databasePath,
+  };
+  const provenance = faviconProvenance(base, row);
 
   const payload = classifyPayload(
     row.bitmap?.imageData ?? null,
@@ -315,6 +379,11 @@ function buildFaviconFinding(
   if (payload.state === "value") {
     context.payloads.set(payload.payload.sha256, payload.payload);
   }
+
+  // A bitmap-less Finding has no bitmap columns to read, so every bitmap field
+  // reads as absent rather than fabricating a value.
+  const bitmapColumn = (name: string): boolean =>
+    row.bitmap !== null && context.bitmapColumns.has(name);
   const iconUrl = preservedString(
     row.record?.url ?? null,
     row.record !== undefined,
@@ -322,7 +391,7 @@ function buildFaviconFinding(
   const iconType = iconTypeField(row.record?.iconType ?? null);
   const lastUpdated = faviconTimestamp(
     row.bitmap?.lastUpdated ?? null,
-    row.bitmap !== null && context.bitmapColumns.has("last_updated"),
+    bitmapColumn("last_updated"),
     context.declaredTimezone,
   );
   const pageUrls = row.associations
@@ -351,38 +420,23 @@ function buildFaviconFinding(
       row.record?.iconType ?? null,
       row.record !== undefined,
     ),
-    width: preservedInteger(
-      row.bitmap?.width ?? null,
-      row.bitmap !== null && context.bitmapColumns.has("width"),
-    ),
+    width: preservedInteger(row.bitmap?.width ?? null, bitmapColumn("width")),
     height: preservedInteger(
       row.bitmap?.height ?? null,
-      row.bitmap !== null && context.bitmapColumns.has("height"),
+      bitmapColumn("height"),
     ),
     lastUpdated,
     lastRequested: faviconTimestamp(
       row.bitmap?.lastRequested ?? null,
-      row.bitmap !== null && context.bitmapColumns.has("last_requested"),
+      bitmapColumn("last_requested"),
       context.declaredTimezone,
     ),
-    payloadSha256:
-      payload.state === "value"
-        ? valueField(payload.payload.sha256)
-        : payload.state === "absent"
-          ? absentField()
-          : unavailableField("unsupported_value"),
-    payloadBytes:
-      payload.state === "value"
-        ? valueField(payload.payload.bytes.toString())
-        : payload.state === "absent"
-          ? absentField()
-          : unavailableField("unsupported_value"),
-    payloadPath:
-      payload.state === "value"
-        ? valueField(`${FAVICON_PAYLOAD_DIRECTORY}/${payload.payload.sha256}`)
-        : payload.state === "absent"
-          ? absentField()
-          : unavailableField("unsupported_value"),
+    payloadSha256: payloadField(payload, (file) => file.sha256),
+    payloadBytes: payloadField(payload, (file) => file.bytes.toString()),
+    payloadPath: payloadField(
+      payload,
+      (file) => `${FAVICON_PAYLOAD_DIRECTORY}/${file.sha256}`,
+    ),
     pageUrls: valueField(pageUrls),
     pageAssociationCount: valueField(pageUrls.length.toString()),
     unreadablePageAssociationCount: valueField(
@@ -394,7 +448,7 @@ function buildFaviconFinding(
     findingKind: "favicon",
     profile: context.profile,
     commitState: context.commitState,
-    provenance: fullProvenance,
+    provenance,
     fields,
   });
 
@@ -406,22 +460,14 @@ function buildFaviconFinding(
   const lastUpdatedUtc =
     lastUpdated.state === "value" ? lastUpdated.value.utc : null;
 
-  const signature = JSON.stringify({
-    bitmapId: row.bitmapId,
-    iconId: row.iconId,
-    iconUrl: iconUrlValue,
-    iconType: row.record?.iconType?.toString() ?? null,
-    width: bigintText(row.bitmap?.width ?? null),
-    height: bigintText(row.bitmap?.height ?? null),
-    lastUpdated: bigintText(row.bitmap?.lastUpdated ?? null),
-    lastRequested: bigintText(row.bitmap?.lastRequested ?? null),
-    payload: payload.state === "value" ? payload.payload.sha256 : payload.state,
-    pageUrls: [...pageUrls].sort(),
-    unreadablePageAssociationCount,
-  });
-
   return {
-    signature,
+    signature: faviconSignature({
+      row,
+      payload,
+      iconUrl: iconUrlValue,
+      pageUrls,
+      unreadablePageAssociationCount,
+    }),
     persisted: {
       finding,
       searchText: [context.profile, iconUrlValue ?? "", ...pageUrls]

--- a/core/src/favicons.ts
+++ b/core/src/favicons.ts
@@ -237,6 +237,204 @@ function iconMappingsByIcon(
   return grouped;
 }
 
+interface FaviconRow {
+  readonly bitmap: RawFaviconBitmap | null;
+  readonly bitmapId: string | null;
+  readonly iconId: string | null;
+  readonly record:
+    | { readonly url: RawFaviconValue; readonly iconType: RawFaviconValue }
+    | undefined;
+  readonly associations: readonly PageAssociation[];
+}
+
+interface BuildFaviconContext {
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+  readonly payloads: Map<string, PayloadFile>;
+  readonly bitmapColumns: ReadonlySet<string>;
+}
+
+function buildFaviconFinding(
+  context: BuildFaviconContext,
+  row: FaviconRow,
+): BuiltFavicon {
+  const base = {
+    manifestEntryId: `${context.manifest.sourceId}:${context.manifest.ordinal}`,
+    sourceId: context.manifest.sourceId,
+    manifestEntryOrdinal: context.manifest.ordinal,
+    manifestPath: context.manifest.path,
+    database: context.manifest.databasePath,
+  };
+  // The Finding grain is one favicon_bitmaps row. An icon that has no cached
+  // bitmap yet -- a known favicon Chromium recorded on a page visit but never
+  // downloaded -- still yields one bitmap-less Finding so the icon URL and its
+  // page associations are never dropped. The primary row then falls back to the
+  // favicons row, or to the first icon_mapping row when even the favicons record
+  // is missing, so every favicons and icon_mapping row stays citable.
+  const primary: SourceRowProvenance =
+    row.bitmap !== null && row.bitmapId !== null
+      ? { ...base, table: "favicon_bitmaps", rowId: row.bitmapId }
+      : row.record !== undefined && row.iconId !== null
+        ? { ...base, table: "favicons", rowId: row.iconId }
+        : {
+            ...base,
+            table: "icon_mapping",
+            rowId: row.associations[0]?.rowId ?? "",
+          };
+
+  const supportingRows: SourceRowProvenance[] = [];
+  if (
+    row.record !== undefined &&
+    row.iconId !== null &&
+    primary.table !== "favicons"
+  ) {
+    supportingRows.push({ ...base, table: "favicons", rowId: row.iconId });
+  }
+  for (const association of row.associations) {
+    if (
+      primary.table === "icon_mapping" &&
+      primary.rowId === association.rowId
+    ) {
+      continue;
+    }
+    supportingRows.push({
+      ...base,
+      table: "icon_mapping",
+      rowId: association.rowId,
+    });
+  }
+  const fullProvenance: Provenance =
+    supportingRows.length === 0 ? primary : { ...primary, supportingRows };
+
+  const payload = classifyPayload(
+    row.bitmap?.imageData ?? null,
+    row.bitmap !== null && context.bitmapColumns.has("image_data"),
+  );
+  if (payload.state === "value") {
+    context.payloads.set(payload.payload.sha256, payload.payload);
+  }
+  const iconUrl = preservedString(
+    row.record?.url ?? null,
+    row.record !== undefined,
+  );
+  const iconType = iconTypeField(row.record?.iconType ?? null);
+  const lastUpdated = faviconTimestamp(
+    row.bitmap?.lastUpdated ?? null,
+    row.bitmap !== null && context.bitmapColumns.has("last_updated"),
+    context.declaredTimezone,
+  );
+  const pageUrls = row.associations
+    .map((association) => association.pageUrl)
+    .filter((value): value is string => value !== null);
+  // page_url is NOT NULL text in Chromium, so a non-string mapping is a read
+  // failure. It is dropped from the URL list but counted separately, so the
+  // list and its count never silently diverge and the failure stays visible.
+  const unreadablePageAssociationCount =
+    row.associations.length - pageUrls.length;
+
+  const relatedRowMissing = row.record === undefined && row.iconId !== null;
+  const fields = {
+    bitmapId: row.bitmapId === null ? absentField() : valueField(row.bitmapId),
+    iconId:
+      row.iconId === null
+        ? unavailableField("related_row_missing")
+        : valueField(row.iconId),
+    iconUrl: relatedRowMissing
+      ? unavailableField("related_row_missing")
+      : iconUrl,
+    iconType: relatedRowMissing
+      ? unavailableField("related_row_missing")
+      : iconType,
+    iconTypeRaw: preservedInteger(
+      row.record?.iconType ?? null,
+      row.record !== undefined,
+    ),
+    width: preservedInteger(
+      row.bitmap?.width ?? null,
+      row.bitmap !== null && context.bitmapColumns.has("width"),
+    ),
+    height: preservedInteger(
+      row.bitmap?.height ?? null,
+      row.bitmap !== null && context.bitmapColumns.has("height"),
+    ),
+    lastUpdated,
+    lastRequested: faviconTimestamp(
+      row.bitmap?.lastRequested ?? null,
+      row.bitmap !== null && context.bitmapColumns.has("last_requested"),
+      context.declaredTimezone,
+    ),
+    payloadSha256:
+      payload.state === "value"
+        ? valueField(payload.payload.sha256)
+        : payload.state === "absent"
+          ? absentField()
+          : unavailableField("unsupported_value"),
+    payloadBytes:
+      payload.state === "value"
+        ? valueField(payload.payload.bytes.toString())
+        : payload.state === "absent"
+          ? absentField()
+          : unavailableField("unsupported_value"),
+    payloadPath:
+      payload.state === "value"
+        ? valueField(`${FAVICON_PAYLOAD_DIRECTORY}/${payload.payload.sha256}`)
+        : payload.state === "absent"
+          ? absentField()
+          : unavailableField("unsupported_value"),
+    pageUrls: valueField(pageUrls),
+    pageAssociationCount: valueField(pageUrls.length.toString()),
+    unreadablePageAssociationCount: valueField(
+      unreadablePageAssociationCount.toString(),
+    ),
+  };
+
+  const finding = createFinding({
+    findingKind: "favicon",
+    profile: context.profile,
+    commitState: context.commitState,
+    provenance: fullProvenance,
+    fields,
+  });
+
+  const iconUrlValue = iconUrl.state === "value" ? iconUrl.value : null;
+  const firstPageUrl =
+    pageUrls.length > 0 ? ([...pageUrls].sort()[0] ?? null) : null;
+  const widthKey =
+    typeof row.bitmap?.width === "bigint" ? row.bitmap.width : null;
+  const lastUpdatedUtc =
+    lastUpdated.state === "value" ? lastUpdated.value.utc : null;
+
+  const signature = JSON.stringify({
+    bitmapId: row.bitmapId,
+    iconId: row.iconId,
+    iconUrl: iconUrlValue,
+    iconType: row.record?.iconType?.toString() ?? null,
+    width: bigintText(row.bitmap?.width ?? null),
+    height: bigintText(row.bitmap?.height ?? null),
+    lastUpdated: bigintText(row.bitmap?.lastUpdated ?? null),
+    lastRequested: bigintText(row.bitmap?.lastRequested ?? null),
+    payload: payload.state === "value" ? payload.payload.sha256 : payload.state,
+    pageUrls: [...pageUrls].sort(),
+    unreadablePageAssociationCount,
+  });
+
+  return {
+    signature,
+    persisted: {
+      finding,
+      searchText: [context.profile, iconUrlValue ?? "", ...pageUrls]
+        .join("\n")
+        .toLocaleLowerCase("en-US"),
+      sortIconUrl: iconUrlValue,
+      sortPageUrl: firstPageUrl,
+      sortLastUpdated: lastUpdatedUtc,
+      sortWidth: widthKey,
+    },
+  };
+}
+
 function buildFavicons(options: {
   readonly pass: FaviconPass;
   readonly commitState: CommitState;
@@ -247,7 +445,17 @@ function buildFavicons(options: {
 }): BuiltFavicon[] {
   const records = faviconRecords(options.pass);
   const mappings = iconMappingsByIcon(options.pass);
-  return options.pass.bitmaps.map((bitmap: RawFaviconBitmap) => {
+  const context: BuildFaviconContext = {
+    commitState: options.commitState,
+    profile: options.profile,
+    manifest: options.manifest,
+    declaredTimezone: options.declaredTimezone,
+    payloads: options.payloads,
+    bitmapColumns: options.pass.schema.bitmapColumns,
+  };
+  const results: BuiltFavicon[] = [];
+  const bitmapIconIds = new Set<string>();
+  for (const bitmap of options.pass.bitmaps) {
     const bitmapId = bigintText(bitmap.rowId);
     if (bitmapId === null) {
       throw new ForensixError(
@@ -256,149 +464,50 @@ function buildFavicons(options: {
       );
     }
     const iconId = bigintText(bitmap.iconId);
-    const record = iconId === null ? undefined : records.get(iconId);
-    const associations = iconId === null ? [] : (mappings.get(iconId) ?? []);
-
-    const provenance: Provenance = {
-      manifestEntryId: `${options.manifest.sourceId}:${options.manifest.ordinal}`,
-      sourceId: options.manifest.sourceId,
-      manifestEntryOrdinal: options.manifest.ordinal,
-      manifestPath: options.manifest.path,
-      database: options.manifest.databasePath,
-      table: "favicon_bitmaps",
-      rowId: bitmapId,
-    };
-    const supportingRows: SourceRowProvenance[] = [];
-    if (iconId !== null && record !== undefined) {
-      supportingRows.push({ ...provenance, table: "favicons", rowId: iconId });
+    if (iconId !== null) {
+      bitmapIconIds.add(iconId);
     }
-    for (const association of associations) {
-      supportingRows.push({
-        ...provenance,
-        table: "icon_mapping",
-        rowId: association.rowId,
-      });
-    }
-    const fullProvenance: Provenance =
-      supportingRows.length === 0
-        ? provenance
-        : { ...provenance, supportingRows };
-
-    const payload = classifyPayload(
-      bitmap.imageData,
-      options.pass.schema.bitmapColumns.has("image_data"),
+    results.push(
+      buildFaviconFinding(context, {
+        bitmap,
+        bitmapId,
+        iconId,
+        record: iconId === null ? undefined : records.get(iconId),
+        associations: iconId === null ? [] : (mappings.get(iconId) ?? []),
+      }),
     );
-    if (payload.state === "value") {
-      options.payloads.set(payload.payload.sha256, payload.payload);
+  }
+
+  // Every favicons row and icon_mapping target with no covering bitmap still
+  // becomes one Finding, so a known icon URL or page association is never lost
+  // just because its payload was never cached.
+  const bitmaplessIconIds = new Set<string>();
+  for (const record of options.pass.favicons) {
+    const id = bigintText(record.rowId);
+    if (id !== null && !bitmapIconIds.has(id)) {
+      bitmaplessIconIds.add(id);
     }
-    const iconUrl = preservedString(record?.url ?? null, record !== undefined);
-    const iconType = iconTypeField(record?.iconType ?? null);
-    const lastUpdated = faviconTimestamp(
-      bitmap.lastUpdated,
-      options.pass.schema.bitmapColumns.has("last_updated"),
-      options.declaredTimezone,
+  }
+  for (const iconId of mappings.keys()) {
+    if (!bitmapIconIds.has(iconId)) {
+      bitmaplessIconIds.add(iconId);
+    }
+  }
+  const sortedBitmapless = [...bitmaplessIconIds].sort((left, right) =>
+    BigInt(left) < BigInt(right) ? -1 : 1,
+  );
+  for (const iconId of sortedBitmapless) {
+    results.push(
+      buildFaviconFinding(context, {
+        bitmap: null,
+        bitmapId: null,
+        iconId,
+        record: records.get(iconId),
+        associations: mappings.get(iconId) ?? [],
+      }),
     );
-    const pageUrls = associations
-      .map((association) => association.pageUrl)
-      .filter((value): value is string => value !== null);
-
-    const fields = {
-      bitmapId: valueField(bitmapId),
-      iconId:
-        iconId === null
-          ? unavailableField("related_row_missing")
-          : valueField(iconId),
-      iconUrl:
-        record === undefined && iconId !== null
-          ? unavailableField("related_row_missing")
-          : iconUrl,
-      iconType:
-        record === undefined && iconId !== null
-          ? unavailableField("related_row_missing")
-          : iconType,
-      iconTypeRaw: preservedInteger(
-        record?.iconType ?? null,
-        record !== undefined,
-      ),
-      width: preservedInteger(
-        bitmap.width,
-        options.pass.schema.bitmapColumns.has("width"),
-      ),
-      height: preservedInteger(
-        bitmap.height,
-        options.pass.schema.bitmapColumns.has("height"),
-      ),
-      lastUpdated,
-      lastRequested: faviconTimestamp(
-        bitmap.lastRequested,
-        options.pass.schema.bitmapColumns.has("last_requested"),
-        options.declaredTimezone,
-      ),
-      payloadSha256:
-        payload.state === "value"
-          ? valueField(payload.payload.sha256)
-          : payload.state === "absent"
-            ? absentField()
-            : unavailableField("unsupported_value"),
-      payloadBytes:
-        payload.state === "value"
-          ? valueField(payload.payload.bytes.toString())
-          : payload.state === "absent"
-            ? absentField()
-            : unavailableField("unsupported_value"),
-      payloadPath:
-        payload.state === "value"
-          ? valueField(`${FAVICON_PAYLOAD_DIRECTORY}/${payload.payload.sha256}`)
-          : payload.state === "absent"
-            ? absentField()
-            : unavailableField("unsupported_value"),
-      pageUrls: valueField(pageUrls),
-      pageAssociationCount: valueField(associations.length.toString()),
-    };
-
-    const finding = createFinding({
-      findingKind: "favicon",
-      profile: options.profile,
-      commitState: options.commitState,
-      provenance: fullProvenance,
-      fields,
-    });
-
-    const iconUrlValue = iconUrl.state === "value" ? iconUrl.value : null;
-    const firstPageUrl =
-      pageUrls.length > 0 ? ([...pageUrls].sort()[0] ?? null) : null;
-    const widthKey = typeof bitmap.width === "bigint" ? bitmap.width : null;
-    const lastUpdatedUtc =
-      lastUpdated.state === "value" ? lastUpdated.value.utc : null;
-
-    const signature = JSON.stringify({
-      bitmapId,
-      iconId,
-      iconUrl: iconUrlValue,
-      iconType: record?.iconType?.toString() ?? null,
-      width: bigintText(bitmap.width),
-      height: bigintText(bitmap.height),
-      lastUpdated: bigintText(bitmap.lastUpdated),
-      lastRequested: bigintText(bitmap.lastRequested),
-      payload:
-        payload.state === "value" ? payload.payload.sha256 : payload.state,
-      pageUrls: [...pageUrls].sort(),
-    });
-
-    return {
-      signature,
-      persisted: {
-        finding,
-        searchText: [options.profile, iconUrlValue ?? "", ...pageUrls]
-          .join("\n")
-          .toLocaleLowerCase("en-US"),
-        sortIconUrl: iconUrlValue,
-        sortPageUrl: firstPageUrl,
-        sortLastUpdated: lastUpdatedUtc,
-        sortWidth: widthKey,
-      },
-    };
-  });
+  }
+  return results;
 }
 
 function manifestIdentity(

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -5,6 +5,7 @@ import {
   type AnalysisRunExitState,
   type CookieArtifactWrite,
   type DeclaredOriginOs,
+  type FaviconArtifactWrite,
   type HistoryArtifactWrite,
   type LoginDataArtifactWrite,
   type MetadataArtifactWrite,
@@ -13,6 +14,7 @@ import {
   type WebDataArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceCookies } from "./cookies.js";
+import { analyseSourceFavicons } from "./favicons.js";
 import { analyseLoginDataProfile } from "./login-data.js";
 import { analyseSourcePreferences } from "./preferences.js";
 import { analyseSourceTopSites } from "./top-sites.js";
@@ -173,6 +175,19 @@ export interface WebDataAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface FaviconsAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly recoveryUnavailableProfileCount: number;
+  readonly committedFaviconCount: number;
+  readonly recoveredFaviconCount: number;
+  readonly payloadFileCount: number;
+  readonly findingCount: number;
+}
+
 export interface PreferencesAnalysisSummary {
   readonly status: "complete" | "partial";
   readonly artifactCount: number;
@@ -195,6 +210,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly loginData: LoginDataAnalysisSummary;
   readonly topSites: TopSitesAnalysisSummary;
   readonly webData: WebDataAnalysisSummary;
+  readonly favicons: FaviconsAnalysisSummary;
   readonly preferences: PreferencesAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
@@ -1256,6 +1272,7 @@ export async function analyseCase(
   const loginDataArtifacts: LoginDataArtifactWrite[] = [];
   const topSitesArtifacts: TopSitesArtifactWrite[] = [];
   const webDataArtifacts: WebDataArtifactWrite[] = [];
+  const faviconArtifacts: FaviconArtifactWrite[] = [];
   const metadataArtifacts: MetadataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
@@ -1302,6 +1319,14 @@ export async function analyseCase(
         workingCopyPath,
       })),
     );
+    faviconArtifacts.push(
+      ...(await analyseSourceFavicons({
+        source,
+        workingCopyPath,
+        caseDirectory,
+        declaredTimezone,
+      })),
+    );
     metadataArtifacts.push(
       ...(await analyseSourcePreferences({ source, workingCopyPath })),
     );
@@ -1320,6 +1345,7 @@ export async function analyseCase(
     loginDataArtifacts,
     topSitesArtifacts,
     webDataArtifacts,
+    faviconArtifacts,
     metadataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
@@ -1373,6 +1399,15 @@ export async function analyseCase(
   const webUnavailable = webDataArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const faviconsAnalysed = faviconArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const faviconsAbsent = faviconArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const faviconsUnavailable = faviconArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   const metadataAnalysed = metadataArtifacts.filter(
     (artifact) => artifact.status === "complete",
   );
@@ -1391,7 +1426,8 @@ export async function analyseCase(
       cookiesAnalysed.length +
       loginAnalysed.length +
       topSitesAnalysed.length +
-      webAnalysed.length,
+      webAnalysed.length +
+      faviconsAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
     cookies: {
@@ -1516,6 +1552,35 @@ export async function analyseCase(
         0,
       ),
       findingCount: webAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+    },
+    favicons: {
+      status: faviconsUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: faviconsAnalysed.length,
+      absentProfileCount: faviconsAbsent.length,
+      unavailableProfileCount: faviconsUnavailable.length,
+      recoveryUnavailableProfileCount: faviconsAnalysed.filter(
+        (artifact) => artifact.recoveryStatus === "unavailable",
+      ).length,
+      committedFaviconCount: faviconsAnalysed.reduce(
+        (count, artifact) => count + artifact.committedFaviconCount,
+        0,
+      ),
+      recoveredFaviconCount: faviconsAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredFaviconCount,
+        0,
+      ),
+      payloadFileCount: faviconsAnalysed.reduce(
+        (count, artifact) => count + artifact.payloadFileCount,
+        0,
+      ),
+      findingCount: faviconsAnalysed.reduce(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -95,6 +95,7 @@ export {
   type CookieAnalysisSummary,
   type DecryptionSummary,
   type EpochFamily,
+  type FaviconsAnalysisSummary,
   type ForensicTimestamp,
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
@@ -191,6 +192,13 @@ export {
   type AutofillQuery,
   type AutofillSort,
 } from "./web-data-query.js";
+export {
+  queryFavicons,
+  type FaviconDirection,
+  type FaviconPage,
+  type FaviconQuery,
+  type FaviconSort,
+} from "./favicons-query.js";
 export {
   queryMetadata,
   type MetadataDirection,

--- a/e2e/favicons-cli.test.ts
+++ b/e2e/favicons-cli.test.ts
@@ -52,6 +52,7 @@ interface FaviconFinding {
     readonly payloadPath: Field<string>;
     readonly pageUrls: Field<readonly string[]>;
     readonly pageAssociationCount: Field<string>;
+    readonly unreadablePageAssociationCount: Field<string>;
   };
 }
 
@@ -383,6 +384,82 @@ describe("compiled analyzer CLI Favicons metadata", () => {
     expect(await readFile(join(source, "Default", "Favicons"))).toEqual(
       defaultBytes,
     );
+  });
+
+  it("keeps bitmap-less icons and their page associations as Findings", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-favicons-nobitmap-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const micros = 13_000_000_000_000_000n;
+
+    // One icon WITH a cached bitmap, and one known favicon that Chromium
+    // recorded on a page visit but never downloaded: a favicons row and its
+    // icon_mapping with no favicon_bitmaps row. Neither the icon URL nor its
+    // page association may be dropped.
+    const path = join(source, "Default", "Favicons");
+    await createFavicons(path, [
+      {
+        iconUrl: "https://cached.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: new Uint8Array([0x01, 0x02]),
+        lastUpdatedMicros: micros,
+        pageUrls: ["https://cached.example/"],
+      },
+    ]);
+    const writer = new DatabaseSync(path);
+    try {
+      const iconId = writer
+        .prepare("INSERT INTO favicons (url, icon_type) VALUES (?, 1)")
+        .run("https://known.example/favicon.ico").lastInsertRowid as number;
+      writer
+        .prepare("INSERT INTO icon_mapping (page_url, icon_id) VALUES (?, ?)")
+        .run("https://known.example/", iconId);
+    } finally {
+      writer.close();
+    }
+
+    const caseDirectory = join(root, "CASE-FAVICONS-NOBITMAP");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    const rows = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "icon-url",
+        "--json",
+      ]).stdout,
+    );
+    expect(rows.items).toHaveLength(2);
+    const known = rows.items.find(
+      (item) =>
+        item.fields.iconUrl.state === "value" &&
+        item.fields.iconUrl.value === "https://known.example/favicon.ico",
+    );
+    expect(known).toBeDefined();
+    // The bitmap-less Finding keeps the icon URL and its page association, cites
+    // the favicons row as Provenance, and reports no cached payload.
+    expect(known).toMatchObject({
+      commitState: "committed",
+      provenance: { table: "favicons", database: "Default/Favicons" },
+      fields: {
+        bitmapId: { state: "absent" },
+        payloadSha256: { state: "absent" },
+        payloadPath: { state: "absent" },
+        pageUrls: { state: "value", value: ["https://known.example/"] },
+        pageAssociationCount: { state: "value", value: "1" },
+      },
+    });
   });
 
   it("distinguishes a missing payload from an unreadable payload value", async () => {

--- a/e2e/favicons-cli.test.ts
+++ b/e2e/favicons-cli.test.ts
@@ -1,0 +1,620 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface FaviconFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "favicon";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+    readonly supportingRows?: readonly {
+      readonly table: string;
+      readonly rowId: string;
+    }[];
+  };
+  readonly fields: {
+    readonly bitmapId: Field<string>;
+    readonly iconId: Field<string>;
+    readonly iconUrl: Field<string>;
+    readonly iconType: Field<string>;
+    readonly iconTypeRaw: Field<string>;
+    readonly width: Field<string>;
+    readonly height: Field<string>;
+    readonly lastUpdated: Field<{ readonly raw: string; readonly utc: string }>;
+    readonly lastRequested: Field<unknown>;
+    readonly payloadSha256: Field<string>;
+    readonly payloadBytes: Field<string>;
+    readonly payloadPath: Field<string>;
+    readonly pageUrls: Field<readonly string[]>;
+    readonly pageAssociationCount: Field<string>;
+  };
+}
+
+interface FaviconPage {
+  readonly status: "ok";
+  readonly command: "favicons";
+  readonly items: readonly FaviconFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+interface IconInput {
+  readonly iconUrl: string;
+  readonly iconType: number;
+  readonly width: number;
+  readonly height: number;
+  readonly imageData: Uint8Array | null;
+  readonly lastUpdatedMicros: bigint;
+  readonly pageUrls: readonly string[];
+}
+
+/**
+ * Build a Favicons database faithful to the current Chromium schema
+ * (version 8): `favicons` (icon URL + type), `favicon_bitmaps` (payload blob at
+ * one pixel size, `last_updated`/`last_requested` as base::Time internal
+ * values), and `icon_mapping` (page URL to icon association), plus a
+ * self-describing `meta.version`.
+ */
+async function createFavicons(
+  path: string,
+  icons: readonly IconInput[],
+  version = 8,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '${version}'), ('last_compatible_version', '1');
+
+      CREATE TABLE favicons (
+        id INTEGER PRIMARY KEY,
+        url LONGVARCHAR NOT NULL,
+        icon_type INTEGER DEFAULT 0
+      );
+      CREATE TABLE favicon_bitmaps (
+        id INTEGER PRIMARY KEY,
+        icon_id INTEGER NOT NULL,
+        last_updated INTEGER DEFAULT 0,
+        image_data BLOB,
+        width INTEGER DEFAULT 0,
+        height INTEGER DEFAULT 0,
+        last_requested INTEGER DEFAULT 0
+      );
+      CREATE TABLE icon_mapping (
+        id INTEGER PRIMARY KEY,
+        page_url LONGVARCHAR NOT NULL,
+        icon_id INTEGER NOT NULL
+      );
+    `);
+    const insertIcon = database.prepare(
+      "INSERT INTO favicons (url, icon_type) VALUES (?, ?)",
+    );
+    const insertBitmap = database.prepare(
+      "INSERT INTO favicon_bitmaps (icon_id, last_updated, image_data, width, height, last_requested) VALUES (?, ?, ?, ?, ?, ?)",
+    );
+    const insertMapping = database.prepare(
+      "INSERT INTO icon_mapping (page_url, icon_id) VALUES (?, ?)",
+    );
+    for (const icon of icons) {
+      const iconId = insertIcon.run(icon.iconUrl, icon.iconType)
+        .lastInsertRowid as number;
+      insertBitmap.run(
+        iconId,
+        icon.lastUpdatedMicros,
+        icon.imageData,
+        icon.width,
+        icon.height,
+        icon.lastUpdatedMicros,
+      );
+      for (const pageUrl of icon.pageUrls) {
+        insertMapping.run(pageUrl, iconId);
+      }
+    }
+  } finally {
+    database.close();
+  }
+}
+
+/** A valid SQLite file that is not a supported Favicons store. */
+async function createUnsupportedFavicons(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '8');
+      CREATE TABLE not_favicons (url LONGVARCHAR);
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Favicons metadata", () => {
+  it("parses Favicons across Profiles with payloads as hashed files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-favicons-e2e-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+
+    const alphaPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x01, 0x02]);
+    const bravoPng = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0a, 0x0b, 0x0c]);
+    const alphaSha = createHash("sha256").update(alphaPng).digest("hex");
+    // 2021-01-01T00:00:00Z in base::Time internal microseconds since 1601.
+    const alphaMicros =
+      BigInt(Date.UTC(2021, 0, 1)) * 1000n + WINDOWS_EPOCH_OFFSET_MICROS;
+    await createFavicons(join(source, "Default", "Favicons"), [
+      {
+        iconUrl: "https://alpha.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: alphaPng,
+        lastUpdatedMicros: alphaMicros,
+        pageUrls: ["https://alpha.example/", "https://alpha.example/about"],
+      },
+      {
+        iconUrl: "https://bravo.example/touch.png",
+        iconType: 2,
+        width: 32,
+        height: 32,
+        imageData: bravoPng,
+        lastUpdatedMicros: alphaMicros,
+        pageUrls: ["https://bravo.example/"],
+      },
+    ]);
+    await createFavicons(join(source, "Profile 1", "Favicons"), [
+      {
+        iconUrl: "https://delta.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: new Uint8Array([0x11, 0x22, 0x33]),
+        lastUpdatedMicros: alphaMicros,
+        pageUrls: ["https://delta.example/"],
+      },
+    ]);
+    const defaultBytes = await readFile(join(source, "Default", "Favicons"));
+    const caseDirectory = join(root, "CASE-FAVICONS");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      favicons: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        absentProfileCount: 0,
+        unavailableProfileCount: 0,
+        committedFaviconCount: 3,
+        recoveredFaviconCount: 0,
+        payloadFileCount: 3,
+      },
+    });
+
+    // AC3: each payload is a separately hashed file named by its SHA-256, and
+    // the row references it by digest and path rather than inlining base64.
+    const payloadOnDisk = await readFile(
+      join(caseDirectory, "favicon-payloads", alphaSha),
+    );
+    expect(new Uint8Array(payloadOnDisk)).toEqual(alphaPng);
+
+    // AC5: bounded, multi-Profile keyset pagination ordered by icon URL.
+    const firstPage = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "icon-url",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage).toMatchObject({ command: "favicons", limit: 2 });
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const [first] = firstPage.items;
+    expect(first).toBeDefined();
+    // AC1 + AC2: icon metadata and page URLs exact against ground truth with
+    // Field State, resolvable Provenance, and Commit State.
+    expect(first).toMatchObject({
+      recordType: "finding",
+      findingKind: "favicon",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Favicons",
+        database: "Default/Favicons",
+        table: "favicon_bitmaps",
+        rowId: "1",
+      },
+      fields: {
+        iconUrl: {
+          state: "value",
+          value: "https://alpha.example/favicon.ico",
+        },
+        iconType: { state: "value", value: "favicon" },
+        width: { state: "value", value: "16" },
+        payloadSha256: { state: "value", value: alphaSha },
+        payloadPath: {
+          state: "value",
+          value: `favicon-payloads/${alphaSha}`,
+        },
+        payloadBytes: { state: "value", value: String(alphaPng.byteLength) },
+        pageAssociationCount: { state: "value", value: "2" },
+      },
+    });
+    // AC1: every associated page URL is traced from the one payload Finding.
+    expect(first?.fields.pageUrls).toEqual({
+      state: "value",
+      value: ["https://alpha.example/", "https://alpha.example/about"],
+    });
+    // AC2: the icon and mapping rows are cited as supporting Provenance.
+    const supportingTables = (first?.provenance.supportingRows ?? []).map(
+      (row) => row.table,
+    );
+    expect(supportingTables).toContain("favicons");
+    expect(supportingTables).toContain("icon_mapping");
+    // AC2: base::Time internal value decoded to an exact UTC instant.
+    expect(first?.fields.lastUpdated).toMatchObject({
+      state: "value",
+      value: { utc: "2021-01-01T00:00:00.000000Z" },
+    });
+
+    const secondPage = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "icon-url",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const allIconUrls = [...firstPage.items, ...secondPage.items].map(
+      (item) =>
+        item.fields.iconUrl.state === "value" && item.fields.iconUrl.value,
+    );
+    expect(new Set(allIconUrls).size).toBe(3);
+    expect(
+      [...firstPage.items, ...secondPage.items].map((item) => item.profile),
+    ).toContain("Profile 1");
+
+    // AC5: search matches icon URL and page URLs.
+    const searched = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--search",
+        "delta",
+        "--json",
+      ]).stdout,
+    );
+    expect(searched.items).toHaveLength(1);
+    expect(searched.items[0]?.profile).toBe("Profile 1");
+
+    // AC5: multi-Profile selection filter.
+    const filtered = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Default",
+        "--json",
+      ]).stdout,
+    );
+    expect(filtered.items).toHaveLength(2);
+    expect(filtered.items.every((item) => item.profile === "Default")).toBe(
+      true,
+    );
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(source, "Default", "Favicons"))).toEqual(
+      defaultBytes,
+    );
+  });
+
+  it("distinguishes a missing payload from an unreadable payload value", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-favicons-payload-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const micros = 13_000_000_000_000_000n;
+
+    const path = join(source, "Default", "Favicons");
+    await createFavicons(path, [
+      {
+        iconUrl: "https://missing.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: null,
+        lastUpdatedMicros: micros,
+        pageUrls: ["https://missing.example/"],
+      },
+    ]);
+    // A second icon whose image_data column holds a non-blob value: a
+    // representation/read failure, distinct from a NULL missing payload.
+    const writer = new DatabaseSync(path);
+    try {
+      const iconId = writer
+        .prepare("INSERT INTO favicons (url, icon_type) VALUES (?, 1)")
+        .run("https://corrupt.example/favicon.ico").lastInsertRowid as number;
+      writer
+        .prepare(
+          "INSERT INTO favicon_bitmaps (icon_id, last_updated, image_data, width, height, last_requested) VALUES (?, ?, ?, 16, 16, ?)",
+        )
+        .run(iconId, micros, "not-a-blob", micros);
+      writer
+        .prepare("INSERT INTO icon_mapping (page_url, icon_id) VALUES (?, ?)")
+        .run("https://corrupt.example/", iconId);
+    } finally {
+      writer.close();
+    }
+
+    const caseDirectory = join(root, "CASE-FAVICONS-PAYLOAD");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+
+    const rows = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "icon-url",
+        "--json",
+      ]).stdout,
+    );
+    expect(rows.items).toHaveLength(2);
+    const [corrupt, missing] = rows.items;
+    // Missing payload: NULL image_data is an absent Field State.
+    expect(missing?.fields).toMatchObject({
+      iconUrl: { state: "value", value: "https://missing.example/favicon.ico" },
+      payloadSha256: { state: "absent" },
+      payloadPath: { state: "absent" },
+    });
+    // Read failure: a non-blob value is an unavailable Field State, never
+    // confused with a missing payload.
+    expect(corrupt?.fields.payloadSha256).toMatchObject({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    expect(corrupt?.fields.payloadPath).toMatchObject({
+      state: "unavailable",
+    });
+  });
+
+  it("keeps committed and WAL-resident associations separate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-favicons-wal-"));
+    temporaryRoots.push(root);
+    const source = join(root, "wal-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const micros = 13_000_000_000_000_000n;
+    const committedIcon = new Uint8Array([0x01, 0x02, 0x03]);
+    const walIcon = new Uint8Array([0x04, 0x05, 0x06, 0x07]);
+    const faviconsPath = join(source, "Default", "Favicons");
+    await createFavicons(faviconsPath, [
+      {
+        iconUrl: "https://committed.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: committedIcon,
+        lastUpdatedMicros: micros,
+        pageUrls: ["https://committed.example/"],
+      },
+    ]);
+
+    const writer = new DatabaseSync(faviconsPath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    const walIconId = writer
+      .prepare("INSERT INTO favicons (url, icon_type) VALUES (?, 1)")
+      .run("https://wal.example/favicon.ico").lastInsertRowid as number;
+    writer
+      .prepare(
+        "INSERT INTO favicon_bitmaps (icon_id, last_updated, image_data, width, height, last_requested) VALUES (?, ?, ?, 16, 16, ?)",
+      )
+      .run(walIconId, micros, walIcon, micros);
+    writer
+      .prepare("INSERT INTO icon_mapping (page_url, icon_id) VALUES (?, ?)")
+      .run("https://wal.example/", walIconId);
+
+    const caseDirectory = join(root, "CASE-FAVICONS-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      favicons: { committedFaviconCount: 1, recoveredFaviconCount: 1 },
+    });
+
+    // AC4: committed rows only.
+    const committed = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/Favicons" },
+      fields: {
+        iconUrl: {
+          state: "value",
+          value: "https://committed.example/favicon.ico",
+        },
+      },
+    });
+
+    // AC4: sidecar (WAL-resident) associations carry the explicit Commit State
+    // and the sidecar Manifest Provenance.
+    const recovered = parseJson<FaviconPage>(
+      runCli([
+        "favicons",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/Favicons-wal",
+        database: "Default/Favicons",
+        table: "favicon_bitmaps",
+      },
+      fields: {
+        iconUrl: { state: "value", value: "https://wal.example/favicon.ico" },
+        pageUrls: { state: "value", value: ["https://wal.example/"] },
+      },
+    });
+  });
+
+  it("distinguishes missing Favicons from an unreadable database", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-favicons-gap-"));
+    temporaryRoots.push(root);
+    const source = join(root, "gap-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const micros = 13_000_000_000_000_000n;
+    // Default: a defensible Favicons store.
+    await createFavicons(join(source, "Default", "Favicons"), [
+      {
+        iconUrl: "https://alpha.example/favicon.ico",
+        iconType: 1,
+        width: 16,
+        height: 16,
+        imageData: new Uint8Array([0x01]),
+        lastUpdatedMicros: micros,
+        pageUrls: ["https://alpha.example/"],
+      },
+    ]);
+    // Profile 1: no Favicons file at all — absent (missing), not unavailable.
+    await mkdir(join(source, "Profile 1"), { recursive: true });
+    await writeFile(join(source, "Profile 1", "Login Data"), "not-a-db");
+    // Profile 2: a valid SQLite database but no favicon tables — unavailable.
+    await createUnsupportedFavicons(join(source, "Profile 2", "Favicons"));
+
+    const caseDirectory = join(root, "CASE-FAVICONS-GAP");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // AC5: an unavailable artifact makes the run partial (exit code 2), while
+    // produced and absent artifacts stay distinct in the summary counts.
+    expect(analysis.status).toBe(2);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      exitState: "partial",
+      favicons: {
+        status: "partial",
+        profileCount: 3,
+        analysedProfileCount: 1,
+        absentProfileCount: 1,
+        unavailableProfileCount: 1,
+        committedFaviconCount: 1,
+      },
+    });
+
+    const rows = parseJson<FaviconPage>(
+      runCli(["favicons", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(rows.items).toHaveLength(1);
+    expect(rows.items[0]?.profile).toBe("Default");
+  });
+});


### PR DESCRIPTION
Closes #181.

Traces each supported Favicon payload to every associated page URL without inflating Case or Extract rows, mirroring the established Findings contract (History/Cookies/Top Sites).

## Acceptance criteria → implementation

- **Current Favicons schemas parsed across all Profiles, including every supported icon-to-page association.**
  `core/src/favicons-sqlite.ts` reads schema versions 7 and 8 (`favicons`, `favicon_bitmaps`, `icon_mapping`, `meta.version`); `last_requested` (v7+) is read when present, absent otherwise. The Finding grain is one `favicon_bitmaps` row joined to its `favicons` record and **all** `icon_mapping` page URLs (listed as an array), so a payload maps to every page without an N×M row explosion. Per-Profile via `analyseSourceFavicons`.

- **Icon metadata and page URLs exact vs ground truth with Field State / Provenance / Commit State.**
  `iconUrl`, `iconType` (decoded + raw), `width`, `height`, `lastUpdated`/`lastRequested` (base::Time internal microseconds → exact UTC, `1601-us`), and `pageUrls` are preserved with `value`/`absent`/`unavailable` states. Provenance cites the `favicon_bitmaps` row plus supporting `favicons` and `icon_mapping` rows. Commit State recorded per Finding.

- **Binary icon payloads written as separately hashed files, not base64 in rows.**
  Payloads are content-addressed and written to `favicon-payloads/<sha256>` under the Case directory (deduplicated, idempotent). Rows carry `payloadSha256`, `payloadBytes`, and `payloadPath` — never the bytes.

- **Committed vs sidecar associations separate.**
  A recovery signature folds in the payload digest and the sorted page-URL set, so a WAL/journal that only adds an icon-to-page mapping surfaces as a distinct sidecar-resident Finding while committed associations stay untouched.

- **Missing payloads vs read failures distinct; bounded multi-Profile query surface.**
  Missing payload (NULL/empty/absent column) → `absent`; non-blob value (read/representation failure) → `unavailable("unsupported_value")`. `core/src/favicons-query.ts` adds the `favicons` command: search, `--profile` filters, `--commit-state`, sort (`icon-url|page-url|last-updated|width|profile`), and keyset pagination with typed `INVALID_CURSOR` guards. Artifact-level absent vs unavailable drives the partial (exit 2) run state.

## Tests

`e2e/favicons-cli.test.ts` (compiled CLI, 4 cases): multi-Profile parse with hashed payload files on disk + exact metadata/page URLs/Provenance/UTC; missing-vs-unreadable payload; committed vs WAL-resident associations; absent-vs-unavailable database gap.

`pnpm verify` green (format, lint, typecheck, 110 tests). No changes to Analyzer output for existing artifacts.