### PR TITLE
feat(downloads): parse Downloads with decoded forensic meaning

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -12,6 +12,7 @@ import {
   queryAutofill,
   queryCookies,
   queryCredentials,
+  queryDownloads,
   queryFavicons,
   queryHistory,
   queryMetadata,
@@ -24,6 +25,8 @@ import {
   type CookieSort,
   type CredentialDirection,
   type CredentialSort,
+  type DownloadDirection,
+  type DownloadSort,
   type FaviconDirection,
   type FaviconSort,
   type TopSiteDirection,
@@ -83,6 +86,14 @@ const USAGE = `Usage:
                    [--sort <icon-url|page-url|last-updated|width|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
+  forensix downloads --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--state <in_progress|complete|cancelled|interrupted>]
+                   [--danger <danger-type>]
+                   [--sort <start-time|end-time|target-path|state|total-bytes|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
   forensix metadata --case <case-directory>
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
@@ -137,6 +148,8 @@ const VALUE_OPTIONS = new Set([
   "--to",
   "--host",
   "--same-site",
+  "--state",
+  "--danger",
   "--type",
   "--sort",
   "--direction",
@@ -748,6 +761,58 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as AutofillSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | AutofillDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "downloads") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--state",
+        "--danger",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The downloads command accepts no positional values.",
+      );
+    }
+    const result = queryDownloads({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      state: optionValue(parsed, "--state"),
+      dangerType: optionValue(parsed, "--danger"),
+      sort: enumOption(parsed, "--sort", [
+        "start-time",
+        "end-time",
+        "target-path",
+        "state",
+        "total-bytes",
+        "profile",
+      ] as const) as DownloadSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | DownloadDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -89,6 +89,32 @@ export interface WebDataArtifactWrite {
   readonly recoveredFieldCount: number;
 }
 
+export interface PersistedDownloadFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sortStart: string | null;
+  readonly sortEnd: string | null;
+  readonly sortTargetPath: string | null;
+  readonly sortState: string | null;
+  readonly sortTotalBytes: bigint | null;
+  readonly dangerType: string | null;
+}
+
+export interface DownloadsArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly schemaVersion: number | null;
+  readonly integrity: string | null;
+  readonly recoveryStatus: "complete" | "unavailable" | "not_applicable";
+  readonly reason: string | null;
+  readonly findings: readonly PersistedDownloadFinding[];
+  readonly committedDownloadCount: number;
+  readonly recoveredDownloadCount: number;
+}
+
 export interface PersistedCookieFinding {
   readonly finding: Finding;
   readonly searchText: string;
@@ -201,6 +227,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly topSitesArtifacts?: readonly TopSitesArtifactWrite[];
   readonly webDataArtifacts?: readonly WebDataArtifactWrite[];
   readonly faviconArtifacts?: readonly FaviconArtifactWrite[];
+  readonly downloadsArtifacts?: readonly DownloadsArtifactWrite[];
   readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
 }
 
@@ -437,6 +464,70 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON web_data_findings(finding_kind, COALESCE(sort_value, ''), finding_id);
     CREATE INDEX IF NOT EXISTS web_data_findings_profile_query
       ON web_data_findings(finding_kind, profile_path, finding_id);
+
+    CREATE TABLE IF NOT EXISTS downloads_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Downloads'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      schema_version INTEGER,
+      integrity TEXT,
+      recovery_status TEXT NOT NULL CHECK (
+        recovery_status IN ('complete', 'unavailable', 'not_applicable')
+      ),
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS downloads_one_active_result
+      ON downloads_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS downloads_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES downloads_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_start TEXT,
+      sort_end TEXT,
+      sort_target TEXT,
+      sort_state TEXT,
+      sort_bytes INTEGER,
+      danger_type TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS downloads_findings_start_query
+      ON downloads_findings(finding_kind, COALESCE(sort_start, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS downloads_findings_end_query
+      ON downloads_findings(finding_kind, COALESCE(sort_end, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS downloads_findings_target_query
+      ON downloads_findings(finding_kind, COALESCE(sort_target, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS downloads_findings_state_query
+      ON downloads_findings(finding_kind, COALESCE(sort_state, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS downloads_findings_bytes_query
+      ON downloads_findings(finding_kind, COALESCE(sort_bytes, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS downloads_findings_profile_query
+      ON downloads_findings(finding_kind, profile_path, commit_state, finding_id);
 
     CREATE TABLE IF NOT EXISTS cookie_artifact_results (
       artifact_result_id INTEGER PRIMARY KEY,
@@ -770,6 +861,34 @@ function insertAutofillFinding(
   );
 }
 
+function insertDownloadFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedDownloadFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortStart,
+    row.sortEnd,
+    row.sortTargetPath,
+    row.sortState,
+    row.sortTotalBytes,
+    row.dangerType,
+  );
+}
+
 function insertCookieFinding(
   statement: ReturnType<DatabaseSync["prepare"]>,
   artifactResultId: bigint,
@@ -988,6 +1107,30 @@ export function storeHistoryAnalysis(
       );
       const activateCurrentWebData = database.prepare(
         "UPDATE web_data_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
+      const insertDownloadsArtifact = database.prepare(
+        `INSERT INTO downloads_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, schema_version, integrity, recovery_status,
+            status, reason, active)
+         VALUES (?, ?, ?, 'Downloads', ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertDownloadFindingStatement = database.prepare(
+        `INSERT INTO downloads_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, sort_start, sort_end,
+            sort_target, sort_state, sort_bytes, danger_type)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousDownloads = database.prepare(
+        `UPDATE downloads_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Downloads'
+            AND active = 1`,
+      );
+      const activateCurrentDownloads = database.prepare(
+        "UPDATE downloads_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
       const insertCookieArtifact = database.prepare(
         `INSERT INTO cookie_artifact_results
@@ -1260,6 +1403,34 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of options.downloadsArtifacts ?? []) {
+        const insertion = insertDownloadsArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.schemaVersion,
+          artifact.integrity,
+          artifact.recoveryStatus,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertDownloadFinding(
+            insertDownloadFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousDownloads.run(artifact.sourceId, artifact.profile);
+          activateCurrentDownloads.run(artifactResultId);
+        }
+      }
+
       for (const artifact of metadataArtifacts) {
         const insertion = insertMetadataArtifact.run(
           runId,
@@ -1302,6 +1473,7 @@ export function storeHistoryAnalysis(
         ...(options.topSitesArtifacts ?? []),
         ...(options.webDataArtifacts ?? []),
         ...(options.faviconArtifacts ?? []),
+        ...(options.downloadsArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",

--- a/core/src/downloads-query.ts
+++ b/core/src/downloads-query.ts
@@ -1,0 +1,402 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type DownloadSort =
+  | "start-time"
+  | "end-time"
+  | "target-path"
+  | "state"
+  | "total-bytes"
+  | "profile";
+export type DownloadDirection = "asc" | "desc";
+
+export interface DownloadQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly state?: string;
+  readonly dangerType?: string;
+  readonly sort?: DownloadSort;
+  readonly direction?: DownloadDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface DownloadPage {
+  readonly status: "ok";
+  readonly command: "downloads";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+const DOWNLOAD_SORTS = [
+  "start-time",
+  "end-time",
+  "target-path",
+  "state",
+  "total-bytes",
+  "profile",
+] as const;
+const DOWNLOAD_DIRECTIONS = ["asc", "desc"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const DOWNLOAD_KIND = "download";
+
+const SORTS: Readonly<Record<DownloadSort, SortDefinition>> = {
+  "start-time": { expression: "COALESCE(f.sort_start, '')", kind: "text" },
+  "end-time": { expression: "COALESCE(f.sort_end, '')", kind: "text" },
+  "target-path": { expression: "COALESCE(f.sort_target, '')", kind: "text" },
+  state: { expression: "COALESCE(f.sort_state, '')", kind: "text" },
+  "total-bytes": { expression: "COALESCE(f.sort_bytes, -1)", kind: "integer" },
+  profile: { expression: "f.profile_path", kind: "text" },
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly state: string | null;
+  readonly dangerType: string | null;
+  readonly sort: DownloadSort;
+  readonly direction: DownloadDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Downloads cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Downloads cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Downloads --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Downloads ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM downloads_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function findingSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'downloads_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Downloads Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryDownloads(input: DownloadQuery): DownloadPage {
+  const direction = enumValue(
+    input.direction,
+    "desc",
+    DOWNLOAD_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "start-time", DOWNLOAD_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortDefinition = SORTS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Downloads queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+  const state = input.state?.toLocaleLowerCase("en-US") ?? null;
+  const dangerType = input.dangerType?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!findingSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Downloads analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      state,
+      dangerType,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [DOWNLOAD_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (state !== null) {
+      conditions.push("f.sort_state = ?");
+      parameters.push(state);
+    }
+    if (dangerType !== null) {
+      conditions.push("f.danger_type = ?");
+      parameters.push(dangerType);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortDefinition.expression} ${operator} ? OR ` +
+          `(${sortDefinition.expression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        findingId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Downloads cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortDefinition.expression} AS cursor_key
+           FROM downloads_findings f
+           JOIN downloads_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortDefinition.expression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "downloads",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/downloads-sqlite.ts
+++ b/core/src/downloads-sqlite.ts
@@ -12,6 +12,21 @@ import {
 } from "./history-sqlite.js";
 import { openDatabaseSync } from "./sqlite-open.js";
 
+/**
+ * Signals that a History database has no `downloads` table at all. This is a
+ * typed, distinct outcome — the table is simply not present, carrying no
+ * download evidence — so the artifact layer can classify it as `absent`
+ * (inapplicable) by `instanceof` rather than by inspecting an untyped error
+ * detail. A corrupt or unreadable database throws a `ForensixError` instead and
+ * stays `unavailable`.
+ */
+export class DownloadsTableAbsentError extends Error {
+  public constructor() {
+    super("History database is missing the downloads table.");
+    this.name = "DownloadsTableAbsentError";
+  }
+}
+
 export type RawDownloadValue = null | string | bigint | Uint8Array;
 
 /**
@@ -134,14 +149,10 @@ function readSchema(database: DatabaseSync): DownloadsSchema {
   }
   // A History database with no `downloads` table simply carries no download
   // evidence. That is `absent` (inapplicable), distinct from a corrupt or
-  // unreadable database, which stays `unavailable`. The flag lets the artifact
-  // layer classify it without conflating the two.
+  // unreadable database, which stays `unavailable`. A dedicated typed error
+  // lets the artifact layer classify it without conflating the two.
   if (!tableExists(database, "downloads")) {
-    throw new ForensixError(
-      "ANALYSIS_FAILED",
-      "History database is missing the downloads table.",
-      { table: "downloads", downloads_table_absent: true },
-    );
+    throw new DownloadsTableAbsentError();
   }
 
   const versionRow = database

--- a/core/src/downloads-sqlite.ts
+++ b/core/src/downloads-sqlite.ts
@@ -1,0 +1,407 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { ForensixError } from "./errors.js";
+import type { CommitState } from "./forensic-model.js";
+import {
+  immutableDatabase,
+  snapshotVerifiedFile,
+  type VerifiedHistoryFile,
+} from "./history-sqlite.js";
+import { openDatabaseSync } from "./sqlite-open.js";
+
+export type RawDownloadValue = null | string | bigint | Uint8Array;
+
+/**
+ * One node of a download's redirect URL chain, from the
+ * `downloads_url_chains` table. `chainIndex` orders the hops (0 is the URL the
+ * user or page first requested; the final index is the URL that actually
+ * served the bytes). The composite `(id, chain_index)` primary key is retained
+ * so each hop carries its own resolvable Provenance row identity.
+ */
+export interface RawDownloadUrlChainNode {
+  readonly chainIndex: bigint | null;
+  readonly url: RawDownloadValue;
+  readonly rowId: string | null;
+}
+
+/**
+ * One row of the Chrome `downloads` table, preserved column-by-column exactly
+ * as stored, together with its ordered URL chain. Values keep their raw SQLite
+ * type so the Finding layer can classify each Field State (value, absent, or
+ * unavailable) without lossy coercion.
+ */
+export interface RawDownloadRow {
+  readonly values: ReadonlyMap<string, RawDownloadValue>;
+  readonly rowId: bigint | null;
+  readonly urlChain: readonly RawDownloadUrlChainNode[];
+  readonly urlChainTablePresent: boolean;
+}
+
+export interface DownloadsSchema {
+  readonly version: number;
+  readonly columns: ReadonlySet<string>;
+  readonly hasUrlChains: boolean;
+}
+
+export interface DownloadsPass {
+  readonly schema: DownloadsSchema;
+  readonly rows: readonly RawDownloadRow[];
+  readonly integrity: string;
+}
+
+export interface RecoveredDownloadsPass extends DownloadsPass {
+  readonly commitState: Exclude<CommitState, "committed">;
+}
+
+export interface DownloadsPasses {
+  readonly committed: DownloadsPass;
+  readonly recovered: RecoveredDownloadsPass | null;
+  readonly recoveryUnavailableReason: string | null;
+}
+
+/**
+ * Columns the Downloads pipeline preserves when present. The `downloads` table
+ * lives inside the History database. `target_path` (and the microsecond
+ * `base::Time` timestamps) arrived together at History schema version 24, so
+ * requiring `target_path` guarantees the timestamp Epoch Family below.
+ */
+export const SUPPORTED_DOWNLOAD_COLUMNS = [
+  "id",
+  "guid",
+  "current_path",
+  "target_path",
+  "start_time",
+  "end_time",
+  "last_access_time",
+  "received_bytes",
+  "total_bytes",
+  "state",
+  "danger_type",
+  "interrupt_reason",
+  "hash",
+  "opened",
+  "transient",
+  "referrer",
+  "site_url",
+  "tab_url",
+  "tab_referrer_url",
+  "http_method",
+  "mime_type",
+  "original_mime_type",
+  "by_ext_id",
+  "by_ext_name",
+  "by_web_app_id",
+  "etag",
+  "last_modified",
+] as const;
+
+const REQUIRED_DOWNLOAD_COLUMNS = [
+  "id",
+  "target_path",
+  "start_time",
+  "state",
+] as const;
+
+function tableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = ? LIMIT 1",
+      )
+      .get(table) !== undefined
+  );
+}
+
+function tableColumns(database: DatabaseSync, table: string): Set<string> {
+  return new Set(
+    database
+      .prepare("SELECT name FROM pragma_table_info(?) ORDER BY cid")
+      .all(table)
+      .map((row) => String(row.name)),
+  );
+}
+
+function readSchema(database: DatabaseSync): DownloadsSchema {
+  if (!tableExists(database, "meta")) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "History database is missing the meta table.",
+      { table: "meta" },
+    );
+  }
+  // A History database with no `downloads` table simply carries no download
+  // evidence. That is `absent` (inapplicable), distinct from a corrupt or
+  // unreadable database, which stays `unavailable`. The flag lets the artifact
+  // layer classify it without conflating the two.
+  if (!tableExists(database, "downloads")) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "History database is missing the downloads table.",
+      { table: "downloads", downloads_table_absent: true },
+    );
+  }
+
+  const versionRow = database
+    .prepare("SELECT value FROM meta WHERE key = 'version' LIMIT 1")
+    .get();
+  const versionText = versionRow?.value;
+  const version =
+    typeof versionText === "string" || typeof versionText === "bigint"
+      ? Number(versionText)
+      : Number.NaN;
+  if (!Number.isSafeInteger(version) || version < 15) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      "History meta.version is missing or unsupported.",
+      { recorded_version: versionText ?? null },
+    );
+  }
+
+  const columns = tableColumns(database, "downloads");
+  const missing = REQUIRED_DOWNLOAD_COLUMNS.filter(
+    (column) => !columns.has(column),
+  );
+  if (missing.length > 0) {
+    throw new ForensixError(
+      "ANALYSIS_FAILED",
+      `Downloads schema version ${version} is missing required downloads columns.`,
+      { version, missing_columns: missing },
+    );
+  }
+
+  return {
+    version,
+    columns,
+    hasUrlChains: tableExists(database, "downloads_url_chains"),
+  };
+}
+
+function normalizeValue(value: unknown): RawDownloadValue {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "bigint" ||
+    value instanceof Uint8Array
+  ) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isSafeInteger(value)) {
+    return BigInt(value);
+  }
+  throw new ForensixError(
+    "ANALYSIS_FAILED",
+    "Downloads contains a value that cannot be preserved exactly.",
+  );
+}
+
+function readUrlChains(
+  database: DatabaseSync,
+): ReadonlyMap<string, RawDownloadUrlChainNode[]> {
+  const chains = new Map<string, RawDownloadUrlChainNode[]>();
+  const statement = database.prepare(
+    `SELECT id AS "id", chain_index AS "chainIndex", url AS "url"
+       FROM downloads_url_chains
+      ORDER BY id, chain_index`,
+  );
+  for (const row of statement.iterate()) {
+    const id = normalizeValue(row.id);
+    if (typeof id !== "bigint") {
+      continue;
+    }
+    const chainIndex = normalizeValue(row.chainIndex);
+    const key = id.toString();
+    const nodes = chains.get(key) ?? [];
+    nodes.push({
+      chainIndex: typeof chainIndex === "bigint" ? chainIndex : null,
+      url: normalizeValue(row.url),
+      rowId:
+        typeof chainIndex === "bigint"
+          ? `${key}:${chainIndex.toString()}`
+          : null,
+    });
+    chains.set(key, nodes);
+  }
+  return chains;
+}
+
+function readPass(database: DatabaseSync): DownloadsPass {
+  const schema = readSchema(database);
+  const selected = SUPPORTED_DOWNLOAD_COLUMNS.filter((column) =>
+    schema.columns.has(column),
+  );
+  const projection = selected
+    .map((column) => `d."${column}" AS "${column}"`)
+    .join(",\n      ");
+  const chains = schema.hasUrlChains
+    ? readUrlChains(database)
+    : new Map<string, RawDownloadUrlChainNode[]>();
+  const statement = database.prepare(`
+    SELECT
+      d.rowid AS "__rowid",
+      ${projection}
+    FROM downloads d
+    ORDER BY d.rowid
+  `);
+  const rows: RawDownloadRow[] = [];
+  for (const row of statement.iterate()) {
+    const values = new Map<string, RawDownloadValue>();
+    for (const column of selected) {
+      values.set(column, normalizeValue(row[column]));
+    }
+    const rawRowId = normalizeValue(row.__rowid);
+    const rowId = typeof rawRowId === "bigint" ? rawRowId : null;
+    rows.push({
+      values,
+      rowId,
+      urlChain: rowId === null ? [] : (chains.get(rowId.toString()) ?? []),
+      urlChainTablePresent: schema.hasUrlChains,
+    });
+  }
+
+  const integrityRow = database.prepare("PRAGMA integrity_check(1)").get();
+  const integrity = String(integrityRow?.integrity_check ?? "unavailable");
+  return { schema, rows, integrity };
+}
+
+function fingerprint(row: RawDownloadRow): string {
+  return JSON.stringify(
+    {
+      values: [...row.values.entries()].sort(([left], [right]) =>
+        left < right ? -1 : left > right ? 1 : 0,
+      ),
+      chain: row.urlChain.map((node) => [
+        node.chainIndex === null ? null : node.chainIndex.toString(),
+        node.url,
+      ]),
+    },
+    (_key, value: unknown) => {
+      if (typeof value === "bigint") {
+        return `${value.toString()}n`;
+      }
+      if (value instanceof Uint8Array) {
+        return `blob:${Buffer.from(value).toString("base64")}`;
+      }
+      return value;
+    },
+  );
+}
+
+/**
+ * Return only rows that a WAL or rollback journal adds or changes relative to
+ * the committed database, keyed by `downloads.rowid`. This keeps recovered
+ * evidence separate from committed evidence, mirroring the History and Web Data
+ * recovery contract.
+ */
+function recoveredOnlyRows(
+  committed: readonly RawDownloadRow[],
+  recovered: readonly RawDownloadRow[],
+): RawDownloadRow[] {
+  const committedByRowId = new Map(
+    committed.flatMap((row) =>
+      row.rowId === null
+        ? []
+        : [[row.rowId.toString(), fingerprint(row)] as const],
+    ),
+  );
+  const rows: RawDownloadRow[] = [];
+  for (const row of recovered) {
+    const id = row.rowId === null ? null : row.rowId.toString();
+    const committedFingerprint =
+      id === null ? undefined : committedByRowId.get(id);
+    if (
+      committedFingerprint === undefined ||
+      committedFingerprint !== fingerprint(row)
+    ) {
+      rows.push(row);
+    }
+  }
+  return rows;
+}
+
+export async function readDownloadsPasses(options: {
+  readonly database: VerifiedHistoryFile;
+  readonly sidecars: readonly VerifiedHistoryFile[];
+}): Promise<DownloadsPasses> {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "forensix-downloads-snapshot-"),
+  );
+  const temporaryDatabasePath = join(
+    temporaryDirectory,
+    basename(options.database.path),
+  );
+  try {
+    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(temporaryDirectory, basename(sidecar.path)),
+      );
+    }
+
+    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    let committed: DownloadsPass;
+    try {
+      committed = readPass(committedDatabase);
+    } finally {
+      committedDatabase.close();
+    }
+
+    const wal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-wal"),
+    );
+    const journal = options.sidecars.find((sidecar) =>
+      sidecar.path.endsWith("-journal"),
+    );
+    const commitState =
+      wal === undefined
+        ? journal === undefined
+          ? null
+          : "journal_resident"
+        : "wal_resident";
+    if (commitState === null) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: "sidecar_not_supplied",
+      };
+    }
+
+    let recoveryDatabase: DatabaseSync;
+    try {
+      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
+        readBigInts: true,
+      });
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_open_failed:${String(error)}`,
+      };
+    }
+    try {
+      const fullRecoveryPass = readPass(recoveryDatabase);
+      return {
+        committed,
+        recovered: {
+          ...fullRecoveryPass,
+          rows: recoveredOnlyRows(committed.rows, fullRecoveryPass.rows),
+          commitState,
+        },
+        recoveryUnavailableReason: null,
+      };
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_read_failed:${String(error)}`,
+      };
+    } finally {
+      recoveryDatabase.close();
+    }
+  } finally {
+    await rm(temporaryDirectory, { force: true, recursive: true });
+  }
+}

