### PR TITLE
feat(bookmarks): parse Bookmarks and backup Bookmarks as Findings

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -10,6 +10,7 @@ import {
   exportCase,
   ingestSource,
   queryAutofill,
+  queryBookmarks,
   queryCookies,
   queryCredentials,
   queryDownloads,
@@ -20,6 +21,9 @@ import {
   renderReport,
   type AutofillDirection,
   type AutofillSort,
+  type BookmarkDirection,
+  type BookmarkSort,
+  type BookmarkSource,
   type CommitState,
   type CookieDirection,
   type CookieSort,
@@ -100,6 +104,13 @@ const USAGE = `Usage:
                    [--type <browser_metadata|profile_metadata>]
                    [--sort <type|profile>] [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
+  forensix bookmarks --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--source <primary|backup>]
+                   [--sort <name|url|date-added|folder|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
   forensix serve --case <case-directory> [--port <port>] [--json]
   forensix export --case <case-directory> --out <output-directory>
                    [--collection <findings|candidates>]... [--profile <profile>]...
@@ -151,6 +162,7 @@ const VALUE_OPTIONS = new Set([
   "--state",
   "--danger",
   "--type",
+  "--source",
   "--sort",
   "--direction",
   "--limit",
@@ -574,6 +586,57 @@ async function run(arguments_: readonly string[]): Promise<number> {
         | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | MetadataDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "bookmarks") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--source",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The bookmarks command accepts no positional values.",
+      );
+    }
+    const result = queryBookmarks({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      source: enumOption(parsed, "--source", ["primary", "backup"] as const) as
+        | BookmarkSource
+        | undefined,
+      sort: enumOption(parsed, "--sort", [
+        "name",
+        "url",
+        "date-added",
+        "folder",
+        "profile",
+      ] as const) as BookmarkSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | BookmarkDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/bookmarks-query.ts
+++ b/core/src/bookmarks-query.ts
@@ -1,0 +1,408 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createFinding,
+  type CommitState,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type BookmarkDirection = "asc" | "desc";
+export type BookmarkSort = "name" | "url" | "date-added" | "folder" | "profile";
+/** Primary `Bookmarks` vs backup `Bookmarks.bak`, exposed as a CLI filter. */
+export type BookmarkSource = "primary" | "backup";
+
+export interface BookmarkQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  readonly source?: BookmarkSource;
+  readonly sort?: BookmarkSort;
+  readonly direction?: BookmarkDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface BookmarkPage {
+  readonly status: "ok";
+  readonly command: "bookmarks";
+  readonly items: readonly Finding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly findingId: string;
+}
+
+interface QueryRow {
+  readonly finding_id: bigint;
+  readonly finding_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const BOOKMARK_DIRECTIONS = ["asc", "desc"] as const;
+const BOOKMARK_SORTS = [
+  "name",
+  "url",
+  "date-added",
+  "folder",
+  "profile",
+] as const;
+const BOOKMARK_SOURCES = ["primary", "backup"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+const BOOKMARK_KIND = "bookmark";
+
+const SOURCE_FILES: Readonly<Record<BookmarkSource, string>> = {
+  primary: "Bookmarks",
+  backup: "Bookmarks.bak",
+};
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+// `date-added` keys on the integer `sort_date_added` column (WebKit microseconds,
+// with a -1 COALESCE sentinel so keys can be negative); every other sort keys on
+// text. The `kind` tag drives the cursor-key validation below, mirroring
+// top-sites-query.ts so the integer/text decision lives in one place.
+const SORTS: Readonly<Record<BookmarkSort, SortDefinition>> = {
+  name: { expression: "COALESCE(f.sort_name, '')", kind: "text" },
+  url: { expression: "COALESCE(f.sort_url, '')", kind: "text" },
+  "date-added": {
+    expression: "COALESCE(f.sort_date_added, -1)",
+    kind: "integer",
+  },
+  folder: { expression: "COALESCE(f.sort_folder, '')", kind: "text" },
+  profile: { expression: "f.profile_path", kind: "text" },
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly source: BookmarkSource | null;
+  readonly sort: BookmarkSort;
+  readonly direction: BookmarkDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Bookmarks cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("findingId" in parsed) ||
+    typeof parsed.findingId !== "string" ||
+    !/^[0-9]+$/.test(parsed.findingId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Bookmarks cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Bookmarks --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Bookmarks ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM bookmarks_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function bookmarkSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'bookmarks_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseFinding(row: QueryRow): Finding {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Bookmark Finding JSON.",
+      { finding_id: row.finding_id.toString() },
+      { cause: error },
+    );
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { finding_id: row.finding_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryBookmarks(input: BookmarkQuery): BookmarkPage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    BOOKMARK_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "name", BOOKMARK_SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const source =
+    input.source === undefined
+      ? null
+      : enumValue(input.source, "primary", BOOKMARK_SOURCES, "--source");
+  const sortDefinition = SORTS[sort];
+  const sortExpression = sortDefinition.expression;
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Bookmarks queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!bookmarkSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Bookmarks analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      source,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "f.finding_kind = ?",
+      "f.record_type = 'finding'",
+    ];
+    const parameters: (string | bigint)[] = [BOOKMARK_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `f.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("f.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (source !== null) {
+      conditions.push("f.source_file = ?");
+      parameters.push(SOURCE_FILES[source]);
+    }
+    if (search !== null) {
+      conditions.push("instr(f.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND f.finding_id ${operator} ?))`,
+      );
+      const findingId = BigInt(cursor.findingId);
+      // An integer sort validates its key with the same regex and int64 range
+      // guard History and Top Sites use, so a forged or out-of-range cursor
+      // surfaces a typed INVALID_CURSOR instead of a raw node:sqlite throw.
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        findingId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Bookmarks cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, findingId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT f.finding_id, f.finding_kind, f.profile_path,
+                f.commit_state, f.provenance_json, f.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM bookmarks_findings f
+           JOIN bookmarks_artifact_results r
+             ON r.artifact_result_id = f.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   f.finding_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "bookmarks",
+      items: pageRows.map(parseFinding),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              findingId: last.finding_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/bookmarks.ts
+++ b/core/src/bookmarks.ts
@@ -14,7 +14,7 @@ import {
   type Provenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
-import { readVerifiedJsonFile, resolveJsonFile } from "./preferences-json.js";
+import { readVerifiedJsonFile, resolveJsonFile } from "./working-copy-json.js";
 import {
   WINDOWS_EPOCH_OFFSET_MICROS,
   utcFromUnixMicros,
@@ -261,13 +261,15 @@ type DocumentParse =
 /**
  * Parse a top-level Bookmarks document. A document that parsed as JSON but has
  * no `roots` object is structurally unsupported (typed `unavailable`), distinct
- * from a byte-level parse failure. Roots are walked in the conventional
+ * from a byte-level parse failure. The returned reason is a bare suffix; the
+ * caller prefixes it with the per-file label so primary and backup stay
+ * distinguishable by reason string. Roots are walked in the conventional
  * `bookmark_bar`, `other`, `synced` order first, then any remaining roots in
  * sorted order, so Finding ordering is deterministic across runs.
  */
 function parseDocument(document: unknown, context: WalkContext): DocumentParse {
   if (!isObject(document) || !isObject(document.roots)) {
-    return { kind: "unsupported", reason: "bookmarks_unsupported_shape" };
+    return { kind: "unsupported", reason: "unsupported_shape" };
   }
   const roots = document.roots;
   const remaining = Object.keys(roots)
@@ -375,7 +377,7 @@ async function analyseBookmarkFile(options: {
       databasePath,
       ordinal: resolution.ordinal,
       status: "unavailable",
-      reason: parsed.reason,
+      reason: `${label}_${parsed.reason}`,
     });
   }
 

--- a/core/src/bookmarks.ts
+++ b/core/src/bookmarks.ts
@@ -1,0 +1,512 @@
+import { join } from "node:path";
+
+import type {
+  BookmarksArtifactWrite,
+  BookmarkSourceFile,
+  PersistedBookmarkFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import {
+  absentField,
+  createFinding,
+  unavailableField,
+  valueField,
+  type FieldState,
+  type Finding,
+  type Provenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import {
+  readVerifiedJsonFile,
+  type VerifiedJsonFile,
+} from "./preferences-json.js";
+
+/**
+ * Chrome stores Bookmarks as a JSON document (not SQLite). Every Profile has a
+ * primary `Bookmarks` file and Chrome writes a `Bookmarks.bak` snapshot of the
+ * previous on-disk state whenever it rewrites the primary. The two files are
+ * separate evidence: this module parses each into its own artifact so the
+ * primary and backup records keep distinct Provenance and are never merged.
+ */
+
+export const BOOKMARK_KIND = "bookmark";
+
+/**
+ * Chrome writes every Bookmarks date field as microseconds since 1601-01-01 UTC
+ * (the WebKit / `base::Time` internal epoch), rendered as a decimal string, on
+ * every platform. The epoch is fixed, so no Declared Origin OS is required to
+ * resolve it.
+ */
+const BOOKMARKS_EPOCH_FAMILY = "1601-us" as const;
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+/** The two Bookmarks evidence files, in their canonical relative filenames. */
+const BOOKMARK_SOURCE_FILES = [
+  "Bookmarks",
+  "Bookmarks.bak",
+] as const satisfies readonly BookmarkSourceFile[];
+
+/** The conventional Chrome bookmark roots, walked first for stable ordering. */
+const PREFERRED_ROOT_KEYS = ["bookmark_bar", "other", "synced"] as const;
+
+interface ManifestIdentity {
+  readonly sourceId: string;
+  readonly ordinal: number;
+  readonly path: string;
+}
+
+interface WalkContext {
+  readonly profile: string;
+  readonly sourceFile: BookmarkSourceFile;
+  readonly manifest: ManifestIdentity;
+  readonly declaredTimezone: string;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function floorDivision(value: bigint, divisor: bigint): bigint {
+  const quotient = value / divisor;
+  const remainder = value % divisor;
+  return remainder < 0n ? quotient - 1n : quotient;
+}
+
+function utcFromUnixMicros(unixMicros: bigint): string | null {
+  const seconds = floorDivision(unixMicros, 1_000_000n);
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = seconds * 1000n + micros / 1000n;
+  const numericMilliseconds = Number(milliseconds);
+  if (!Number.isSafeInteger(numericMilliseconds)) {
+    return null;
+  }
+  const date = new Date(numericMilliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  const base = date.toISOString();
+  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
+}
+
+/**
+ * A Bookmarks string field. A missing or explicitly `null` value is `absent`; a
+ * present value of the wrong type is `unavailable` with a typed reason so a
+ * malformed entry is never mistaken for a removed one.
+ */
+function stringField(value: unknown): FieldState<string> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  return typeof value === "string"
+    ? valueField(value)
+    : unavailableField("unsupported_value");
+}
+
+/**
+ * Resolve a Bookmarks WebKit-epoch date field. A missing value or the Chrome
+ * "never" sentinel `"0"` is `absent`; a non-numeric-string value is
+ * `unavailable`; an out-of-range instant is `unavailable`. A resolved value
+ * keeps the exact raw string, the fixed epoch family, and the derived UTC.
+ */
+function timestampField(
+  value: unknown,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (value === undefined || value === null) {
+    return absentField();
+  }
+  if (typeof value !== "string" || !/^-?[0-9]+$/.test(value)) {
+    return unavailableField("unsupported_value");
+  }
+  const micros = BigInt(value);
+  if (micros === 0n) {
+    return absentField();
+  }
+  const utc = utcFromUnixMicros(micros - WINDOWS_EPOCH_OFFSET_MICROS);
+  if (utc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: value,
+      epochFamily: BOOKMARKS_EPOCH_FAMILY,
+      utc,
+      declaredTimezone,
+      resolution: "webkit_bookmarks_epoch",
+    },
+    { synthetic: false },
+  );
+}
+
+function optionalString(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value;
+  }
+  return typeof value === "number" && Number.isInteger(value)
+    ? value.toString()
+    : undefined;
+}
+
+function buildBookmark(options: {
+  readonly node: Record<string, unknown>;
+  readonly ancestry: readonly string[];
+  readonly rootKey: string;
+  readonly context: WalkContext;
+  readonly index: number;
+}): PersistedBookmarkFinding {
+  const { node, ancestry, rootKey, context } = options;
+  const id = optionalString(node.id);
+  const guid = optionalString(node.guid);
+  const rowId = id ?? guid ?? `${context.sourceFile}#${options.index}`;
+
+  const provenance: Provenance = {
+    manifestEntryId: `${context.manifest.sourceId}:${context.manifest.ordinal}`,
+    sourceId: context.manifest.sourceId,
+    manifestEntryOrdinal: context.manifest.ordinal,
+    manifestPath: context.manifest.path,
+    database: context.manifest.path,
+    table: "bookmarks",
+    rowId,
+  };
+
+  const name = stringField(node.name);
+  const url = stringField(node.url);
+  const dateAdded = timestampField(node.date_added, context.declaredTimezone);
+  const dateLastUsed = timestampField(
+    node.date_last_used,
+    context.declaredTimezone,
+  );
+  const folderPath = ancestry.join(" / ");
+  const parentFolder =
+    ancestry.length > 0
+      ? valueField(ancestry[ancestry.length - 1] as string)
+      : absentField();
+
+  const fields = {
+    bookmarkId: id === undefined ? absentField() : valueField(id),
+    guid: guid === undefined ? absentField() : valueField(guid),
+    name,
+    url,
+    dateAdded,
+    dateLastUsed,
+    sourceFile: valueField(context.sourceFile),
+    rootFolder: valueField(rootKey),
+    parentFolder,
+    folderPath: valueField(folderPath, { synthetic: true }),
+  };
+
+  const finding: Finding = createFinding({
+    findingKind: BOOKMARK_KIND,
+    profile: context.profile,
+    commitState: "committed",
+    provenance,
+    fields,
+  });
+
+  const nameValue = name.state === "value" ? name.value : null;
+  const urlValue = url.state === "value" ? url.value : null;
+  return {
+    finding,
+    searchText: [
+      context.profile,
+      nameValue ?? "",
+      urlValue ?? "",
+      folderPath,
+      context.sourceFile,
+    ]
+      .join("\n")
+      .toLocaleLowerCase("en-US"),
+    sourceFile: context.sourceFile,
+    sortName: nameValue,
+    sortUrl: urlValue,
+    sortDateAdded:
+      dateAdded.state === "value" ? BigInt(dateAdded.value.raw) : null,
+    sortFolder: folderPath,
+  };
+}
+
+/**
+ * Depth-first walk of a Bookmarks node tree. A `folder` node contributes its
+ * name to the ancestry and recurses into its children; a `url` node yields one
+ * Finding carrying the full folder ancestry from the containing root. A node of
+ * an unknown type, or a non-object child, is skipped so that one corrupt entry
+ * never discards the rest of an otherwise defensible tree.
+ */
+function walkNode(options: {
+  readonly node: unknown;
+  readonly ancestry: readonly string[];
+  readonly rootKey: string;
+  readonly context: WalkContext;
+  readonly counter: { value: number };
+  readonly out: PersistedBookmarkFinding[];
+}): void {
+  const { node, ancestry, rootKey, context, counter, out } = options;
+  if (!isObject(node)) {
+    return;
+  }
+  if (node.type === "folder") {
+    const folderName =
+      typeof node.name === "string" && node.name.length > 0
+        ? node.name
+        : rootKey;
+    const childAncestry = [...ancestry, folderName];
+    if (Array.isArray(node.children)) {
+      for (const child of node.children) {
+        walkNode({
+          node: child,
+          ancestry: childAncestry,
+          rootKey,
+          context,
+          counter,
+          out,
+        });
+      }
+    }
+    return;
+  }
+  if (node.type === "url") {
+    counter.value += 1;
+    out.push(
+      buildBookmark({
+        node,
+        ancestry,
+        rootKey,
+        context,
+        index: counter.value,
+      }),
+    );
+  }
+}
+
+type DocumentParse =
+  | { readonly kind: "ok"; readonly findings: PersistedBookmarkFinding[] }
+  | { readonly kind: "unsupported"; readonly reason: string };
+
+/**
+ * Parse a top-level Bookmarks document. A document that parsed as JSON but has
+ * no `roots` object is structurally unsupported (typed `unavailable`), distinct
+ * from a byte-level parse failure. Roots are walked in the conventional
+ * `bookmark_bar`, `other`, `synced` order first, then any remaining roots in
+ * sorted order, so Finding ordering is deterministic across runs.
+ */
+function parseDocument(document: unknown, context: WalkContext): DocumentParse {
+  if (!isObject(document) || !isObject(document.roots)) {
+    return { kind: "unsupported", reason: "bookmarks_unsupported_shape" };
+  }
+  const roots = document.roots;
+  const remaining = Object.keys(roots)
+    .filter((key) => !PREFERRED_ROOT_KEYS.includes(key as never))
+    .sort();
+  const orderedKeys = [
+    ...PREFERRED_ROOT_KEYS.filter((key) => Object.hasOwn(roots, key)),
+    ...remaining,
+  ];
+  const out: PersistedBookmarkFinding[] = [];
+  const counter = { value: 0 };
+  for (const key of orderedKeys) {
+    walkNode({
+      node: roots[key],
+      ancestry: [],
+      rootKey: key,
+      context,
+      counter,
+      out,
+    });
+  }
+  return { kind: "ok", findings: out };
+}
+
+type FileResolution =
+  | {
+      readonly kind: "ready";
+      readonly file: VerifiedJsonFile;
+      readonly ordinal: number;
+    }
+  | {
+      readonly kind: "absent" | "unavailable";
+      readonly reason: string;
+      readonly ordinal: number | null;
+    };
+
+function resolveFile(options: {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+  readonly path: string;
+  readonly label: string;
+}): FileResolution {
+  const { source, workingCopyPath, path, label } = options;
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  if (ordinal < 0) {
+    return { kind: "absent", reason: `${label}_absent`, ordinal: null };
+  }
+  const entry = source.entries[ordinal];
+  if (entry === undefined || entry.state === "absent") {
+    return { kind: "absent", reason: `${label}_absent`, ordinal };
+  }
+  if (entry.state === "unavailable") {
+    return {
+      kind: "unavailable",
+      reason: `${label}_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+      ordinal,
+    };
+  }
+  if (!entry.copied) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_not_in_working_copy`,
+      ordinal,
+    };
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_manifest_representation_incomplete`,
+      ordinal,
+    };
+  }
+  return {
+    kind: "ready",
+    ordinal,
+    file: {
+      path: join(workingCopyPath, ...path.split("/")),
+      manifestPath: path,
+      size: entry.size,
+      sha256: entry.sha256,
+    },
+  };
+}
+
+function unavailableArtifact(options: {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly sourceFile: BookmarkSourceFile;
+  readonly databasePath: string;
+  readonly ordinal: number | null;
+  readonly status: "absent" | "unavailable";
+  readonly reason: string;
+}): BookmarksArtifactWrite {
+  return {
+    sourceId: options.sourceId,
+    profile: options.profile,
+    artifact: options.sourceFile,
+    status: options.status,
+    manifestEntryOrdinal: options.ordinal,
+    databasePath: options.databasePath,
+    reason: options.reason,
+    findings: [],
+    bookmarkCount: 0,
+  };
+}
+
+async function analyseBookmarkFile(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+  readonly sourceFile: BookmarkSourceFile;
+}): Promise<BookmarksArtifactWrite> {
+  const { source, profile, sourceFile } = options;
+  const databasePath =
+    profile === "." ? sourceFile : `${profile}/${sourceFile}`;
+  const label = sourceFile === "Bookmarks" ? "bookmarks" : "bookmarks_backup";
+  const resolution = resolveFile({
+    source,
+    workingCopyPath: options.workingCopyPath,
+    path: databasePath,
+    label,
+  });
+  if (resolution.kind !== "ready") {
+    return unavailableArtifact({
+      sourceId: source.sourceId,
+      profile,
+      sourceFile,
+      databasePath,
+      ordinal: resolution.ordinal,
+      status: resolution.kind,
+      reason: resolution.reason,
+    });
+  }
+
+  const read = await readVerifiedJsonFile(resolution.file);
+  if (read.status !== "parsed") {
+    return unavailableArtifact({
+      sourceId: source.sourceId,
+      profile,
+      sourceFile,
+      databasePath,
+      ordinal: resolution.ordinal,
+      status: "unavailable",
+      reason: `${label}_${read.reason}`,
+    });
+  }
+
+  const context: WalkContext = {
+    profile,
+    sourceFile,
+    manifest: {
+      sourceId: source.sourceId,
+      ordinal: resolution.ordinal,
+      path: databasePath,
+    },
+    declaredTimezone: options.declaredTimezone,
+  };
+  const parsed = parseDocument(read.value, context);
+  if (parsed.kind === "unsupported") {
+    return unavailableArtifact({
+      sourceId: source.sourceId,
+      profile,
+      sourceFile,
+      databasePath,
+      ordinal: resolution.ordinal,
+      status: "unavailable",
+      reason: parsed.reason,
+    });
+  }
+
+  return {
+    sourceId: source.sourceId,
+    profile,
+    artifact: sourceFile,
+    status: "complete",
+    manifestEntryOrdinal: resolution.ordinal,
+    databasePath,
+    reason: null,
+    findings: parsed.findings,
+    bookmarkCount: parsed.findings.length,
+  };
+}
+
+export interface BookmarksAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+}
+
+/**
+ * Parse the primary `Bookmarks` and backup `Bookmarks.bak` documents for every
+ * Profile into bookmark Findings. Each Profile yields two artifacts, one per
+ * file, so primary and backup evidence stays independently addressable: a
+ * missing expected file is `absent`, a byte-intact but malformed document is a
+ * typed `unavailable`, and the two never collapse into one record.
+ */
+export async function analyseSourceBookmarks(
+  input: BookmarksAnalysisInput,
+): Promise<BookmarksArtifactWrite[]> {
+  const artifacts: BookmarksArtifactWrite[] = [];
+  for (const profile of input.source.profiles) {
+    for (const sourceFile of BOOKMARK_SOURCE_FILES) {
+      artifacts.push(
+        await analyseBookmarkFile({
+          source: input.source,
+          profile: profile.path,
+          workingCopyPath: input.workingCopyPath,
+          declaredTimezone: input.declaredTimezone,
+          sourceFile,
+        }),
+      );
+    }
+  }
+  return artifacts;
+}
+
+export type { Finding as BookmarkFinding };

--- a/core/src/bookmarks.ts
+++ b/core/src/bookmarks.ts
@@ -1,5 +1,3 @@
-import { join } from "node:path";
-
 import type {
   BookmarksArtifactWrite,
   BookmarkSourceFile,
@@ -16,10 +14,11 @@ import {
   type Provenance,
 } from "./forensic-model.js";
 import type { ForensicTimestamp } from "./history.js";
+import { readVerifiedJsonFile, resolveJsonFile } from "./preferences-json.js";
 import {
-  readVerifiedJsonFile,
-  type VerifiedJsonFile,
-} from "./preferences-json.js";
+  WINDOWS_EPOCH_OFFSET_MICROS,
+  utcFromUnixMicros,
+} from "./forensic-time.js";
 
 /**
  * Chrome stores Bookmarks as a JSON document (not SQLite). Every Profile has a
@@ -38,7 +37,6 @@ export const BOOKMARK_KIND = "bookmark";
  * resolve it.
  */
 const BOOKMARKS_EPOCH_FAMILY = "1601-us" as const;
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
 
 /** The two Bookmarks evidence files, in their canonical relative filenames. */
 const BOOKMARK_SOURCE_FILES = [
@@ -64,28 +62,6 @@ interface WalkContext {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function floorDivision(value: bigint, divisor: bigint): bigint {
-  const quotient = value / divisor;
-  const remainder = value % divisor;
-  return remainder < 0n ? quotient - 1n : quotient;
-}
-
-function utcFromUnixMicros(unixMicros: bigint): string | null {
-  const seconds = floorDivision(unixMicros, 1_000_000n);
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = seconds * 1000n + micros / 1000n;
-  const numericMilliseconds = Number(milliseconds);
-  if (!Number.isSafeInteger(numericMilliseconds)) {
-    return null;
-  }
-  const date = new Date(numericMilliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  const base = date.toISOString();
-  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
 }
 
 /**
@@ -316,66 +292,6 @@ function parseDocument(document: unknown, context: WalkContext): DocumentParse {
   return { kind: "ok", findings: out };
 }
 
-type FileResolution =
-  | {
-      readonly kind: "ready";
-      readonly file: VerifiedJsonFile;
-      readonly ordinal: number;
-    }
-  | {
-      readonly kind: "absent" | "unavailable";
-      readonly reason: string;
-      readonly ordinal: number | null;
-    };
-
-function resolveFile(options: {
-  readonly source: CaseSourceRecord;
-  readonly workingCopyPath: string;
-  readonly path: string;
-  readonly label: string;
-}): FileResolution {
-  const { source, workingCopyPath, path, label } = options;
-  const ordinal = source.entries.findIndex((entry) => entry.path === path);
-  if (ordinal < 0) {
-    return { kind: "absent", reason: `${label}_absent`, ordinal: null };
-  }
-  const entry = source.entries[ordinal];
-  if (entry === undefined || entry.state === "absent") {
-    return { kind: "absent", reason: `${label}_absent`, ordinal };
-  }
-  if (entry.state === "unavailable") {
-    return {
-      kind: "unavailable",
-      reason: `${label}_unavailable:${entry.unavailable_reason ?? "unknown"}`,
-      ordinal,
-    };
-  }
-  if (!entry.copied) {
-    return {
-      kind: "unavailable",
-      reason: `${label}_not_in_working_copy`,
-      ordinal,
-    };
-  }
-  if (entry.size === null || entry.sha256 === null) {
-    return {
-      kind: "unavailable",
-      reason: `${label}_manifest_representation_incomplete`,
-      ordinal,
-    };
-  }
-  return {
-    kind: "ready",
-    ordinal,
-    file: {
-      path: join(workingCopyPath, ...path.split("/")),
-      manifestPath: path,
-      size: entry.size,
-      sha256: entry.sha256,
-    },
-  };
-}
-
 function unavailableArtifact(options: {
   readonly sourceId: string;
   readonly profile: string;
@@ -409,12 +325,12 @@ async function analyseBookmarkFile(options: {
   const databasePath =
     profile === "." ? sourceFile : `${profile}/${sourceFile}`;
   const label = sourceFile === "Bookmarks" ? "bookmarks" : "bookmarks_backup";
-  const resolution = resolveFile({
+  const resolution = resolveJsonFile(
     source,
-    workingCopyPath: options.workingCopyPath,
-    path: databasePath,
+    options.workingCopyPath,
+    databasePath,
     label,
-  });
+  );
   if (resolution.kind !== "ready") {
     return unavailableArtifact({
       sourceId: source.sourceId,

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -190,6 +190,36 @@ export interface FaviconArtifactWrite {
   readonly payloadFileCount: number;
 }
 
+export type BookmarkSourceFile = "Bookmarks" | "Bookmarks.bak";
+
+export interface PersistedBookmarkFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly sourceFile: BookmarkSourceFile;
+  readonly sortName: string | null;
+  readonly sortUrl: string | null;
+  readonly sortDateAdded: bigint | null;
+  readonly sortFolder: string | null;
+}
+
+export interface BookmarksArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  /**
+   * The Bookmarks evidence file backing this record. Chrome keeps a primary
+   * `Bookmarks` document and a `Bookmarks.bak` snapshot of the previous state;
+   * storing the filename here keeps the two scopes distinct so the primary and
+   * backup records are never silently merged.
+   */
+  readonly artifact: BookmarkSourceFile;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  readonly databasePath: string;
+  readonly reason: string | null;
+  readonly findings: readonly PersistedBookmarkFinding[];
+  readonly bookmarkCount: number;
+}
+
 export interface PersistedMetadataFinding {
   readonly finding: Finding;
   readonly searchText: string;
@@ -229,6 +259,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly faviconArtifacts?: readonly FaviconArtifactWrite[];
   readonly downloadsArtifacts?: readonly DownloadsArtifactWrite[];
   readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
+  readonly bookmarksArtifacts?: readonly BookmarksArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -757,6 +788,62 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON preferences_findings(finding_kind, sort_type, finding_id);
     CREATE INDEX IF NOT EXISTS preferences_findings_profile_query
       ON preferences_findings(finding_kind, sort_profile, finding_id);
+
+    CREATE TABLE IF NOT EXISTS bookmarks_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact IN ('Bookmarks', 'Bookmarks.bak')),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS bookmarks_one_active_result
+      ON bookmarks_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS bookmarks_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES bookmarks_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      source_file TEXT NOT NULL CHECK (source_file IN ('Bookmarks', 'Bookmarks.bak')),
+      sort_name TEXT,
+      sort_url TEXT,
+      sort_date_added INTEGER,
+      sort_folder TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS bookmarks_findings_name_query
+      ON bookmarks_findings(finding_kind, COALESCE(sort_name, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS bookmarks_findings_url_query
+      ON bookmarks_findings(finding_kind, COALESCE(sort_url, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS bookmarks_findings_date_added_query
+      ON bookmarks_findings(finding_kind, COALESCE(sort_date_added, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS bookmarks_findings_folder_query
+      ON bookmarks_findings(finding_kind, COALESCE(sort_folder, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS bookmarks_findings_profile_query
+      ON bookmarks_findings(finding_kind, source_file, profile_path, finding_id);
   `);
 }
 
@@ -993,11 +1080,39 @@ function insertMetadataFinding(
   );
 }
 
+function insertBookmarkFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedBookmarkFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sourceFile,
+    row.sortName,
+    row.sortUrl,
+    row.sortDateAdded,
+    row.sortFolder,
+  );
+}
+
 export function storeHistoryAnalysis(
   options: StoreHistoryAnalysisOptions,
 ): StoredHistoryAnalysis {
   const cookieArtifacts = options.cookieArtifacts ?? [];
   const metadataArtifacts = options.metadataArtifacts ?? [];
+  const bookmarksArtifacts = options.bookmarksArtifacts ?? [];
   const runId = randomUUID();
   const database = openDatabaseSync(
     join(resolve(options.caseDirectory), CASE_FILENAME),
@@ -1225,6 +1340,29 @@ export function storeHistoryAnalysis(
       );
       const activateCurrentMetadata = database.prepare(
         "UPDATE preferences_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
+      const insertBookmarkArtifact = database.prepare(
+        `INSERT INTO bookmarks_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, status, reason, active)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertBookmarkFindingStatement = database.prepare(
+        `INSERT INTO bookmarks_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state,
+            provenance_json, fields_json, search_text, source_file, sort_name,
+            sort_url, sort_date_added, sort_folder)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousBookmark = database.prepare(
+        `UPDATE bookmarks_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = ?
+            AND active = 1`,
+      );
+      const activateCurrentBookmark = database.prepare(
+        "UPDATE bookmarks_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
 
       for (const artifact of options.artifacts) {
@@ -1461,11 +1599,44 @@ export function storeHistoryAnalysis(
         }
       }
 
-      // Metadata artifacts are recorded and queryable but deliberately excluded
-      // from the Analysis Run exit-state aggregation: `Local State` and
-      // `Preferences` are contextual scaffolding, and their presence must not
+      for (const artifact of bookmarksArtifacts) {
+        const insertion = insertBookmarkArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.artifact,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertBookmarkFinding(
+            insertBookmarkFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousBookmark.run(
+            artifact.sourceId,
+            artifact.profile,
+            artifact.artifact,
+          );
+          activateCurrentBookmark.run(artifactResultId);
+        }
+      }
+
+      // The SQLite primary stores (History, Cookies, Login Data, Web Data, Top
+      // Sites, Favicons) drive the Analysis Run exit state. The JSON-derived
+      // artifacts —
+      // `Local State`/`Preferences` metadata and the `Bookmarks`/`Bookmarks.bak`
+      // documents — are recorded and independently queryable but deliberately
+      // excluded here: a valid-but-empty or malformed JSON document must not
       // change the History/Cookies/Login exit-code semantics an operator relies
-      // on. Metadata health is surfaced separately in the analyse summary.
+      // on. Their health is surfaced separately in the analyse summary.
       const combinedArtifacts = [
         ...options.artifacts,
         ...cookieArtifacts,

--- a/core/src/cookies.ts
+++ b/core/src/cookies.ts
@@ -1,5 +1,9 @@
 import { join } from "node:path";
 
+import {
+  WINDOWS_EPOCH_OFFSET_MICROS,
+  utcFromUnixMicros,
+} from "./forensic-time.js";
 import type {
   CookieArtifactWrite,
   DeclaredOriginOs,
@@ -35,7 +39,6 @@ import { schemeOf, type DecryptionSettings } from "./oscrypt.js";
  * Below it the analyzer refuses to assert an epoch without a Declared Origin OS.
  */
 const COOKIE_VERIFIED_SCHEMA_MINIMUM = 10;
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
 
 const SAME_SITE_LABELS = new Map<bigint, string>([
   [-1n, "unspecified"],
@@ -136,28 +139,6 @@ function enumFields(
         ? unavailableField("unsupported_value")
         : valueField(label),
   };
-}
-
-function floorDivision(value: bigint, divisor: bigint): bigint {
-  const quotient = value / divisor;
-  const remainder = value % divisor;
-  return remainder < 0n ? quotient - 1n : quotient;
-}
-
-function utcFromUnixMicros(unixMicros: bigint): string | null {
-  const seconds = floorDivision(unixMicros, 1_000_000n);
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = seconds * 1000n + micros / 1000n;
-  const numericMilliseconds = Number(milliseconds);
-  if (!Number.isSafeInteger(numericMilliseconds)) {
-    return null;
-  }
-  const date = new Date(numericMilliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  const base = date.toISOString();
-  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
 }
 
 function resolveCookieEpoch(

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -3,6 +3,7 @@ import { join, resolve } from "node:path";
 import {
   storeHistoryAnalysis,
   type AnalysisRunExitState,
+  type BookmarksArtifactWrite,
   type CookieArtifactWrite,
   type DeclaredOriginOs,
   type DownloadsArtifactWrite,
@@ -14,6 +15,7 @@ import {
   type TopSitesArtifactWrite,
   type WebDataArtifactWrite,
 } from "./case-findings.js";
+import { analyseSourceBookmarks } from "./bookmarks.js";
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseDownloadsProfile } from "./downloads.js";
 import { analyseSourceFavicons } from "./favicons.js";
@@ -218,6 +220,18 @@ export interface PreferencesAnalysisSummary {
   readonly findingCount: number;
 }
 
+export interface BookmarksAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly primaryAnalysedCount: number;
+  readonly backupAnalysedCount: number;
+  readonly absentCount: number;
+  readonly unavailableCount: number;
+  readonly bookmarkCount: number;
+  readonly findingCount: number;
+  readonly declaredTimezone: string;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -232,6 +246,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly favicons: FaviconsAnalysisSummary;
   readonly downloads: DownloadsAnalysisSummary;
   readonly preferences: PreferencesAnalysisSummary;
+  readonly bookmarks: BookmarksAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
 
@@ -1264,6 +1279,7 @@ export async function analyseCase(
   const faviconArtifacts: FaviconArtifactWrite[] = [];
   const downloadsArtifacts: DownloadsArtifactWrite[] = [];
   const metadataArtifacts: MetadataArtifactWrite[] = [];
+  const bookmarksArtifacts: BookmarksArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1328,6 +1344,13 @@ export async function analyseCase(
     metadataArtifacts.push(
       ...(await analyseSourcePreferences({ source, workingCopyPath })),
     );
+    bookmarksArtifacts.push(
+      ...(await analyseSourceBookmarks({
+        source,
+        workingCopyPath,
+        declaredTimezone,
+      })),
+    );
   }
 
   await verifyWorkingCopy(caseDirectory);
@@ -1346,6 +1369,7 @@ export async function analyseCase(
     faviconArtifacts,
     downloadsArtifacts,
     metadataArtifacts,
+    bookmarksArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1423,6 +1447,15 @@ export async function analyseCase(
     (artifact) => artifact.status === "absent",
   );
   const metadataUnavailable = metadataArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
+  const bookmarksAnalysed = bookmarksArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const bookmarksAbsent = bookmarksArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const bookmarksUnavailable = bookmarksArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
   return {
@@ -1635,6 +1668,30 @@ export async function analyseCase(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),
+    },
+    bookmarks: {
+      status: bookmarksUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      primaryAnalysedCount: bookmarksAnalysed.filter(
+        (artifact) => artifact.artifact === "Bookmarks",
+      ).length,
+      backupAnalysedCount: bookmarksAnalysed.filter(
+        (artifact) => artifact.artifact === "Bookmarks.bak",
+      ).length,
+      absentCount: bookmarksAbsent.length,
+      unavailableCount: bookmarksUnavailable.length,
+      bookmarkCount: bookmarksAnalysed.reduce(
+        (count, artifact) => count + artifact.bookmarkCount,
+        0,
+      ),
+      findingCount: bookmarksAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
+      declaredTimezone,
     },
     decryption: {
       enabled: decryption.enabled,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -101,6 +101,7 @@ export {
   type HistoryAnalysisSummary,
   type LoginDataAnalysisSummary,
   type PreferencesAnalysisSummary,
+  type BookmarksAnalysisSummary,
   type TopSitesAnalysisSummary,
   type WebDataAnalysisSummary,
 } from "./history.js";
@@ -216,7 +217,17 @@ export {
   type MetadataType,
 } from "./preferences-query.js";
 export {
+  queryBookmarks,
+  type BookmarkDirection,
+  type BookmarkPage,
+  type BookmarkQuery,
+  type BookmarkSort,
+  type BookmarkSource,
+} from "./bookmarks-query.js";
+export {
   type AnalysisRunExitState,
+  type BookmarksArtifactWrite,
+  type BookmarkSourceFile,
   type DeclaredOriginOs,
 } from "./case-findings.js";
 export { openDatabaseSync, type OpenDatabaseConfig } from "./sqlite-open.js";

--- a/core/src/login-data.ts
+++ b/core/src/login-data.ts
@@ -1,5 +1,9 @@
 import { join } from "node:path";
 
+import {
+  WINDOWS_EPOCH_OFFSET_MICROS,
+  utcFromUnixMicros,
+} from "./forensic-time.js";
 import type {
   LoginDataArtifactWrite,
   PersistedLoginFinding,
@@ -27,8 +31,6 @@ import {
   type VerifiedLoginFile,
 } from "./login-data-sqlite.js";
 
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
-
 /**
  * Chrome stores password-store timestamps as `base::Time` internal values, i.e.
  * microseconds since 1601-01-01 UTC, on every platform. Unlike History, the
@@ -45,28 +47,6 @@ interface ManifestIdentity {
 
 interface BuiltCredential {
   readonly persisted: PersistedLoginFinding;
-}
-
-function floorDivision(value: bigint, divisor: bigint): bigint {
-  const quotient = value / divisor;
-  const remainder = value % divisor;
-  return remainder < 0n ? quotient - 1n : quotient;
-}
-
-function utcFromUnixMicros(unixMicros: bigint): string | null {
-  const seconds = floorDivision(unixMicros, 1_000_000n);
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = seconds * 1000n + micros / 1000n;
-  const numericMilliseconds = Number(milliseconds);
-  if (!Number.isSafeInteger(numericMilliseconds)) {
-    return null;
-  }
-  const date = new Date(numericMilliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  const base = date.toISOString();
-  return `${base.slice(0, -5)}.${micros.toString().padStart(6, "0")}Z`;
 }
 
 function preservedString(value: RawLoginValue): FieldState<string> {

--- a/core/src/preferences-json.ts
+++ b/core/src/preferences-json.ts
@@ -1,5 +1,7 @@
 import { lstat } from "node:fs/promises";
+import { join } from "node:path";
 
+import type { CaseSourceRecord } from "./case.js";
 import { WorkingCopyIntegrityRefusal } from "./errors.js";
 import { readStableRegularFile } from "./stable-file.js";
 
@@ -93,4 +95,86 @@ export async function readVerifiedJsonFile(
     return { status: "unreadable", reason: "malformed_json" };
   }
   return { status: "parsed", value };
+}
+
+/**
+ * Where a named Working Copy JSON file stands relative to the Manifest, before
+ * any bytes are read. `ready` carries the verified-file identity; `absent` and
+ * `unavailable` carry a typed reason (prefixed with the caller's `label`) so a
+ * removed-or-missing file stays distinct from a present-but-unusable one.
+ */
+export type FileResolution =
+  | {
+      readonly kind: "ready";
+      readonly file: VerifiedJsonFile;
+      readonly ordinal: number;
+    }
+  | {
+      readonly kind: "absent" | "unavailable";
+      readonly reason: string;
+      readonly ordinal: number | null;
+    };
+
+/**
+ * Resolve a Manifest-declared JSON file within a Source's Working Copy. A file
+ * absent from the Manifest or recorded as absent is `absent`; a file that is
+ * unavailable, uncopied, or missing its size/hash representation is a typed
+ * `unavailable`. Only a `ready` result is safe to pass to `readVerifiedJsonFile`.
+ */
+export function resolveJsonFile(
+  source: CaseSourceRecord,
+  workingCopyPath: string,
+  path: string,
+  label: string,
+): FileResolution {
+  const ordinal = source.entries.findIndex((entry) => entry.path === path);
+  if (ordinal < 0) {
+    return {
+      kind: "absent",
+      reason: `${label}_manifest_entry_missing`,
+      ordinal: null,
+    };
+  }
+  const entry = source.entries[ordinal];
+  if (entry === undefined) {
+    return {
+      kind: "absent",
+      reason: `${label}_manifest_entry_missing`,
+      ordinal: null,
+    };
+  }
+  if (entry.state === "absent") {
+    return { kind: "absent", reason: `${label}_absent`, ordinal };
+  }
+  if (entry.state === "unavailable") {
+    return {
+      kind: "unavailable",
+      reason: `${label}_unavailable:${entry.unavailable_reason ?? "unknown"}`,
+      ordinal,
+    };
+  }
+  if (!entry.copied) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_not_in_working_copy`,
+      ordinal,
+    };
+  }
+  if (entry.size === null || entry.sha256 === null) {
+    return {
+      kind: "unavailable",
+      reason: `${label}_manifest_representation_incomplete`,
+      ordinal,
+    };
+  }
+  return {
+    kind: "ready",
+    ordinal,
+    file: {
+      path: join(workingCopyPath, ...path.split("/")),
+      manifestPath: path,
+      size: entry.size,
+      sha256: entry.sha256,
+    },
+  };
 }

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -13,7 +13,7 @@ import {
   type Provenance,
   type SourceRowProvenance,
 } from "./forensic-model.js";
-import { readVerifiedJsonFile, resolveJsonFile } from "./preferences-json.js";
+import { readVerifiedJsonFile, resolveJsonFile } from "./working-copy-json.js";
 
 export const BROWSER_METADATA_KIND = "browser_metadata";
 export const PROFILE_METADATA_KIND = "profile_metadata";

--- a/core/src/preferences.ts
+++ b/core/src/preferences.ts
@@ -1,5 +1,3 @@
-import { join } from "node:path";
-
 import type {
   MetadataArtifactWrite,
   PersistedMetadataFinding,
@@ -15,10 +13,7 @@ import {
   type Provenance,
   type SourceRowProvenance,
 } from "./forensic-model.js";
-import {
-  readVerifiedJsonFile,
-  type VerifiedJsonFile,
-} from "./preferences-json.js";
+import { readVerifiedJsonFile, resolveJsonFile } from "./preferences-json.js";
 
 export const BROWSER_METADATA_KIND = "browser_metadata";
 export const PROFILE_METADATA_KIND = "profile_metadata";
@@ -201,76 +196,6 @@ function firstAccount(preferences: unknown): {
     return { count, account: result.value[0] ?? null };
   }
   return { count, account: null };
-}
-
-type FileResolution =
-  | {
-      readonly kind: "ready";
-      readonly file: VerifiedJsonFile;
-      readonly ordinal: number;
-    }
-  | {
-      readonly kind: "absent" | "unavailable";
-      readonly reason: string;
-      readonly ordinal: number | null;
-    };
-
-function resolveJsonFile(
-  source: CaseSourceRecord,
-  workingCopyPath: string,
-  path: string,
-  label: string,
-): FileResolution {
-  const ordinal = source.entries.findIndex((entry) => entry.path === path);
-  if (ordinal < 0) {
-    return {
-      kind: "absent",
-      reason: `${label}_manifest_entry_missing`,
-      ordinal: null,
-    };
-  }
-  const entry = source.entries[ordinal];
-  if (entry === undefined) {
-    return {
-      kind: "absent",
-      reason: `${label}_manifest_entry_missing`,
-      ordinal: null,
-    };
-  }
-  if (entry.state === "absent") {
-    return { kind: "absent", reason: `${label}_absent`, ordinal };
-  }
-  if (entry.state === "unavailable") {
-    return {
-      kind: "unavailable",
-      reason: `${label}_unavailable:${entry.unavailable_reason ?? "unknown"}`,
-      ordinal,
-    };
-  }
-  if (!entry.copied) {
-    return {
-      kind: "unavailable",
-      reason: `${label}_not_in_working_copy`,
-      ordinal,
-    };
-  }
-  if (entry.size === null || entry.sha256 === null) {
-    return {
-      kind: "unavailable",
-      reason: `${label}_manifest_representation_incomplete`,
-      ordinal,
-    };
-  }
-  return {
-    kind: "ready",
-    ordinal,
-    file: {
-      path: join(workingCopyPath, ...path.split("/")),
-      manifestPath: path,
-      size: entry.size,
-      sha256: entry.sha256,
-    },
-  };
 }
 
 function unavailableArtifact(

--- a/core/src/working-copy-json.ts
+++ b/core/src/working-copy-json.ts
@@ -6,10 +6,11 @@ import { WorkingCopyIntegrityRefusal } from "./errors.js";
 import { readStableRegularFile } from "./stable-file.js";
 
 /**
- * A Working Copy JSON file (Chrome `Preferences` or `Local State`) pinned to the
- * exact Manifest representation recorded at ingest. The reader re-verifies the
- * bytes against this identity before it parses anything, so analysis never
- * trusts content that drifted from the recorded evidence.
+ * A Working Copy JSON file (any Chrome JSON artifact, e.g. `Preferences`,
+ * `Local State`, or `Bookmarks`/`Bookmarks.bak`) pinned to the exact Manifest
+ * representation recorded at ingest. The reader re-verifies the bytes against
+ * this identity before it parses anything, so analysis never trusts content
+ * that drifted from the recorded evidence.
  */
 export interface VerifiedJsonFile {
   readonly path: string;

--- a/core/test/bookmarks.test.ts
+++ b/core/test/bookmarks.test.ts
@@ -227,10 +227,13 @@ describe("analyseSourceBookmarks", () => {
       workingCopyPath,
       profiles: ["Default"],
       entries: [
-        // Primary parses as JSON but has no roots: unsupported shape.
-        { path: "Default/Bookmarks", bytes: JSON.stringify({ version: 1 }) },
-        // Backup is byte-intact but not JSON: malformed.
-        { path: "Default/Bookmarks.bak", bytes: "{ broken," },
+        // Primary is byte-intact but not JSON: malformed.
+        { path: "Default/Bookmarks", bytes: "{ broken," },
+        // Backup parses as JSON but has no roots: unsupported shape.
+        {
+          path: "Default/Bookmarks.bak",
+          bytes: JSON.stringify({ version: 1 }),
+        },
       ],
     });
 
@@ -245,14 +248,16 @@ describe("analyseSourceBookmarks", () => {
     const backup = artifacts.find(
       (candidate) => candidate.artifact === "Bookmarks.bak",
     );
+    // Both reasons are label-prefixed, so primary and backup stay
+    // distinguishable by reason string alone across every failure branch.
     expect(primary).toMatchObject({
       status: "unavailable",
-      reason: "bookmarks_unsupported_shape",
+      reason: "bookmarks_malformed_json",
       findings: [],
     });
     expect(backup).toMatchObject({
       status: "unavailable",
-      reason: "bookmarks_backup_malformed_json",
+      reason: "bookmarks_backup_unsupported_shape",
     });
   });
 

--- a/core/test/bookmarks.test.ts
+++ b/core/test/bookmarks.test.ts
@@ -1,0 +1,282 @@
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { analyseSourceBookmarks } from "../src/bookmarks.js";
+import type { BookmarksArtifactWrite } from "../src/case-findings.js";
+import type { CaseSourceRecord } from "../src/case.js";
+import type { FieldState, Finding } from "../src/forensic-model.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+interface EntrySpec {
+  readonly path: string;
+  readonly state?: "value" | "absent" | "unavailable";
+  readonly unavailableReason?: string;
+  readonly bytes?: string;
+}
+
+/**
+ * Materialize a Working Copy on disk and build the matching manifest entries so
+ * `readVerifiedJsonFile` re-verifies against the exact recorded representation.
+ */
+async function buildSource(options: {
+  readonly workingCopyPath: string;
+  readonly profiles: readonly string[];
+  readonly entries: readonly EntrySpec[];
+}): Promise<CaseSourceRecord> {
+  const entries = [];
+  for (const spec of options.entries) {
+    const state = spec.state ?? "value";
+    if (state === "value" && spec.bytes !== undefined) {
+      const absolute = join(options.workingCopyPath, ...spec.path.split("/"));
+      await mkdir(join(absolute, ".."), { recursive: true });
+      await writeFile(absolute, spec.bytes);
+      const buffer = Buffer.from(spec.bytes);
+      entries.push({
+        path: spec.path,
+        state: "value",
+        unavailable_reason: null,
+        node_type: "file",
+        copied: true,
+        size: buffer.byteLength,
+        sha256: createHash("sha256").update(buffer).digest("hex"),
+      });
+      continue;
+    }
+    entries.push({
+      path: spec.path,
+      state,
+      unavailable_reason: spec.unavailableReason ?? null,
+      node_type: state === "absent" ? "absent" : "file",
+      copied: false,
+      size: null,
+      sha256: null,
+    });
+  }
+  return {
+    sourceId: "SRC-TEST",
+    entries,
+    profiles: options.profiles.map((path, index) => ({
+      profileId: `P-${index}`,
+      path,
+    })),
+  } as unknown as CaseSourceRecord;
+}
+
+function field(finding: Finding, name: string): FieldState<unknown> {
+  const value = finding.fields[name];
+  if (value === undefined) {
+    throw new Error(`Finding has no field ${name}`);
+  }
+  return value;
+}
+
+function complete(
+  artifacts: readonly BookmarksArtifactWrite[],
+  artifact: "Bookmarks" | "Bookmarks.bak",
+  profile: string,
+): BookmarksArtifactWrite {
+  const match = artifacts.find(
+    (candidate) =>
+      candidate.artifact === artifact && candidate.profile === profile,
+  );
+  if (match === undefined) {
+    throw new Error(`No ${artifact} artifact for ${profile}`);
+  }
+  return match;
+}
+
+describe("analyseSourceBookmarks", () => {
+  it("carries deep folder ancestry and falls back to guid for a missing id", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bm-unit-"));
+    temporaryRoots.push(root);
+    const workingCopyPath = join(root, "working-copy");
+    const document = JSON.stringify({
+      roots: {
+        bookmark_bar: {
+          type: "folder",
+          id: "1",
+          name: "Bookmarks bar",
+          children: [
+            {
+              type: "folder",
+              id: "2",
+              name: "Reading",
+              children: [
+                {
+                  type: "folder",
+                  id: "3",
+                  name: "Papers",
+                  children: [
+                    {
+                      // No id: the rowId and bookmarkId fall back to the guid.
+                      type: "url",
+                      guid: "guid-deep",
+                      name: "Deep",
+                      url: "https://deep.example.com/",
+                      date_added: "13350000000000000",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    });
+    const source = await buildSource({
+      workingCopyPath,
+      profiles: ["Default"],
+      entries: [{ path: "Default/Bookmarks", bytes: document }],
+    });
+
+    const artifacts = await analyseSourceBookmarks({
+      source,
+      workingCopyPath,
+      declaredTimezone: "UTC",
+    });
+    const primary = complete(artifacts, "Bookmarks", "Default");
+    expect(primary.status).toBe("complete");
+    expect(primary.findings).toHaveLength(1);
+    const deep = primary.findings[0]?.finding as Finding;
+    expect(field(deep, "folderPath")).toEqual({
+      state: "value",
+      value: "Bookmarks bar / Reading / Papers",
+      synthetic: true,
+    });
+    expect(field(deep, "parentFolder")).toEqual({
+      state: "value",
+      value: "Papers",
+    });
+    expect(field(deep, "bookmarkId")).toEqual({ state: "absent" });
+    expect(field(deep, "guid")).toEqual({
+      state: "value",
+      value: "guid-deep",
+    });
+    // The rowId falls back to the guid so Provenance stays resolvable.
+    expect(deep.provenance.rowId).toBe("guid-deep");
+  });
+
+  it("keeps a url node with a missing url/name as typed field states", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bm-partial-"));
+    temporaryRoots.push(root);
+    const workingCopyPath = join(root, "working-copy");
+    const document = JSON.stringify({
+      roots: {
+        other: {
+          type: "folder",
+          id: "2",
+          name: "Other bookmarks",
+          children: [
+            { type: "url", id: "7", name: "No URL", date_added: "0" },
+            { type: "url", id: "8", url: "https://no-name.example.com/" },
+            // A non-object child and an unknown-type node are both skipped.
+            42,
+            { type: "separator", id: "9" },
+          ],
+        },
+      },
+    });
+    const source = await buildSource({
+      workingCopyPath,
+      profiles: ["Default"],
+      entries: [{ path: "Default/Bookmarks", bytes: document }],
+    });
+
+    const artifacts = await analyseSourceBookmarks({
+      source,
+      workingCopyPath,
+      declaredTimezone: "UTC",
+    });
+    const primary = complete(artifacts, "Bookmarks", "Default");
+    expect(primary.findings).toHaveLength(2);
+    const [first, second] = primary.findings;
+    expect(field(first?.finding as Finding, "url")).toEqual({
+      state: "absent",
+    });
+    // date_added "0" is the Chrome "never" sentinel, so it is absent.
+    expect(field(first?.finding as Finding, "dateAdded")).toEqual({
+      state: "absent",
+    });
+    expect(field(second?.finding as Finding, "name")).toEqual({
+      state: "absent",
+    });
+    expect(field(second?.finding as Finding, "url")).toEqual({
+      state: "value",
+      value: "https://no-name.example.com/",
+    });
+  });
+
+  it("distinguishes absent, malformed, and unsupported-shape files", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bm-status-"));
+    temporaryRoots.push(root);
+    const workingCopyPath = join(root, "working-copy");
+    const source = await buildSource({
+      workingCopyPath,
+      profiles: ["Default"],
+      entries: [
+        // Primary parses as JSON but has no roots: unsupported shape.
+        { path: "Default/Bookmarks", bytes: JSON.stringify({ version: 1 }) },
+        // Backup is byte-intact but not JSON: malformed.
+        { path: "Default/Bookmarks.bak", bytes: "{ broken," },
+      ],
+    });
+
+    const artifacts = await analyseSourceBookmarks({
+      source,
+      workingCopyPath,
+      declaredTimezone: "UTC",
+    });
+    const primary = artifacts.find(
+      (candidate) => candidate.artifact === "Bookmarks",
+    );
+    const backup = artifacts.find(
+      (candidate) => candidate.artifact === "Bookmarks.bak",
+    );
+    expect(primary).toMatchObject({
+      status: "unavailable",
+      reason: "bookmarks_unsupported_shape",
+      findings: [],
+    });
+    expect(backup).toMatchObject({
+      status: "unavailable",
+      reason: "bookmarks_backup_malformed_json",
+    });
+  });
+
+  it("marks an expected-but-missing file absent, not unavailable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bm-absent-"));
+    temporaryRoots.push(root);
+    const workingCopyPath = join(root, "working-copy");
+    const source = await buildSource({
+      workingCopyPath,
+      profiles: ["Default"],
+      entries: [
+        { path: "Default/Bookmarks", bytes: JSON.stringify({ roots: {} }) },
+        { path: "Default/Bookmarks.bak", state: "absent" },
+      ],
+    });
+
+    const artifacts = await analyseSourceBookmarks({
+      source,
+      workingCopyPath,
+      declaredTimezone: "UTC",
+    });
+    const backup = complete(artifacts, "Bookmarks.bak", "Default");
+    expect(backup.status).toBe("absent");
+    expect(backup.reason).toBe("bookmarks_backup_absent");
+    expect(backup.findings).toHaveLength(0);
+  });
+});

--- a/core/test/working-copy-json.test.ts
+++ b/core/test/working-copy-json.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { WorkingCopyIntegrityRefusal } from "../src/errors.js";
-import { readVerifiedJsonFile } from "../src/preferences-json.js";
+import { readVerifiedJsonFile } from "../src/working-copy-json.js";
 
 const roots: string[] = [];
 

--- a/e2e/bookmarks-cli.test.ts
+++ b/e2e/bookmarks-cli.test.ts
@@ -1,0 +1,573 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+interface FieldValue<T> {
+  readonly state: "value";
+  readonly value: T;
+  readonly synthetic?: boolean;
+}
+
+interface Unavailable {
+  readonly state: "unavailable";
+  readonly reason: string;
+}
+
+interface Absent {
+  readonly state: "absent";
+}
+
+type Field<T> = FieldValue<T> | Unavailable | Absent;
+
+interface BookmarkFinding {
+  readonly recordType: "finding";
+  readonly findingKind: "bookmark";
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly provenance: {
+    readonly sourceId: string;
+    readonly manifestEntryId: string;
+    readonly manifestEntryOrdinal: number;
+    readonly manifestPath: string;
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+  };
+  readonly fields: Record<string, Field<unknown>>;
+}
+
+interface BookmarkPage {
+  readonly status: "ok";
+  readonly command: "bookmarks";
+  readonly items: readonly BookmarkFinding[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+// Default primary Bookmarks: three URL bookmarks across two roots and a nested
+// folder, plus one bookmark whose date_added is the wrong type (unavailable).
+const DEFAULT_BOOKMARKS = {
+  checksum: "abc123",
+  roots: {
+    bookmark_bar: {
+      type: "folder",
+      id: "1",
+      guid: "guid-bar",
+      name: "Bookmarks bar",
+      date_added: "13350000000000000",
+      children: [
+        {
+          type: "url",
+          id: "5",
+          guid: "guid-example",
+          name: "Example",
+          url: "https://example.com/",
+          date_added: "13350000001000000",
+          date_last_used: "0",
+        },
+        {
+          type: "folder",
+          id: "6",
+          name: "Work",
+          children: [
+            {
+              type: "url",
+              id: "7",
+              guid: "guid-docs",
+              name: "Docs",
+              url: "https://docs.example.com/",
+              date_added: "13350000002000000",
+              date_last_used: "13360000000000000",
+            },
+          ],
+        },
+      ],
+    },
+    other: {
+      type: "folder",
+      id: "2",
+      name: "Other bookmarks",
+      children: [
+        {
+          type: "url",
+          id: "8",
+          name: "News",
+          url: "https://news.example.com/",
+          date_added: 12345,
+        },
+      ],
+    },
+    synced: {
+      type: "folder",
+      id: "3",
+      name: "Mobile bookmarks",
+      children: [],
+    },
+  },
+  version: 1,
+};
+
+// Default backup Bookmarks: a distinct earlier state of the same profile. The
+// primary "Example" points at example.com; the backup keeps the superseded
+// old.example.com value under the same node id. The two must never merge.
+const DEFAULT_BOOKMARKS_BAK = {
+  checksum: "old000",
+  roots: {
+    bookmark_bar: {
+      type: "folder",
+      id: "1",
+      name: "Bookmarks bar",
+      children: [
+        {
+          type: "url",
+          id: "5",
+          name: "Example (old)",
+          url: "https://old.example.com/",
+          date_added: "13340000000000000",
+        },
+      ],
+    },
+    other: { type: "folder", id: "2", name: "Other bookmarks", children: [] },
+    synced: { type: "folder", id: "3", name: "Mobile bookmarks", children: [] },
+  },
+  version: 1,
+};
+
+const PROFILE_ONE_BOOKMARKS = {
+  roots: {
+    bookmark_bar: {
+      type: "folder",
+      id: "1",
+      name: "Bookmarks bar",
+      children: [
+        {
+          type: "url",
+          id: "9",
+          name: "Search",
+          url: "https://search.example.com/",
+          date_added: "13350500000000000",
+        },
+      ],
+    },
+    other: { type: "folder", id: "2", name: "Other bookmarks", children: [] },
+    synced: { type: "folder", id: "3", name: "Mobile bookmarks", children: [] },
+  },
+  version: 1,
+};
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(join(source, "Default"), { recursive: true });
+  await mkdir(join(source, "Profile 1"), { recursive: true });
+  await writeJson(join(source, "Default", "Bookmarks"), DEFAULT_BOOKMARKS);
+  await writeJson(
+    join(source, "Default", "Bookmarks.bak"),
+    DEFAULT_BOOKMARKS_BAK,
+  );
+  // Profile 1 has only a primary file, so its backup is expected-but-absent.
+  await writeJson(
+    join(source, "Profile 1", "Bookmarks"),
+    PROFILE_ONE_BOOKMARKS,
+  );
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Bookmark Finding pipeline", () => {
+  it("parses primary and backup Bookmarks across Profiles with exact fields", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bookmarks-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const primaryBytes = await readFile(join(source, "Default", "Bookmarks"));
+    const caseDirectory = join(root, "CASE-BOOKMARKS");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    // AC1: current and backup Bookmarks parsed across all Profiles. Two
+    // Profiles, two files each: Default has both, Profile 1 backup is absent.
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      bookmarks: {
+        status: "complete",
+        profileCount: 2,
+        primaryAnalysedCount: 2,
+        backupAnalysedCount: 1,
+        absentCount: 1,
+        unavailableCount: 0,
+        bookmarkCount: 5,
+        findingCount: 5,
+      },
+    });
+
+    // AC5: default sort is by name ascending across every Profile and file.
+    const all = parseJson<BookmarkPage>(
+      runCli(["bookmarks", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(all.items.map((row) => row.fields.name)).toEqual([
+      { state: "value", value: "Docs" },
+      { state: "value", value: "Example" },
+      { state: "value", value: "Example (old)" },
+      { state: "value", value: "News" },
+      { state: "value", value: "Search" },
+    ]);
+
+    // AC2: URL, name, folder ancestry, source file, and timestamps are exact.
+    const docs = all.items.find(
+      (row) => (row.fields.name as FieldValue<string>).value === "Docs",
+    );
+    expect(docs).toMatchObject({
+      findingKind: "bookmark",
+      profile: "Default",
+      commitState: "committed",
+      provenance: {
+        manifestPath: "Default/Bookmarks",
+        database: "Default/Bookmarks",
+        table: "bookmarks",
+        rowId: "7",
+      },
+      fields: {
+        bookmarkId: { state: "value", value: "7" },
+        guid: { state: "value", value: "guid-docs" },
+        name: { state: "value", value: "Docs" },
+        url: { state: "value", value: "https://docs.example.com/" },
+        sourceFile: { state: "value", value: "Bookmarks" },
+        rootFolder: { state: "value", value: "bookmark_bar" },
+        parentFolder: { state: "value", value: "Work" },
+        folderPath: {
+          state: "value",
+          value: "Bookmarks bar / Work",
+          synthetic: true,
+        },
+        dateAdded: {
+          state: "value",
+          value: {
+            raw: "13350000002000000",
+            epochFamily: "1601-us",
+            utc: "2024-01-17T21:20:02.000000Z",
+            resolution: "webkit_bookmarks_epoch",
+          },
+        },
+        dateLastUsed: {
+          state: "value",
+          value: {
+            raw: "13360000000000000",
+            epochFamily: "1601-us",
+            utc: "2024-05-12T15:06:40.000000Z",
+          },
+        },
+      },
+    });
+
+    // AC2: the Chrome "never used" sentinel 0 is absent, not a bogus instant.
+    const example = all.items.find(
+      (row) =>
+        (row.fields.name as FieldValue<string>).value === "Example" &&
+        row.profile === "Default",
+    );
+    expect(example?.fields.dateLastUsed).toEqual({ state: "absent" });
+    expect(example?.fields.dateAdded).toMatchObject({
+      state: "value",
+      value: { utc: "2024-01-17T21:20:01.000000Z" },
+    });
+
+    // AC2: a wrong-typed date is unavailable with a typed reason, never blank.
+    const news = all.items.find(
+      (row) => (row.fields.name as FieldValue<string>).value === "News",
+    );
+    expect(news?.fields.dateAdded).toEqual({
+      state: "unavailable",
+      reason: "unsupported_value",
+    });
+    expect(news?.fields.rootFolder).toEqual({ state: "value", value: "other" });
+    expect(news?.fields.folderPath).toEqual({
+      state: "value",
+      value: "Other bookmarks",
+      synthetic: true,
+    });
+
+    // AC3: the primary and backup "Example" records both exist, carry distinct
+    // Provenance (different source file), and are never merged into one.
+    const backup = all.items.find(
+      (row) =>
+        (row.fields.name as FieldValue<string>).value === "Example (old)",
+    );
+    expect(backup).toMatchObject({
+      profile: "Default",
+      provenance: {
+        manifestPath: "Default/Bookmarks.bak",
+        database: "Default/Bookmarks.bak",
+        rowId: "5",
+      },
+      fields: {
+        sourceFile: { state: "value", value: "Bookmarks.bak" },
+        url: { state: "value", value: "https://old.example.com/" },
+      },
+    });
+    expect(example?.provenance.manifestPath).toBe("Default/Bookmarks");
+    expect(example?.fields.url).toEqual({
+      state: "value",
+      value: "https://example.com/",
+    });
+    // Same node id "5" in two files, but two distinct Findings.
+    expect(example?.provenance.rowId).toBe("5");
+    expect(backup?.provenance.rowId).toBe("5");
+    expect(example?.provenance.manifestPath).not.toBe(
+      backup?.provenance.manifestPath,
+    );
+
+    // AC5: source filter isolates primary from backup.
+    const primaryOnly = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--source",
+        "primary",
+        "--json",
+      ]).stdout,
+    );
+    expect(
+      primaryOnly.items.every(
+        (row) =>
+          (row.fields.sourceFile as FieldValue<string>).value === "Bookmarks",
+      ),
+    ).toBe(true);
+    expect(primaryOnly.items).toHaveLength(4);
+
+    const backupOnly = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--source",
+        "backup",
+        "--json",
+      ]).stdout,
+    );
+    expect(backupOnly.items).toHaveLength(1);
+    expect(backupOnly.items[0]?.provenance.manifestPath).toBe(
+      "Default/Bookmarks.bak",
+    );
+
+    // AC5: Profile filter narrows to one Profile.
+    const profileOne = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Profile 1",
+        "--json",
+      ]).stdout,
+    );
+    expect(profileOne.items).toHaveLength(1);
+    expect(profileOne.items[0]?.fields.name).toEqual({
+      state: "value",
+      value: "Search",
+    });
+
+    // AC5: search matches name, URL, and folder path (case-insensitive).
+    const searched = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--search",
+        "docs.example.com",
+        "--json",
+      ]).stdout,
+    );
+    expect(searched.items).toHaveLength(1);
+    expect(searched.items[0]?.fields.name).toEqual({
+      state: "value",
+      value: "Docs",
+    });
+
+    // AC5: sort by date-added ascending, with keyset pagination and a cursor.
+    const firstPage = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--source",
+        "primary",
+        "--sort",
+        "date-added",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    // News has an unavailable date_added (COALESCE sentinel -1), so it sorts
+    // first; Search (2024-01-23) sorts after Example (2024-01-17).
+    expect(firstPage.items.map((row) => row.fields.name)).toEqual([
+      { state: "value", value: "News" },
+      { state: "value", value: "Example" },
+    ]);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const secondPage = parseJson<BookmarkPage>(
+      runCli([
+        "bookmarks",
+        "--case",
+        caseDirectory,
+        "--source",
+        "primary",
+        "--sort",
+        "date-added",
+        "--direction",
+        "asc",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    expect(secondPage.items.map((row) => row.fields.name)).toEqual([
+      { state: "value", value: "Docs" },
+      { state: "value", value: "Search" },
+    ]);
+
+    // AC5: broken input rejected.
+    const badLimit = runCli([
+      "bookmarks",
+      "--case",
+      caseDirectory,
+      "--limit",
+      "0",
+      "--json",
+    ]);
+    expect(badLimit.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(badLimit.stderr)).toMatchObject({
+      code: "INVALID_ARGUMENT",
+    });
+
+    // AC5: a stale cursor after re-analysis is rejected.
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const stale = runCli([
+      "bookmarks",
+      "--case",
+      caseDirectory,
+      "--source",
+      "primary",
+      "--sort",
+      "date-added",
+      "--direction",
+      "asc",
+      "--limit",
+      "2",
+      "--after",
+      firstPage.nextCursor as string,
+      "--json",
+    ]);
+    expect(stale.status).toBe(1);
+    expect(parseJson<Record<string, unknown>>(stale.stderr)).toMatchObject({
+      code: "INVALID_CURSOR",
+    });
+
+    // AC1: analysis never mutates the Source bytes.
+    expect(await readFile(join(source, "Default", "Bookmarks"))).toEqual(
+      primaryBytes,
+    );
+  });
+
+  it("reports malformed JSON as unavailable and a missing file as absent", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-bookmarks-bad-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(join(source, "Default"), { recursive: true });
+    await mkdir(join(source, "Profile 1"), { recursive: true });
+    // Default's primary is byte-intact but unparseable (unavailable); its
+    // backup is simply missing (absent). Profile 1 keeps a valid primary so the
+    // Case still has a defensible, queryable Bookmarks result.
+    await writeFile(
+      join(source, "Default", "Bookmarks"),
+      "{ not valid json ,,",
+    );
+    await writeJson(
+      join(source, "Profile 1", "Bookmarks"),
+      PROFILE_ONE_BOOKMARKS,
+    );
+    const caseDirectory = join(root, "CASE-BOOKMARKS-BAD");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+
+    // AC4: the malformed primary is unavailable and the missing files are
+    // absent. Bookmarks are JSON-derived and do not drive the Analysis Run exit
+    // state (like Preferences metadata), so the run stays clean while the
+    // bookmarks summary reports its own partial health.
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      exitState: "complete",
+      bookmarks: {
+        status: "partial",
+        primaryAnalysedCount: 1,
+        backupAnalysedCount: 0,
+        absentCount: 2,
+        unavailableCount: 1,
+        findingCount: 1,
+      },
+    });
+
+    // AC4: the defensible Profile 1 bookmark is still queryable.
+    const results = parseJson<BookmarkPage>(
+      runCli(["bookmarks", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(results.items).toHaveLength(1);
+    expect(results.items[0]?.profile).toBe("Profile 1");
+    expect(results.items[0]?.fields.name).toEqual({
+      state: "value",
+      value: "Search",
+    });
+  });
+});


### PR DESCRIPTION
Closes #180.

Lets an investigator review saved navigation evidence from both the primary and backup Bookmark files with folder context and time metadata intact. Bookmarks are JSON files (not SQLite); this mirrors the established Findings contract used by History, Cookies, Top Sites, and Preferences metadata.

## Acceptance criteria → where it lands

- [x] **Current + backup Bookmarks parsed across all Profiles.** `analyseSourceBookmarks` (`core/src/bookmarks.ts`) walks each Profile's `Bookmarks` and `Bookmarks.bak` root trees (`bookmark_bar`, `other`, `synced`, plus any extra roots, deterministic order) and emits one Finding per URL node. Wired into `analyseCase` in `core/src/history.ts`.
- [x] **URLs, names, folder ancestry, source file, timestamps, and other fields exact vs ground truth.** Each Finding carries `url`, `name`, `guid`, `bookmarkId`, `rootFolder`, `parentFolder`, synthetic `folderPath` (full ancestry), `sourceFile`, and `dateAdded` / `dateLastUsed` as `ForensicTimestamp`s (WebKit `1601-us` epoch, exact raw string + derived UTC). Verified byte-exact in the e2e suite; source bytes are never mutated.
- [x] **Primary and backup retain distinct Provenance and are never merged.** One artifact per file per Profile (`artifact IN ('Bookmarks','Bookmarks.bak')`, `UNIQUE(run_id, source_id, profile_path, artifact)`). The same node id in both files yields two independent Findings with different `manifestPath`/`database`.
- [x] **Malformed JSON is unavailable (typed reason) while a missing expected file is absent.** A missing file → `absent` (`bookmarks_absent` / `bookmarks_backup_absent`); a byte-intact but unparseable document → `unavailable` (`*_malformed_json`); a parsed-but-shapeless document → `unavailable` (`bookmarks_unsupported_shape`); a wrong-typed value → `unavailable("unsupported_value")`; the Chrome `"0"` "never" sentinel → `absent`.
- [x] **Bounded, searchable, sortable, filterable, paginated, multi-Profile CLI.** New `forensix bookmarks` command (`cli/src/cli.ts`) over `queryBookmarks` (`core/src/bookmarks-query.ts`): multi-`--profile`, `--search`, `--commit-state`, `--source primary|backup`, `--sort name|url|date-added|folder|profile`, `--direction`, `--limit 1-100`, `--after` keyset cursor with query-fingerprint stale-cursor rejection.

## Notes

- Bookmarks are JSON-derived artifacts surfaced in their own `bookmarks` analyse summary block. Like Preferences metadata, they are recorded and independently queryable but **do not drive the Analysis Run exit state**, so existing History/Cookies/Login exit-code semantics stay byte-for-byte identical (a valid-but-empty or malformed Bookmarks document cannot flip an exit code). The SQLite primary stores remain the exit-state drivers.
- `Bookmarks` and `Bookmarks.bak` were already tier-1 expected in the selection policy, so ingest already copies them.

## Tests

- `e2e/bookmarks-cli.test.ts` — compiled-CLI pipeline: exact fields, distinct primary/backup Provenance, folder ancestry, timestamps, source/profile/search filters, date-added keyset pagination, stale-cursor rejection, malformed→unavailable / missing→absent.
- `core/test/bookmarks.test.ts` — parser units: deep folder ancestry, GUID-fallback rowId, missing url/name field states, skipped non-object/unknown-type nodes, and the absent / malformed / unsupported-shape distinction.

`pnpm verify` (format, lint, typecheck, full vitest — 112 tests) green on Node 24.15.0.