--- a/core/src/downloads.ts
+++ b/core/src/downloads.ts
@@ -19,6 +19,7 @@ import {
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
 import {
+  DownloadsTableAbsentError,
   readDownloadsPasses,
   type DownloadsSchema,
   type RawDownloadRow,
@@ -495,12 +496,16 @@ export async function analyseDownloadsProfile(options: {
     options.profile === "." ? "History" : `${options.profile}/History`;
   const manifest = manifestIdentity(options.source, databasePath);
   if (manifest === null) {
+    // Mirror the sibling per-Profile artifacts (e.g. Web Data): a missing
+    // manifest entry is `absent`, not `unavailable`, so it never degrades an
+    // otherwise clean Analysis Run. The History artifact independently reports
+    // the missing History file.
     return unavailableArtifact(
       options.source.sourceId,
       options.profile,
       databasePath,
       null,
-      "unavailable",
+      "absent",
       "downloads_manifest_entry_missing",
     );
   }
@@ -637,17 +642,14 @@ export async function analyseDownloadsProfile(options: {
     // download evidence: report it as `absent` so it never degrades an
     // otherwise clean Analysis Run, while a corrupt or unreadable database
     // stays `unavailable` with its distinct typed reason.
-    if (
-      error instanceof ForensixError &&
-      error.details.downloads_table_absent === true
-    ) {
+    if (error instanceof DownloadsTableAbsentError) {
       return unavailableArtifact(
         options.source.sourceId,
         options.profile,
         databasePath,
         manifest.ordinal,
         "absent",
-        "downloads_table_absent:History database is missing the downloads table.",
+        `downloads_table_absent:${error.message}`,
       );
     }
     const reason =

--- a/core/src/downloads.ts
+++ b/core/src/downloads.ts
@@ -17,6 +17,11 @@ import {
   type Provenance,
   type SourceRowProvenance,
 } from "./forensic-model.js";
+import {
+  boundedSortInteger,
+  utcFromUnixMicros,
+  WINDOWS_EPOCH_OFFSET_MICROS,
+} from "./forensic-time.js";
 import type { ForensicTimestamp } from "./history.js";
 import {
   DownloadsTableAbsentError,
@@ -34,7 +39,6 @@ import type { VerifiedHistoryFile } from "./history-sqlite.js";
  * Declared Origin OS is needed to resolve the Epoch Family.
  */
 const DOWNLOAD_EPOCH_FAMILY = "1601-us" as const;
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
 
 /**
  * `downloads.state` — `DownloadDatabase` `DownloadState`. Value 3 (BUG_140687)
@@ -116,27 +120,8 @@ interface ManifestIdentity {
   readonly databasePath: string;
 }
 
-function floorDivision(value: bigint, divisor: bigint): bigint {
-  const quotient = value / divisor;
-  const remainder = value % divisor;
-  return remainder < 0n ? quotient - 1n : quotient;
-}
-
 function utcFromWindowsMicros(windowsMicros: bigint): string | null {
-  const unixMicros = windowsMicros - WINDOWS_EPOCH_OFFSET_MICROS;
-  const seconds = floorDivision(unixMicros, 1_000_000n);
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = seconds * 1000n + micros / 1000n;
-  const numericMilliseconds = Number(milliseconds);
-  if (!Number.isSafeInteger(numericMilliseconds)) {
-    return null;
-  }
-  const date = new Date(numericMilliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  const base = date.toISOString();
-  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+  return utcFromUnixMicros(windowsMicros - WINDOWS_EPOCH_OFFSET_MICROS);
 }
 
 function preservedString(value: RawDownloadValue): FieldState<string> {
@@ -433,15 +418,6 @@ function buildDownloads(options: {
         dangerType.decoded.state === "value" ? dangerType.decoded.value : null,
     };
   });
-}
-
-const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
-const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
-
-function boundedSortInteger(value: bigint): bigint | null {
-  return value >= SQLITE_MIN_INTEGER && value <= SQLITE_MAX_INTEGER
-    ? value
-    : null;
 }
 
 function manifestIdentity(

--- a/core/src/downloads.ts
+++ b/core/src/downloads.ts
@@ -1,0 +1,666 @@
+import { join } from "node:path";
+
+import type {
+  DownloadsArtifactWrite,
+  PersistedDownloadFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type CommitState,
+  type FieldState,
+  type Finding,
+  type Provenance,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import {
+  readDownloadsPasses,
+  type DownloadsSchema,
+  type RawDownloadRow,
+  type RawDownloadValue,
+} from "./downloads-sqlite.js";
+import type { VerifiedHistoryFile } from "./history-sqlite.js";
+
+/**
+ * Chrome serialises `downloads` timestamps as a `base::Time` internal value:
+ * microseconds since 1601-01-01 UTC, on every platform. This arrived with
+ * `target_path` at History schema version 24, which the reader requires, so no
+ * Declared Origin OS is needed to resolve the Epoch Family.
+ */
+const DOWNLOAD_EPOCH_FAMILY = "1601-us" as const;
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+/**
+ * `downloads.state` — `DownloadDatabase` `DownloadState`. Value 3 (BUG_140687)
+ * is a deprecated placeholder that is deliberately left undecoded so it is not
+ * conflated with the real INTERRUPTED (4) state; its raw value is still kept.
+ */
+const DOWNLOAD_STATES = new Map<bigint, string>([
+  [0n, "in_progress"],
+  [1n, "complete"],
+  [2n, "cancelled"],
+  [4n, "interrupted"],
+]);
+
+/** `downloads.danger_type` — `download::DownloadDangerType`. */
+const DANGER_TYPES = new Map<bigint, string>([
+  [0n, "not_dangerous"],
+  [1n, "dangerous_file"],
+  [2n, "dangerous_url"],
+  [3n, "dangerous_content"],
+  [4n, "maybe_dangerous_content"],
+  [5n, "uncommon_content"],
+  [6n, "user_validated"],
+  [7n, "dangerous_host"],
+  [8n, "potentially_unwanted"],
+  [9n, "allowlisted_by_policy"],
+  [10n, "async_scanning"],
+  [11n, "blocked_password_protected"],
+  [12n, "blocked_too_large"],
+  [13n, "sensitive_content_warning"],
+  [14n, "sensitive_content_block"],
+  [15n, "deep_scanned_safe"],
+  [16n, "deep_scanned_opened_dangerous"],
+  [17n, "prompt_for_scanning"],
+  [18n, "blocked_unsupported_file_type"],
+  [19n, "dangerous_account_compromise"],
+  [20n, "deep_scanned_failed"],
+  [21n, "prompt_for_local_password_scanning"],
+  [22n, "async_local_password_scanning"],
+]);
+
+/** `downloads.interrupt_reason` — `download::DownloadInterruptReason` (sparse). */
+const INTERRUPT_REASONS = new Map<bigint, string>([
+  [0n, "none"],
+  [1n, "file_failed"],
+  [2n, "file_access_denied"],
+  [3n, "file_no_space"],
+  [5n, "file_name_too_long"],
+  [6n, "file_too_large"],
+  [7n, "file_virus_infected"],
+  [10n, "file_transient_error"],
+  [11n, "file_blocked"],
+  [12n, "file_security_check_failed"],
+  [13n, "file_too_short"],
+  [14n, "file_hash_mismatch"],
+  [15n, "file_same_as_source"],
+  [20n, "network_failed"],
+  [21n, "network_timeout"],
+  [22n, "network_disconnected"],
+  [23n, "network_server_down"],
+  [24n, "network_invalid_request"],
+  [30n, "server_failed"],
+  [31n, "server_no_range"],
+  [32n, "server_bad_content"],
+  [33n, "server_unauthorized"],
+  [34n, "server_cert_problem"],
+  [35n, "server_forbidden"],
+  [36n, "server_unreachable"],
+  [37n, "server_content_length_mismatch"],
+  [38n, "server_cross_origin_redirect"],
+  [40n, "user_canceled"],
+  [41n, "user_shutdown"],
+  [50n, "crash"],
+]);
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+  readonly databasePath: string;
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromWindowsMicros(windowsMicros: bigint): string | null {
+  const unixMicros = windowsMicros - WINDOWS_EPOCH_OFFSET_MICROS;
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+function preservedString(value: RawDownloadValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+function preservedInteger(value: RawDownloadValue): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "bigint"
+    ? valueField(value.toString())
+    : unavailableField("unsupported_value");
+}
+
+function preservedBoolean(value: RawDownloadValue): FieldState<boolean> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  if (value === 0n) {
+    return valueField(false);
+  }
+  if (value === 1n) {
+    return valueField(true);
+  }
+  return unavailableField("unsupported_value");
+}
+
+function timestampField(
+  raw: RawDownloadValue,
+  schemaVersion: number,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (raw === undefined || raw === null || raw === 0n) {
+    return absentField();
+  }
+  if (typeof raw !== "bigint") {
+    return unavailableField("unsupported_value");
+  }
+  const utc = utcFromWindowsMicros(raw);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: raw.toString(),
+      epochFamily: DOWNLOAD_EPOCH_FAMILY,
+      utc,
+      declaredTimezone,
+      resolution: `verified_history_schema_version_${schemaVersion}`,
+    },
+    { synthetic: false },
+  );
+}
+
+/**
+ * Decode an enumerated integer column while retaining its raw value in a
+ * companion field, so every decoded meaning stays independently reviewable
+ * against ground truth. An unmapped code keeps the raw value and marks the
+ * decoded field `unavailable` rather than guessing.
+ */
+function decodedEnum(
+  value: RawDownloadValue,
+  table: ReadonlyMap<bigint, string>,
+): { readonly raw: FieldState<string>; readonly decoded: FieldState<string> } {
+  if (value === undefined || value === null) {
+    return { raw: absentField(), decoded: absentField() };
+  }
+  if (typeof value !== "bigint") {
+    return {
+      raw: unavailableField("unsupported_value"),
+      decoded: unavailableField("unsupported_value"),
+    };
+  }
+  const decoded = table.get(value);
+  return {
+    raw: valueField(value.toString()),
+    decoded:
+      decoded === undefined
+        ? unavailableField("unsupported_value")
+        : valueField(decoded),
+  };
+}
+
+/**
+ * Represent the `downloads.hash` BLOB (the SHA-256 of the downloaded bytes) as
+ * lowercase hex plus its byte length. A digest is rendered in its canonical
+ * reviewable form; binary is never base64-smuggled into a Finding row.
+ */
+function contentHashField(value: RawDownloadValue): {
+  readonly sha256: FieldState<string>;
+  readonly byteLength: FieldState<string>;
+} {
+  if (value === undefined || value === null) {
+    return { sha256: absentField(), byteLength: absentField() };
+  }
+  if (!(value instanceof Uint8Array)) {
+    return {
+      sha256: unavailableField("unsupported_value"),
+      byteLength: unavailableField("unsupported_value"),
+    };
+  }
+  if (value.length === 0) {
+    return { sha256: absentField(), byteLength: valueField("0") };
+  }
+  return {
+    sha256: valueField(Buffer.from(value).toString("hex")),
+    byteLength: valueField(value.length.toString()),
+  };
+}
+
+function sourceRowProvenance(
+  manifest: ManifestIdentity,
+  table: string,
+  rowId: string,
+): SourceRowProvenance {
+  return {
+    manifestEntryId: `${manifest.sourceId}:${manifest.ordinal}`,
+    sourceId: manifest.sourceId,
+    manifestEntryOrdinal: manifest.ordinal,
+    manifestPath: manifest.path,
+    database: manifest.databasePath,
+    table,
+    rowId,
+  };
+}
+
+function textValue(field: FieldState<string>): string {
+  return field.state === "value" ? field.value : "";
+}
+
+function timeValue(field: FieldState<ForensicTimestamp>): string | null {
+  return field.state === "value" ? field.value.utc : null;
+}
+
+function buildDownloads(options: {
+  readonly rows: readonly RawDownloadRow[];
+  readonly schema: DownloadsSchema;
+  readonly commitState: CommitState;
+  readonly profile: string;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+}): PersistedDownloadFinding[] {
+  return options.rows.map((row) => {
+    if (row.rowId === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Downloads downloads.id is not an exact integer.",
+      );
+    }
+    const rowId = row.rowId.toString();
+    const get = (column: string): RawDownloadValue =>
+      row.values.get(column) ?? null;
+
+    const targetPath = preservedString(get("target_path"));
+    const currentPath = preservedString(get("current_path"));
+    const startTime = timestampField(
+      get("start_time"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const endTime = timestampField(
+      get("end_time"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const lastAccessTime = timestampField(
+      get("last_access_time"),
+      options.schema.version,
+      options.declaredTimezone,
+    );
+    const state = decodedEnum(get("state"), DOWNLOAD_STATES);
+    const dangerType = decodedEnum(get("danger_type"), DANGER_TYPES);
+    const interruptReason = decodedEnum(
+      get("interrupt_reason"),
+      INTERRUPT_REASONS,
+    );
+    const contentHash = contentHashField(get("hash"));
+
+    // URL chain: ordered redirect hops with resolvable Provenance per hop.
+    const chainUrls = row.urlChain.map((node) => node.url);
+    const chainStrings = chainUrls.filter(
+      (url): url is string => typeof url === "string",
+    );
+    const firstNode = row.urlChain[0];
+    const lastNode = row.urlChain.at(-1);
+    const chainField = (
+      node: (typeof row.urlChain)[number] | undefined,
+    ): FieldState<string> => {
+      if (!row.urlChainTablePresent) {
+        return absentField();
+      }
+      if (node === undefined) {
+        return absentField();
+      }
+      return preservedString(node.url);
+    };
+    const originalUrl = chainField(firstNode);
+    const finalUrl = chainField(lastNode);
+    const urlChain: FieldState<readonly string[]> = row.urlChainTablePresent
+      ? valueField(chainStrings)
+      : absentField();
+
+    const fields = {
+      downloadId: valueField(rowId),
+      guid: preservedString(get("guid")),
+      targetPath,
+      currentPath,
+      startTime,
+      endTime,
+      lastAccessTime,
+      receivedBytes: preservedInteger(get("received_bytes")),
+      totalBytes: preservedInteger(get("total_bytes")),
+      stateRaw: state.raw,
+      state: state.decoded,
+      dangerTypeRaw: dangerType.raw,
+      dangerType: dangerType.decoded,
+      interruptReasonRaw: interruptReason.raw,
+      interruptReason: interruptReason.decoded,
+      opened: preservedBoolean(get("opened")),
+      transient: preservedBoolean(get("transient")),
+      referrer: preservedString(get("referrer")),
+      siteUrl: preservedString(get("site_url")),
+      tabUrl: preservedString(get("tab_url")),
+      tabReferrerUrl: preservedString(get("tab_referrer_url")),
+      httpMethod: preservedString(get("http_method")),
+      mimeType: preservedString(get("mime_type")),
+      originalMimeType: preservedString(get("original_mime_type")),
+      byExtId: preservedString(get("by_ext_id")),
+      byExtName: preservedString(get("by_ext_name")),
+      byWebAppId: preservedString(get("by_web_app_id")),
+      etag: preservedString(get("etag")),
+      lastModified: preservedString(get("last_modified")),
+      contentSha256: contentHash.sha256,
+      contentHashByteLength: contentHash.byteLength,
+      originalUrl,
+      finalUrl,
+      urlChain,
+      urlChainLength: row.urlChainTablePresent
+        ? valueField(row.urlChain.length.toString())
+        : absentField(),
+    };
+
+    const supportingRows: SourceRowProvenance[] = row.urlChain.flatMap(
+      (node) =>
+        node.rowId === null
+          ? []
+          : [
+              sourceRowProvenance(
+                options.manifest,
+                "downloads_url_chains",
+                node.rowId,
+              ),
+            ],
+    );
+    const provenance: Provenance = {
+      ...sourceRowProvenance(options.manifest, "downloads", rowId),
+      ...(supportingRows.length === 0 ? {} : { supportingRows }),
+    };
+    const finding: Finding = createFinding({
+      findingKind: "download",
+      profile: options.profile,
+      commitState: options.commitState,
+      provenance,
+      fields,
+    });
+    return {
+      finding,
+      searchText: [
+        options.profile,
+        textValue(targetPath),
+        textValue(currentPath),
+        state.decoded.state === "value" ? state.decoded.value : "",
+        ...chainStrings,
+        textValue(fields.referrer),
+        textValue(fields.tabUrl),
+      ]
+        .join("\n")
+        .toLocaleLowerCase("en-US"),
+      sortStart: timeValue(startTime),
+      sortEnd: timeValue(endTime),
+      sortTargetPath: textValue(targetPath) || null,
+      sortState: state.decoded.state === "value" ? state.decoded.value : null,
+      sortTotalBytes:
+        fields.totalBytes.state === "value"
+          ? boundedSortInteger(BigInt(fields.totalBytes.value))
+          : null,
+      dangerType:
+        dangerType.decoded.state === "value" ? dangerType.decoded.value : null,
+    };
+  });
+}
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function boundedSortInteger(value: bigint): bigint | null {
+  return value >= SQLITE_MIN_INTEGER && value <= SQLITE_MAX_INTEGER
+    ? value
+    : null;
+}
+
+function manifestIdentity(
+  source: CaseSourceRecord,
+  path: string,
+  databasePath = path,
+): ManifestIdentity | null {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  return ordinal < 0
+    ? null
+    : { sourceId: source.sourceId, ordinal, path, databasePath };
+}
+
+function unavailableArtifact(
+  sourceId: string,
+  profile: string,
+  databasePath: string,
+  manifestEntryOrdinal: number | null,
+  status: "absent" | "unavailable",
+  reason: string,
+): DownloadsArtifactWrite {
+  return {
+    sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal,
+    databasePath,
+    schemaVersion: null,
+    integrity: null,
+    recoveryStatus: "unavailable",
+    reason,
+    findings: [],
+    committedDownloadCount: 0,
+    recoveredDownloadCount: 0,
+  };
+}
+
+/**
+ * Parse the `downloads` artifact for one Profile. Downloads live inside the
+ * History database, so this reads the same verified `History` file and its
+ * sidecars but produces its own artifact result. A broken or absent Downloads
+ * table therefore yields a reasoned unavailability for Downloads without
+ * suppressing the Profile's usable History visit results.
+ */
+export async function analyseDownloadsProfile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+}): Promise<DownloadsArtifactWrite> {
+  const databasePath =
+    options.profile === "." ? "History" : `${options.profile}/History`;
+  const manifest = manifestIdentity(options.source, databasePath);
+  if (manifest === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      null,
+      "unavailable",
+      "downloads_manifest_entry_missing",
+    );
+  }
+  const entry = options.source.entries[manifest.ordinal];
+  if (entry === undefined) {
+    throw new Error("Manifest ordinal became invalid.");
+  }
+  if (entry.state === "absent") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "absent",
+      "downloads_absent",
+    );
+  }
+  if (entry.state === "unavailable") {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      `downloads_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+    );
+  }
+  if (!entry.copied) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "downloads_not_in_working_copy",
+    );
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      "downloads_manifest_representation_incomplete",
+    );
+  }
+
+  const verifiedDatabase: VerifiedHistoryFile = {
+    path: join(options.workingCopyPath, ...databasePath.split("/")),
+    manifestPath: databasePath,
+    size: entry.size,
+    sha256: entry.sha256,
+  };
+  const sidecars: VerifiedHistoryFile[] = options.source.entries
+    .filter(
+      (candidate) =>
+        candidate.copied &&
+        candidate.state === "value" &&
+        candidate.size !== null &&
+        candidate.sha256 !== null &&
+        (candidate.path === `${databasePath}-wal` ||
+          candidate.path === `${databasePath}-journal`),
+    )
+    .map((candidate) => ({
+      path: join(options.workingCopyPath, ...candidate.path.split("/")),
+      manifestPath: candidate.path,
+      size: candidate.size as number,
+      sha256: candidate.sha256 as string,
+    }));
+
+  try {
+    const passes = await readDownloadsPasses({
+      database: verifiedDatabase,
+      sidecars,
+    });
+    const recoveredManifest =
+      passes.recovered === null
+        ? null
+        : manifestIdentity(
+            options.source,
+            `${databasePath}${
+              passes.recovered.commitState === "wal_resident"
+                ? "-wal"
+                : "-journal"
+            }`,
+            databasePath,
+          );
+    if (passes.recovered !== null && recoveredManifest === null) {
+      throw new ForensixError(
+        "ANALYSIS_FAILED",
+        "Downloads recovery content has no resolvable sidecar Manifest entry.",
+        { database_path: databasePath },
+      );
+    }
+    const committed = buildDownloads({
+      rows: passes.committed.rows,
+      schema: passes.committed.schema,
+      commitState: "committed",
+      profile: options.profile,
+      manifest,
+      declaredTimezone: options.declaredTimezone,
+    });
+    const recovered =
+      passes.recovered === null
+        ? []
+        : buildDownloads({
+            rows: passes.recovered.rows,
+            schema: passes.recovered.schema,
+            commitState: passes.recovered.commitState,
+            profile: options.profile,
+            manifest: recoveredManifest as ManifestIdentity,
+            declaredTimezone: options.declaredTimezone,
+          });
+    return {
+      sourceId: options.source.sourceId,
+      profile: options.profile,
+      status: "complete",
+      manifestEntryOrdinal: manifest.ordinal,
+      databasePath,
+      schemaVersion: passes.committed.schema.version,
+      integrity: passes.committed.integrity,
+      recoveryStatus: passes.recovered === null ? "unavailable" : "complete",
+      reason: passes.recoveryUnavailableReason,
+      findings: [...committed, ...recovered],
+      committedDownloadCount: committed.length,
+      recoveredDownloadCount: recovered.length,
+    };
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    // A History database that simply has no `downloads` table carries no
+    // download evidence: report it as `absent` so it never degrades an
+    // otherwise clean Analysis Run, while a corrupt or unreadable database
+    // stays `unavailable` with its distinct typed reason.
+    if (
+      error instanceof ForensixError &&
+      error.details.downloads_table_absent === true
+    ) {
+      return unavailableArtifact(
+        options.source.sourceId,
+        options.profile,
+        databasePath,
+        manifest.ordinal,
+        "absent",
+        "downloads_table_absent:History database is missing the downloads table.",
+      );
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `downloads_read_failed:${String(error)}`;
+    return unavailableArtifact(
+      options.source.sourceId,
+      options.profile,
+      databasePath,
+      manifest.ordinal,
+      "unavailable",
+      reason,
+    );
+  }
+}

--- a/core/src/forensic-time.ts
+++ b/core/src/forensic-time.ts
@@ -1,0 +1,48 @@
+/**
+ * Shared, pure time and integer-range primitives for the History-family
+ * artifacts. History and the Downloads that live inside the History database
+ * serialise timestamps with the same `base::Time` epoch, so the conversion and
+ * SQLite range helpers live here once rather than being copied per artifact.
+ */
+
+/** Microseconds between 1601-01-01 (the `base::Time` epoch) and 1970-01-01 UTC. */
+export const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+/** Inclusive bounds of a signed 64-bit SQLite INTEGER column. */
+export const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+export const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+/** Floor division for bigints, so negative (pre-epoch) values round toward -inf. */
+export function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+/**
+ * Render microseconds since the Unix epoch as an ISO 8601 UTC instant with full
+ * microsecond precision, or `null` when the value falls outside the range a
+ * JavaScript `Date` can represent exactly.
+ */
+export function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+/** Keep a bigint only when it fits a signed 64-bit SQLite INTEGER sort column. */
+export function boundedSortInteger(value: bigint): bigint | null {
+  return value >= SQLITE_MIN_INTEGER && value <= SQLITE_MAX_INTEGER
+    ? value
+    : null;
+}

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -5,6 +5,7 @@ import {
   type AnalysisRunExitState,
   type CookieArtifactWrite,
   type DeclaredOriginOs,
+  type DownloadsArtifactWrite,
   type FaviconArtifactWrite,
   type HistoryArtifactWrite,
   type LoginDataArtifactWrite,
@@ -14,6 +15,7 @@ import {
   type WebDataArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceCookies } from "./cookies.js";
+import { analyseDownloadsProfile } from "./downloads.js";
 import { analyseSourceFavicons } from "./favicons.js";
 import { analyseLoginDataProfile } from "./login-data.js";
 import { analyseSourcePreferences } from "./preferences.js";
@@ -188,6 +190,18 @@ export interface FaviconsAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface DownloadsAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly recoveryUnavailableProfileCount: number;
+  readonly committedDownloadCount: number;
+  readonly recoveredDownloadCount: number;
+  readonly findingCount: number;
+}
+
 export interface PreferencesAnalysisSummary {
   readonly status: "complete" | "partial";
   readonly artifactCount: number;
@@ -211,6 +225,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly topSites: TopSitesAnalysisSummary;
   readonly webData: WebDataAnalysisSummary;
   readonly favicons: FaviconsAnalysisSummary;
+  readonly downloads: DownloadsAnalysisSummary;
   readonly preferences: PreferencesAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
@@ -1273,6 +1288,7 @@ export async function analyseCase(
   const topSitesArtifacts: TopSitesArtifactWrite[] = [];
   const webDataArtifacts: WebDataArtifactWrite[] = [];
   const faviconArtifacts: FaviconArtifactWrite[] = [];
+  const downloadsArtifacts: DownloadsArtifactWrite[] = [];
   const metadataArtifacts: MetadataArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
@@ -1297,6 +1313,14 @@ export async function analyseCase(
       );
       webDataArtifacts.push(
         await analyseWebDataProfile({
+          source,
+          profile: profile.path,
+          workingCopyPath,
+          declaredTimezone,
+        }),
+      );
+      downloadsArtifacts.push(
+        await analyseDownloadsProfile({
           source,
           profile: profile.path,
           workingCopyPath,
@@ -1346,6 +1370,7 @@ export async function analyseCase(
     topSitesArtifacts,
     webDataArtifacts,
     faviconArtifacts,
+    downloadsArtifacts,
     metadataArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
@@ -1408,6 +1433,15 @@ export async function analyseCase(
   const faviconsUnavailable = faviconArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const downloadsAnalysed = downloadsArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const downloadsAbsent = downloadsArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const downloadsUnavailable = downloadsArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   const metadataAnalysed = metadataArtifacts.filter(
     (artifact) => artifact.status === "complete",
   );
@@ -1427,7 +1461,8 @@ export async function analyseCase(
       loginAnalysed.length +
       topSitesAnalysed.length +
       webAnalysed.length +
-      faviconsAnalysed.length,
+      faviconsAnalysed.length +
+      downloadsAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
     cookies: {
@@ -1581,6 +1616,31 @@ export async function analyseCase(
         0,
       ),
       findingCount: faviconsAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+    },
+    downloads: {
+      status: downloadsUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: downloadsAnalysed.length,
+      absentProfileCount: downloadsAbsent.length,
+      unavailableProfileCount: downloadsUnavailable.length,
+      recoveryUnavailableProfileCount: downloadsAnalysed.filter(
+        (artifact) => artifact.recoveryStatus === "unavailable",
+      ).length,
+      committedDownloadCount: downloadsAnalysed.reduce(
+        (count, artifact) => count + artifact.committedDownloadCount,
+        0,
+      ),
+      recoveredDownloadCount: downloadsAnalysed.reduce(
+        (count, artifact) => count + artifact.recoveredDownloadCount,
+        0,
+      ),
+      findingCount: downloadsAnalysed.reduce(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -33,6 +33,11 @@ import {
 } from "./case.js";
 import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
 import {
+  boundedSortInteger,
+  utcFromUnixMicros,
+  WINDOWS_EPOCH_OFFSET_MICROS,
+} from "./forensic-time.js";
+import {
   absentField,
   createFinding,
   unavailableField,
@@ -249,9 +254,6 @@ interface BuiltVisit {
   readonly provenance: Provenance;
 }
 
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
-const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
-const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
 const TRANSITION_CORES = new Map<number, string>([
   [0, "link"],
   [1, "typed"],
@@ -358,28 +360,6 @@ function preservedString(
   return typeof value === "string"
     ? valueField(value)
     : unavailableField("unsupported_value");
-}
-
-function floorDivision(value: bigint, divisor: bigint): bigint {
-  const quotient = value / divisor;
-  const remainder = value % divisor;
-  return remainder < 0n ? quotient - 1n : quotient;
-}
-
-function utcFromUnixMicros(unixMicros: bigint): string | null {
-  const seconds = floorDivision(unixMicros, 1_000_000n);
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = seconds * 1000n + micros / 1000n;
-  const numericMilliseconds = Number(milliseconds);
-  if (!Number.isSafeInteger(numericMilliseconds)) {
-    return null;
-  }
-  const date = new Date(numericMilliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  const base = date.toISOString();
-  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
 }
 
 function resolveHistoryEpoch(
@@ -892,12 +872,6 @@ function durationSummaryFields(visits: readonly BuiltVisit[]): {
         ? absentField()
         : valueField((total / BigInt(withDurationCount)).toString()),
   };
-}
-
-function boundedSortInteger(value: bigint): bigint | null {
-  return value >= SQLITE_MIN_INTEGER && value <= SQLITE_MAX_INTEGER
-    ? value
-    : null;
 }
 
 function buildSummaries(

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -94,6 +94,7 @@ export {
   type AnalyseCaseResult,
   type CookieAnalysisSummary,
   type DecryptionSummary,
+  type DownloadsAnalysisSummary,
   type EpochFamily,
   type FaviconsAnalysisSummary,
   type ForensicTimestamp,
@@ -199,6 +200,13 @@ export {
   type FaviconQuery,
   type FaviconSort,
 } from "./favicons-query.js";
+export {
+  queryDownloads,
+  type DownloadDirection,
+  type DownloadPage,
+  type DownloadQuery,
+  type DownloadSort,
+} from "./downloads-query.js";
 export {
   queryMetadata,
   type MetadataDirection,

--- a/e2e/downloads-cli.test.ts
+++ b/e2e/downloads-cli.test.ts
@@ -1,0 +1,799 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface DownloadFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "download";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+    readonly supportingRows?: readonly {
+      readonly table: string;
+      readonly rowId: string;
+    }[];
+  };
+  readonly fields: {
+    readonly downloadId: Field<string>;
+    readonly targetPath: Field<string>;
+    readonly currentPath: Field<string>;
+    readonly startTime: Field<{
+      readonly raw: string;
+      readonly epochFamily: string;
+      readonly utc: string;
+      readonly declaredTimezone: string;
+      readonly resolution: string;
+    }>;
+    readonly endTime: Field<unknown>;
+    readonly receivedBytes: Field<string>;
+    readonly totalBytes: Field<string>;
+    readonly stateRaw: Field<string>;
+    readonly state: Field<string>;
+    readonly dangerTypeRaw: Field<string>;
+    readonly dangerType: Field<string>;
+    readonly interruptReasonRaw: Field<string>;
+    readonly interruptReason: Field<string>;
+    readonly opened: Field<boolean>;
+    readonly referrer: Field<string>;
+    readonly mimeType: Field<string>;
+    readonly contentSha256: Field<string>;
+    readonly contentHashByteLength: Field<string>;
+    readonly originalUrl: Field<string>;
+    readonly finalUrl: Field<string>;
+    readonly urlChain: Field<readonly string[]>;
+    readonly urlChainLength: Field<string>;
+  };
+}
+
+interface DownloadPage {
+  readonly status: "ok";
+  readonly command: "downloads";
+  readonly items: readonly DownloadFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+// base::Time internal value: microseconds since 1601-01-01 UTC.
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+function windowsMicros(unixSeconds: bigint): bigint {
+  return unixSeconds * 1_000_000n + WINDOWS_EPOCH_OFFSET_MICROS;
+}
+
+interface DownloadRow {
+  readonly id: bigint;
+  readonly targetPath: string;
+  readonly startTime: bigint;
+  readonly endTime: bigint;
+  readonly receivedBytes: bigint;
+  readonly totalBytes: bigint;
+  readonly state: bigint;
+  readonly dangerType: bigint;
+  readonly interruptReason: bigint;
+  readonly hash: Uint8Array;
+  readonly opened: bigint;
+  readonly referrer: string;
+  readonly mimeType: string;
+  readonly chain: readonly string[];
+}
+
+function createHistorySchema(database: DatabaseSync): void {
+  database.exec(`
+    CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+    INSERT INTO meta (key, value) VALUES ('version', '74'), ('last_compatible_version', '16');
+
+    CREATE TABLE urls (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url LONGVARCHAR,
+      title LONGVARCHAR,
+      visit_count INTEGER DEFAULT 0 NOT NULL,
+      typed_count INTEGER DEFAULT 0 NOT NULL,
+      last_visit_time INTEGER NOT NULL,
+      hidden INTEGER DEFAULT 0 NOT NULL
+    );
+
+    CREATE TABLE visits (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url INTEGER NOT NULL,
+      visit_time INTEGER NOT NULL,
+      from_visit INTEGER,
+      external_referrer_url TEXT,
+      transition INTEGER DEFAULT 0 NOT NULL,
+      segment_id INTEGER,
+      visit_duration INTEGER DEFAULT 0 NOT NULL,
+      incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+      opener_visit INTEGER,
+      originator_cache_guid TEXT,
+      originator_visit_id INTEGER,
+      originator_from_visit INTEGER,
+      originator_opener_visit INTEGER,
+      is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+      consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+      visited_link_id INTEGER,
+      app_id TEXT
+    );
+
+    CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+
+    CREATE TABLE downloads (
+      id INTEGER PRIMARY KEY,
+      guid VARCHAR NOT NULL,
+      current_path LONGVARCHAR NOT NULL,
+      target_path LONGVARCHAR NOT NULL,
+      start_time INTEGER NOT NULL,
+      received_bytes INTEGER NOT NULL,
+      total_bytes INTEGER NOT NULL,
+      state INTEGER NOT NULL,
+      danger_type INTEGER NOT NULL,
+      interrupt_reason INTEGER NOT NULL,
+      hash BLOB NOT NULL,
+      end_time INTEGER NOT NULL,
+      opened INTEGER NOT NULL,
+      last_access_time INTEGER NOT NULL,
+      transient INTEGER NOT NULL,
+      referrer VARCHAR NOT NULL,
+      site_url VARCHAR NOT NULL,
+      tab_url VARCHAR NOT NULL,
+      tab_referrer_url VARCHAR NOT NULL,
+      http_method VARCHAR NOT NULL,
+      by_ext_id VARCHAR NOT NULL,
+      by_ext_name VARCHAR NOT NULL,
+      by_web_app_id VARCHAR NOT NULL,
+      etag VARCHAR NOT NULL,
+      last_modified VARCHAR NOT NULL,
+      mime_type VARCHAR(255) NOT NULL,
+      original_mime_type VARCHAR(255) NOT NULL
+    );
+
+    CREATE TABLE downloads_url_chains (
+      id INTEGER NOT NULL,
+      chain_index INTEGER NOT NULL,
+      url LONGVARCHAR NOT NULL,
+      PRIMARY KEY (id, chain_index)
+    );
+
+    INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+    VALUES (1, 'https://tab.example/dl', 'Download page', 1, 0, ${windowsMicros(
+      1_704_164_600n,
+    )}, 0);
+
+    INSERT INTO visits
+      (id, url, visit_time, from_visit, transition, visit_duration)
+    VALUES (1, 1, ${windowsMicros(1_704_164_600n)}, 0, 0, 0);
+  `);
+}
+
+function insertDownload(database: DatabaseSync, row: DownloadRow): void {
+  database
+    .prepare(
+      `INSERT INTO downloads
+         (id, guid, current_path, target_path, start_time, received_bytes,
+          total_bytes, state, danger_type, interrupt_reason, hash, end_time,
+          opened, last_access_time, transient, referrer, site_url, tab_url,
+          tab_referrer_url, http_method, by_ext_id, by_ext_name, by_web_app_id,
+          etag, last_modified, mime_type, original_mime_type)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      row.id,
+      `guid-${row.id.toString()}`,
+      row.targetPath,
+      row.targetPath,
+      row.startTime,
+      row.receivedBytes,
+      row.totalBytes,
+      row.state,
+      row.dangerType,
+      row.interruptReason,
+      row.hash,
+      row.endTime,
+      row.opened,
+      0n,
+      0n,
+      row.referrer,
+      "https://tab.example",
+      "https://tab.example/dl",
+      "",
+      "GET",
+      "",
+      "",
+      "",
+      "",
+      "",
+      row.mimeType,
+      row.mimeType,
+    );
+  const insertChain = database.prepare(
+    "INSERT INTO downloads_url_chains (id, chain_index, url) VALUES (?, ?, ?)",
+  );
+  row.chain.forEach((url, index) => {
+    insertChain.run(row.id, BigInt(index), url);
+  });
+}
+
+async function createHistory(
+  path: string,
+  rows: readonly DownloadRow[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    createHistorySchema(database);
+    for (const row of rows) {
+      insertDownload(database, row);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+const CONTENT_HASH = Uint8Array.from(
+  Array.from({ length: 32 }, (_value, index) => index),
+);
+const CONTENT_HASH_HEX =
+  "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"), [
+    {
+      id: 1n,
+      targetPath: "/home/alice/Downloads/report.pdf",
+      startTime: windowsMicros(1_704_164_645n), // 2024-01-02T03:04:05Z
+      endTime: windowsMicros(1_704_164_650n),
+      receivedBytes: 1024n,
+      totalBytes: 1024n,
+      state: 1n, // complete
+      dangerType: 0n, // not_dangerous
+      interruptReason: 0n, // none
+      hash: CONTENT_HASH,
+      opened: 1n,
+      referrer: "https://referrer.example/page",
+      mimeType: "application/pdf",
+      chain: [
+        "https://start.example/a",
+        "https://redir.example/b",
+        "https://cdn.example/report.pdf",
+      ],
+    },
+    {
+      id: 2n,
+      targetPath: "/home/alice/Downloads/malware.exe",
+      startTime: windowsMicros(1_704_164_655n), // 2024-01-02T03:04:15Z
+      endTime: 0n, // never finished -> absent
+      receivedBytes: 500n,
+      totalBytes: 2000n,
+      state: 4n, // interrupted
+      dangerType: 7n, // dangerous_host
+      interruptReason: 20n, // network_failed
+      hash: new Uint8Array(0), // no content hash yet
+      opened: 0n,
+      referrer: "https://evil.example/landing",
+      mimeType: "application/x-msdownload",
+      chain: ["https://evil.example/malware.exe"],
+    },
+  ]);
+  await createHistory(join(source, "Profile 1", "History"), [
+    {
+      id: 1n,
+      targetPath: "/home/alice/Downloads/photo.jpg",
+      startTime: windowsMicros(1_704_164_665n), // 2024-01-02T03:04:25Z
+      endTime: windowsMicros(1_704_164_666n),
+      receivedBytes: 2048n,
+      totalBytes: 2048n,
+      state: 1n,
+      dangerType: 0n,
+      interruptReason: 0n,
+      hash: CONTENT_HASH,
+      opened: 1n,
+      referrer: "https://pics.example/gallery",
+      mimeType: "image/jpeg",
+      chain: ["https://pics.example/photo.jpg"],
+    },
+  ]);
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Downloads findings", () => {
+  it("decodes downloads and URL chains across Profiles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-dl-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const defaultBytes = await readFile(join(source, "Default", "History"));
+    const caseDirectory = join(root, "CASE-DL");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "America/New_York",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      // AC6: Downloads live in History but are their own artifact; History
+      // visits stay usable alongside a complete Downloads result.
+      history: { status: "complete", analysedProfileCount: 2 },
+      downloads: {
+        status: "complete",
+        profileCount: 2,
+        analysedProfileCount: 2,
+        unavailableProfileCount: 0,
+        committedDownloadCount: 3,
+        recoveredDownloadCount: 0,
+      },
+    });
+
+    // AC5: bounded, multi-Profile keyset pagination ordered by start time.
+    const firstPage = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "start-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage).toMatchObject({ command: "downloads", limit: 2 });
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const [report, malware] = firstPage.items;
+    expect(report).toBeDefined();
+    // AC1 + AC3: exact target path/state; one Field State each; Commit State;
+    // Provenance resolvable to the exact downloads rowid and chain rows.
+    expect(report).toMatchObject({
+      recordType: "finding",
+      findingKind: "download",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/History",
+        database: "Default/History",
+        table: "downloads",
+        rowId: "1",
+      },
+      fields: {
+        targetPath: {
+          state: "value",
+          value: "/home/alice/Downloads/report.pdf",
+        },
+        state: { state: "value", value: "complete" },
+        stateRaw: { state: "value", value: "1" },
+        dangerType: { state: "value", value: "not_dangerous" },
+        dangerTypeRaw: { state: "value", value: "0" },
+        interruptReason: { state: "value", value: "none" },
+        interruptReasonRaw: { state: "value", value: "0" },
+        receivedBytes: { state: "value", value: "1024" },
+        totalBytes: { state: "value", value: "1024" },
+        opened: { state: "value", value: true },
+        mimeType: { state: "value", value: "application/pdf" },
+        referrer: { state: "value", value: "https://referrer.example/page" },
+      },
+    });
+    // AC1: URL-chain relationships preserved, ordered, with per-hop Provenance.
+    expect(report?.fields.urlChain).toEqual({
+      state: "value",
+      value: [
+        "https://start.example/a",
+        "https://redir.example/b",
+        "https://cdn.example/report.pdf",
+      ],
+    });
+    expect(report?.fields.originalUrl).toEqual({
+      state: "value",
+      value: "https://start.example/a",
+    });
+    expect(report?.fields.finalUrl).toEqual({
+      state: "value",
+      value: "https://cdn.example/report.pdf",
+    });
+    expect(report?.fields.urlChainLength).toEqual({
+      state: "value",
+      value: "3",
+    });
+    expect(report?.provenance.supportingRows).toEqual([
+      {
+        manifestEntryId: expect.any(String),
+        sourceId: expect.any(String),
+        manifestEntryOrdinal: expect.any(Number),
+        manifestPath: "Default/History",
+        database: "Default/History",
+        table: "downloads_url_chains",
+        rowId: "1:0",
+      },
+      {
+        manifestEntryId: expect.any(String),
+        sourceId: expect.any(String),
+        manifestEntryOrdinal: expect.any(Number),
+        manifestPath: "Default/History",
+        database: "Default/History",
+        table: "downloads_url_chains",
+        rowId: "1:1",
+      },
+      {
+        manifestEntryId: expect.any(String),
+        sourceId: expect.any(String),
+        manifestEntryOrdinal: expect.any(Number),
+        manifestPath: "Default/History",
+        database: "Default/History",
+        table: "downloads_url_chains",
+        rowId: "1:2",
+      },
+    ]);
+    // AC4: timestamp keeps raw value, Epoch Family (1601-us), and UTC.
+    expect(report?.fields.startTime).toEqual({
+      state: "value",
+      synthetic: false,
+      value: {
+        raw: windowsMicros(1_704_164_645n).toString(),
+        epochFamily: "1601-us",
+        utc: "2024-01-02T03:04:05.000000Z",
+        declaredTimezone: "America/New_York",
+        resolution: "verified_history_schema_version_74",
+      },
+    });
+    // AC2: the content hash BLOB is rendered as reviewable hex, never base64.
+    expect(report?.fields.contentSha256).toEqual({
+      state: "value",
+      value: CONTENT_HASH_HEX,
+    });
+    expect(report?.fields.contentHashByteLength).toEqual({
+      state: "value",
+      value: "32",
+    });
+
+    // AC2: decoded danger/interrupt/state on the interrupted download retain
+    // their raw codes; a never-finished download has an absent end time and an
+    // absent (not blank) content hash.
+    expect(malware).toMatchObject({
+      profile: "Default",
+      fields: {
+        state: { state: "value", value: "interrupted" },
+        stateRaw: { state: "value", value: "4" },
+        dangerType: { state: "value", value: "dangerous_host" },
+        dangerTypeRaw: { state: "value", value: "7" },
+        interruptReason: { state: "value", value: "network_failed" },
+        interruptReasonRaw: { state: "value", value: "20" },
+      },
+    });
+    expect(malware?.fields.endTime).toEqual({ state: "absent" });
+    expect(malware?.fields.contentSha256).toEqual({ state: "absent" });
+    expect(malware?.fields.contentHashByteLength).toEqual({
+      state: "value",
+      value: "0",
+    });
+
+    const secondPage = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "start-time",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    expect(secondPage.items).toHaveLength(1);
+    expect(secondPage.items[0]?.profile).toBe("Profile 1");
+    const allIds = [...firstPage.items, ...secondPage.items].map(
+      (item) => `${item.profile}:${item.provenance.rowId}`,
+    );
+    expect(new Set(allIds).size).toBe(3);
+
+    // Filter surface: state and danger-type filters return exact subsets.
+    const interrupted = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--state",
+        "interrupted",
+        "--json",
+      ]).stdout,
+    );
+    expect(interrupted.items).toHaveLength(1);
+    expect(interrupted.items[0]?.fields.targetPath).toEqual({
+      state: "value",
+      value: "/home/alice/Downloads/malware.exe",
+    });
+    const dangerous = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--danger",
+        "dangerous_host",
+        "--json",
+      ]).stdout,
+    );
+    expect(dangerous.items).toHaveLength(1);
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(source, "Default", "History"))).toEqual(
+      defaultBytes,
+    );
+  });
+
+  it("keeps committed and WAL-resident downloads separate", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-dl-wal-"));
+    temporaryRoots.push(root);
+    const source = join(root, "wal-source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const historyPath = join(source, "Default", "History");
+    await createHistory(historyPath, [
+      {
+        id: 1n,
+        targetPath: "/home/alice/Downloads/committed.pdf",
+        startTime: windowsMicros(1_704_164_645n),
+        endTime: windowsMicros(1_704_164_650n),
+        receivedBytes: 10n,
+        totalBytes: 10n,
+        state: 1n,
+        dangerType: 0n,
+        interruptReason: 0n,
+        hash: CONTENT_HASH,
+        opened: 1n,
+        referrer: "https://referrer.example/a",
+        mimeType: "application/pdf",
+        chain: ["https://cdn.example/committed.pdf"],
+      },
+    ]);
+
+    const writer = new DatabaseSync(historyPath);
+    writer.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA wal_autocheckpoint = 0;
+      PRAGMA wal_checkpoint(TRUNCATE);
+    `);
+    insertDownload(writer, {
+      id: 2n,
+      targetPath: "/home/alice/Downloads/wal-only.zip",
+      startTime: windowsMicros(1_704_164_700n),
+      endTime: windowsMicros(1_704_164_705n),
+      receivedBytes: 20n,
+      totalBytes: 20n,
+      state: 1n,
+      dangerType: 0n,
+      interruptReason: 0n,
+      hash: CONTENT_HASH,
+      opened: 0n,
+      referrer: "https://referrer.example/b",
+      mimeType: "application/zip",
+      chain: ["https://cdn.example/wal-only.zip"],
+    });
+
+    const caseDirectory = join(root, "CASE-DL-WAL");
+    try {
+      expect(
+        runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+      ).toBe(0);
+    } finally {
+      writer.close();
+    }
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      downloads: { committedDownloadCount: 1, recoveredDownloadCount: 1 },
+    });
+
+    const committed = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "committed",
+        "--json",
+      ]).stdout,
+    );
+    expect(committed.items).toHaveLength(1);
+    expect(committed.items[0]).toMatchObject({
+      commitState: "committed",
+      provenance: { manifestPath: "Default/History" },
+      fields: {
+        targetPath: {
+          state: "value",
+          value: "/home/alice/Downloads/committed.pdf",
+        },
+      },
+    });
+
+    const recovered = parseJson<DownloadPage>(
+      runCli([
+        "downloads",
+        "--case",
+        caseDirectory,
+        "--commit-state",
+        "wal_resident",
+        "--json",
+      ]).stdout,
+    );
+    expect(recovered.items).toHaveLength(1);
+    expect(recovered.items[0]).toMatchObject({
+      commitState: "wal_resident",
+      provenance: {
+        manifestPath: "Default/History-wal",
+        database: "Default/History",
+        table: "downloads",
+      },
+      fields: {
+        targetPath: {
+          state: "value",
+          value: "/home/alice/Downloads/wal-only.zip",
+        },
+      },
+    });
+  });
+
+  it("reports Downloads unavailable without suppressing usable History", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-dl-bad-"));
+    temporaryRoots.push(root);
+    const source = join(root, "bad-source");
+    await mkdir(join(source, "Default"), { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    // A History database with visits but no downloads table.
+    const historyPath = join(source, "Default", "History");
+    const database = new DatabaseSync(historyPath);
+    try {
+      database.exec(`
+        CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+        INSERT INTO meta (key, value) VALUES ('version', '74'), ('last_compatible_version', '16');
+        CREATE TABLE urls (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, url LONGVARCHAR, title LONGVARCHAR,
+          visit_count INTEGER DEFAULT 0 NOT NULL, typed_count INTEGER DEFAULT 0 NOT NULL,
+          last_visit_time INTEGER NOT NULL, hidden INTEGER DEFAULT 0 NOT NULL
+        );
+        CREATE TABLE visits (
+          id INTEGER PRIMARY KEY AUTOINCREMENT, url INTEGER NOT NULL,
+          visit_time INTEGER NOT NULL, from_visit INTEGER,
+          external_referrer_url TEXT, transition INTEGER DEFAULT 0 NOT NULL,
+          segment_id INTEGER, visit_duration INTEGER DEFAULT 0 NOT NULL,
+          incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+          opener_visit INTEGER, originator_cache_guid TEXT, originator_visit_id INTEGER,
+          originator_from_visit INTEGER, originator_opener_visit INTEGER,
+          is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+          consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+          visited_link_id INTEGER, app_id TEXT
+        );
+        CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+        INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+        VALUES (1, 'https://kept.example/', 'Kept', 1, 0, ${windowsMicros(
+          1_704_164_600n,
+        )}, 0);
+        INSERT INTO visits (id, url, visit_time, from_visit, transition, visit_duration)
+        VALUES (1, 1, ${windowsMicros(1_704_164_600n)}, 0, 0, 0);
+      `);
+    } finally {
+      database.close();
+    }
+
+    const caseDirectory = join(root, "CASE-DL-BAD");
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // History is complete; a History database with no downloads table carries
+    // no download evidence, so Downloads is `absent` (inapplicable), not
+    // `unavailable`. Absent evidence never degrades an otherwise clean run, so
+    // the run stays complete (exit 0) and usable History is never suppressed.
+    expect(analysis.status).toBe(0);
+    const parsed = parseJson<{
+      readonly history: {
+        readonly status: string;
+        readonly analysedProfileCount: number;
+      };
+      readonly downloads: {
+        readonly status: string;
+        readonly analysedProfileCount: number;
+        readonly absentProfileCount: number;
+        readonly unavailableProfileCount: number;
+      };
+    }>(analysis.stdout);
+    expect(parsed.history).toMatchObject({
+      status: "complete",
+      analysedProfileCount: 1,
+    });
+    expect(parsed.downloads).toMatchObject({
+      status: "complete",
+      analysedProfileCount: 0,
+      absentProfileCount: 1,
+      unavailableProfileCount: 0,
+    });
+
+    // History visits remain queryable.
+    const history = parseJson<{ readonly items: readonly unknown[] }>(
+      runCli(["history", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(history.items.length).toBeGreaterThanOrEqual(1);
+
+    // The Downloads query returns an empty page (no active result), not an error.
+    const downloads = parseJson<DownloadPage>(
+      runCli(["downloads", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(downloads.items).toHaveLength(0);
+
+    // The typed reason names the missing downloads table in the Case.
+    const caseDatabase = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readOnly: true,
+    });
+    try {
+      const row = caseDatabase
+        .prepare(
+          `SELECT status, reason FROM downloads_artifact_results
+            WHERE profile_path = 'Default'`,
+        )
+        .get() as { readonly status: string; readonly reason: string };
+      expect(row.status).toBe("absent");
+      expect(row.reason).toContain("missing the downloads table");
+    } finally {
+      caseDatabase.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #179.

Downloads live in the History database. This adds a **Downloads** artifact that parses the `downloads` and `downloads_url_chains` tables across every Profile, mirroring the established Findings contract (History / Cookies / Web Data / Top Sites). Analyzer and Collector stay separate and offline; the Case remains the record of truth.

### New modules (mirror the web-data trio)
- `core/src/downloads-sqlite.ts` — verified snapshot + committed/recovered passes over the shared History file and its WAL/rollback-journal sidecars; column-presence schema detection; exact value preservation.
- `core/src/downloads.ts` — builds `download` Findings with decoded forensic meaning.
- `core/src/downloads-query.ts` — bounded `queryDownloads` surface.
- Wired into `case-findings.ts` (schema + persistence + exit-state), `history.ts` (`analyseCase` + summary), `index.ts`, and the `forensix downloads` CLI command.

### Acceptance criteria → implementation
- **Parse current download schemas + URL-chain relationships across every Profile** — reads `downloads` joined with its ordered `downloads_url_chains`; per-Profile artifact results; `originalUrl` / `finalUrl` / `urlChain` / `urlChainLength` with per-hop Provenance (`downloads_url_chains` rows `id:chain_index`).
- **URLs / target paths / states / interrupt reasons / danger types / timestamps exact vs ground truth** — `target_path`, `current_path`, `referrer`, `site_url`, `tab_url`, sizes, MIME types, etc. preserved exactly; `state`, `danger_type`, `interrupt_reason` decoded against the canonical Chromium enums (`DownloadState`, `DownloadDangerType`, `DownloadInterruptReason`).
- **Decoded values RETAIN the underlying raw value** — every decoded field ships a companion `*Raw` field (`stateRaw`, `dangerTypeRaw`, `interruptReasonRaw`); an unmapped code keeps the raw value and marks the decoded field `unavailable` rather than guessing.
- **Every row preserves Field State, Provenance, Commit State, full timestamp semantics** — distinct `value` / `absent` / `unavailable`; timestamps are `base::Time` internal (1601-us) with raw + Epoch Family + UTC + declared timezone; committed vs `wal_resident` / `journal_resident` kept separate.
- **Broken inputs produce reasoned unavailability without suppressing usable History** — a corrupt/unreadable History DB is `unavailable` with a typed reason; a History DB **with no `downloads` table** is `absent` (inapplicable) so it never degrades an otherwise clean run, and History visits stay fully queryable alongside it.
- **Bounded query surface** — `forensix downloads` with search, `--profile` (multi, ≤100), `--commit-state`, `--state`, `--danger`, `--sort` (start/end time, target path, state, total bytes, profile), `--direction`, `--limit` (1–100), and fingerprinted keyset `--after` pagination.

Binary payload handling: the `downloads.hash` BLOB (the file's SHA-256) is rendered as reviewable lowercase hex plus byte length — never base64-smuggled into a row.

### Tests
`e2e/downloads-cli.test.ts` (compiled-CLI): decoding + URL chains + timestamps + hash-as-hex across Profiles with keyset pagination and state/danger filters; committed vs WAL-resident separation with sidecar Provenance; and a missing-downloads-table Profile that stays `absent` while History remains complete and queryable.

`pnpm verify` is green (format:check, lint, typecheck, 109/109 vitest).