### PR TITLE
feat(candidates): rank identity and behavior Candidates from Findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Browser-level metadata (Chrome version, variations country, OSCrypt key presence
 Avatar and demographic values that live in the browser-level `profile.info_cache` slice are attributed to the owning Profile through a supporting Provenance row.
 Every value is verified against the current schema and carries a Field State: a removed or inapplicable key is `absent`, while a malformed or unreadable input is `unavailable` with a typed reason.
 
+After the Findings are written, the analyzer derives ranked identity and behavior **Candidates** from them (Web Data autofill, Preferences/Local State metadata, and History visits).
+A Candidate is nominal: it is a ranked hypothesis with a supporting count and resolvable row-level Provenance.
+A Candidate is never a Finding and never a factual summary tile.
+Names, countries, phone numbers, addresses, and habits only ever appear as ranked, hedged Candidates, never as asserted facts.
+Candidate generation reads Findings and never mutates, hides, or re-scores any source row.
+See [`docs/candidates.md`](docs/candidates.md) for the supported heuristics and their deterministic behavior for ties, no evidence, conflicting evidence, and unavailable inputs.
+
 ## Requirements
 
 - Node.js 24.15.0 or newer
@@ -211,6 +218,31 @@ You can repeat `--profile` to query at most 100 Profiles.
 Use `--commit-state` to keep committed and recovered rows separate.
 Each credential Finding carries Provenance, the raw and UTC timestamps with their Epoch Family, and the secret's encryption prefix.
 The secret itself stays `unavailable` with the reason `encrypted_secret_without_key_material` until authorized key material is supplied.
+
+## Query identity and behavior Candidates
+
+The `candidates` command returns ranked identity and behavior Candidates with the same bounded, multi-Profile query surface as the Finding lists.
+TYPE (the `candidateKind`) is the first column, and each query returns a Completeness Statement before any row.
+Each query returns 50 rows by default; set `--limit` from 1 through 100 and use `nextCursor` as the next `--after` value.
+
+```sh
+node cli/dist/cli.js candidates \
+  --case "/path/to/CASE-001" \
+  --profile Default \
+  --category identity \
+  --kind identity_email \
+  --search "example" \
+  --sort rank \
+  --direction asc \
+  --limit 50 \
+  --json
+```
+
+The sorts are `rank`, `kind`, `supporting-count`, `value`, and `profile`.
+Filter by `--category identity|behavior` and by an exact `--kind`, and repeat `--profile` to query at most 100 Profiles.
+Every row carries its `rank`, `supportingCount`, and resolvable Provenance; aggregated evidence is carried as supporting Provenance rows.
+A Candidate never carries a Commit State and is never a Finding.
+See [`docs/candidates.md`](docs/candidates.md) for the heuristics and the deterministic behavior for ties, no evidence, conflicting evidence, and unavailable inputs.
 
 ## Decrypt supported secrets offline
 

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -12,6 +12,7 @@ import {
   queryAutofill,
   queryBookmarks,
   queryCache,
+  queryCandidates,
   queryCookies,
   queryCredentials,
   queryDownloads,
@@ -23,6 +24,8 @@ import {
   renderReport,
   type AutofillDirection,
   type AutofillSort,
+  type CandidateDirection,
+  type CandidateSort,
   type BookmarkDirection,
   type BookmarkSort,
   type BookmarkSource,
@@ -96,6 +99,12 @@ const USAGE = `Usage:
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <created-time|last-used-time|field-name|value|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix candidates --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--category <identity|behavior>] [--kind <candidate-kind>]
+                   [--sort <rank|kind|supporting-count|value|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix favicons --case <case-directory>
@@ -182,6 +191,8 @@ const VALUE_OPTIONS = new Set([
   "--same-site",
   "--state",
   "--danger",
+  "--category",
+  "--kind",
   "--type",
   "--source",
   "--record-type",
@@ -950,6 +961,54 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as AutofillSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | AutofillDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "candidates") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--category",
+        "--kind",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The candidates command accepts no positional values.",
+      );
+    }
+    const result = queryCandidates({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      category: enumOption(parsed, "--category", [
+        "identity",
+        "behavior",
+      ] as const),
+      kind: optionValue(parsed, "--kind"),
+      sort: enumOption(parsed, "--sort", [
+        "rank",
+        "kind",
+        "supporting-count",
+        "value",
+        "profile",
+      ] as const) as CandidateSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | CandidateDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -69,12 +69,6 @@ interface CandidateRecord {
 
 interface CandidatePage {
   readonly status: "ok";
-  readonly completeness: {
-    readonly attempted: number;
-    readonly produced: number;
-    readonly absent: number;
-    readonly unavailable: number;
-  };
   readonly items: readonly CandidateRecord[];
   readonly nextCursor: string | null;
   readonly limit: number;
@@ -281,7 +275,9 @@ function renderFieldCell(field: FieldState): HTMLTableCellElement {
   return cell;
 }
 
-function collectColumns(rows: readonly Finding[]): readonly string[] {
+function collectColumns(
+  rows: readonly { readonly fields: Readonly<Record<string, FieldState>> }[],
+): readonly string[] {
   const columns: string[] = [];
   const seen = new Set<string>();
   for (const row of rows) {
@@ -670,20 +666,6 @@ const CANDIDATE_SORTS = [
   "profile",
 ] as const;
 
-function candidateColumns(rows: readonly CandidateRecord[]): readonly string[] {
-  const columns: string[] = [];
-  const seen = new Set<string>();
-  for (const row of rows) {
-    for (const key of Object.keys(row.fields)) {
-      if (!seen.has(key)) {
-        seen.add(key);
-        columns.push(key);
-      }
-    }
-  }
-  return columns;
-}
-
 /**
  * Candidates render in their own table. TYPE stays the first column, but the
  * Candidate is clearly not a Finding: RANK and SUPPORTING sit up front, and
@@ -696,7 +678,7 @@ function renderCandidateTable(rows: readonly CandidateRecord[]): HTMLElement {
       textContent: "No Candidates for this filter.",
     });
   }
-  const columns = candidateColumns(rows);
+  const columns = collectColumns(rows);
   const table = el("table", { className: "rows" });
   const head = el("tr");
   head.append(el("th", { className: "col-type", textContent: "TYPE" }));
@@ -745,45 +727,15 @@ function renderCandidateTable(rows: readonly CandidateRecord[]): HTMLElement {
   return table;
 }
 
-function renderCandidateCompleteness(
-  completeness: CandidatePage["completeness"] | undefined,
-): HTMLElement {
-  const panel = el("section", { className: "completeness" });
-  panel.append(el("h4", { textContent: "Completeness Statement" }));
-  if (completeness === undefined || completeness.attempted === 0) {
-    panel.append(
-      el("p", {
-        className: "muted",
-        textContent: "Candidate generation was not attempted.",
-      }),
-    );
-    return panel;
-  }
-  panel.append(
-    el("p", {
-      textContent:
-        `Attempted ${String(completeness.attempted)} · ` +
-        `produced ${String(completeness.produced)} · ` +
-        `absent ${String(completeness.absent)} · ` +
-        `unavailable ${String(completeness.unavailable)}`,
-    }),
-  );
-  panel.append(
-    el("p", {
-      className: "muted",
-      textContent:
-        "Candidates are nominal and ranked. They are never Findings and never " +
-        "factual summaries.",
-    }),
-  );
-  return panel;
-}
-
 async function renderCandidatesTab(container: HTMLElement): Promise<void> {
   container.replaceChildren(el("p", { textContent: "Loading…" }));
+  let completeness: CaseCompleteness;
   let profiles: CaseProfiles;
   try {
-    profiles = await callApi<CaseProfiles>("profiles", []);
+    [completeness, profiles] = await Promise.all([
+      callApi<CaseCompleteness>("completeness", []),
+      callApi<CaseProfiles>("profiles", []),
+    ]);
   } catch (error) {
     container.replaceChildren(
       el("p", {
@@ -876,7 +828,9 @@ async function renderCandidatesTab(container: HTMLElement): Promise<void> {
   apply.type = "button";
   bar.append(apply);
 
-  const completenessHost = el("div");
+  const statement = completeness.statements.find(
+    (entry) => entry.artifact === "Candidates",
+  );
   const status = el("div", { className: "list-status", textContent: "" });
   const body = el("div", { className: "list-body" });
   const moreButton = el("button", { textContent: "Load more" });
@@ -915,10 +869,6 @@ async function renderCandidatesTab(container: HTMLElement): Promise<void> {
     status.textContent = "Loading…";
     try {
       const page = await callApi<CandidatePage>("candidates", parameters);
-      // Completeness always renders before any row.
-      completenessHost.replaceChildren(
-        renderCandidateCompleteness(page.completeness),
-      );
       accumulated = [...accumulated, ...page.items];
       cursor = page.nextCursor;
       body.replaceChildren(renderCandidateTable(accumulated));
@@ -940,7 +890,14 @@ async function renderCandidatesTab(container: HTMLElement): Promise<void> {
     void load(false);
   });
 
-  container.replaceChildren(completenessHost, bar, status, body, moreButton);
+  // Completeness always renders before any row.
+  container.replaceChildren(
+    renderCompleteness(statement),
+    bar,
+    status,
+    body,
+    moreButton,
+  );
   void load(true);
 }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -45,9 +45,9 @@ interface Finding {
   readonly fields: Readonly<Record<string, FieldState>>;
 }
 
-interface Page {
+interface PageOf<Row> {
   readonly status: "ok";
-  readonly items: readonly Finding[];
+  readonly items: readonly Row[];
   readonly nextCursor: string | null;
   readonly limit: number;
 }
@@ -65,13 +65,6 @@ interface CandidateRecord {
     readonly rowId?: string;
   };
   readonly fields: Readonly<Record<string, FieldState>>;
-}
-
-interface CandidatePage {
-  readonly status: "ok";
-  readonly items: readonly CandidateRecord[];
-  readonly nextCursor: string | null;
-  readonly limit: number;
 }
 
 interface CompletenessArtifact {
@@ -104,6 +97,8 @@ interface CaseProfiles {
 interface ExtraFilter {
   readonly parameter: string;
   readonly label: string;
+  /** When present the filter renders a <select> of these values, not a text box. */
+  readonly options?: readonly string[];
 }
 
 interface ArtifactConfig {
@@ -113,6 +108,13 @@ interface ArtifactConfig {
   readonly completenessArtifact: string;
   readonly sorts: readonly string[];
   readonly extras: readonly ExtraFilter[];
+  /** Direction options; the first is the default. Defaults to desc-then-asc. */
+  readonly directions?: readonly string[];
+  /**
+   * A single ranked list with no Commit State duality (Candidates), instead of
+   * the committed + sidecar pair every Finding artifact renders.
+   */
+  readonly singleList?: boolean;
 }
 
 const TOKEN = window.__FORENSIX_TOKEN__ ?? "";
@@ -178,6 +180,23 @@ const ARTIFACTS: readonly ArtifactConfig[] = [
     completenessArtifact: "Top Sites",
     sorts: ["rank", "url", "title", "profile"],
     extras: [],
+  },
+  {
+    key: "candidates",
+    label: "Candidates",
+    route: "candidates",
+    completenessArtifact: "Candidates",
+    sorts: ["rank", "kind", "supporting-count", "value", "profile"],
+    directions: ["asc", "desc"],
+    singleList: true,
+    extras: [
+      {
+        parameter: "category",
+        label: "Category",
+        options: ["", "identity", "behavior"],
+      },
+      { parameter: "kind", label: "Kind" },
+    ],
   },
 ];
 
@@ -291,6 +310,43 @@ function collectColumns(
   return columns;
 }
 
+/** The SOURCE ROW cell shared by every result table: manifest · table · rowid. */
+function sourceRowCell(provenance: {
+  readonly manifestPath?: string;
+  readonly table?: string;
+  readonly rowId?: string;
+}): HTMLTableCellElement {
+  const source = [
+    provenance.manifestPath ?? "",
+    provenance.table ?? "",
+    provenance.rowId ?? "",
+  ]
+    .filter((part) => part.length > 0)
+    .join(" · ");
+  return el("td", { className: "muted", textContent: source });
+}
+
+/** Append one <td> per dynamic field column, marking a missing field absent. */
+function appendFieldCells(
+  tr: HTMLElement,
+  fields: Readonly<Record<string, FieldState>>,
+  columns: readonly string[],
+): void {
+  for (const column of columns) {
+    const field = fields[column];
+    tr.append(
+      field === undefined
+        ? el("td", {}, [
+            el("span", {
+              className: "mark mark-absent",
+              textContent: "absent",
+            }),
+          ])
+        : renderFieldCell(field),
+    );
+  }
+}
+
 function renderRowsTable(rows: readonly Finding[]): HTMLElement {
   if (rows.length === 0) {
     return el("p", {
@@ -323,62 +379,38 @@ function renderRowsTable(rows: readonly Finding[]): HTMLElement {
         textContent: COMMIT_LABELS[row.commitState],
       }),
     );
-    const source = [
-      row.provenance.manifestPath ?? "",
-      row.provenance.table ?? "",
-      row.provenance.rowId ?? "",
-    ]
-      .filter((part) => part.length > 0)
-      .join(" · ");
-    tr.append(el("td", { className: "muted", textContent: source }));
-    for (const column of columns) {
-      const field = row.fields[column];
-      tr.append(
-        field === undefined
-          ? el("td", {}, [
-              el("span", {
-                className: "mark mark-absent",
-                textContent: "absent",
-              }),
-            ])
-          : renderFieldCell(field),
-      );
-    }
+    tr.append(sourceRowCell(row.provenance));
+    appendFieldCells(tr, row.fields, columns);
     tbody.append(tr);
   }
   table.append(thead, tbody);
   return table;
 }
 
-interface ListParameters {
-  readonly config: ArtifactConfig;
-  readonly commitStates: readonly CommitState[];
-  readonly base: readonly (readonly [string, string])[];
+interface PaginatedListParameters<Row> {
+  readonly route: string;
   readonly heading: string;
+  readonly controls?: HTMLElement;
+  /** Full query parameters for one load, evaluated fresh each request. */
+  readonly baseParams: () => readonly (readonly [string, string])[];
+  readonly renderTable: (rows: readonly Row[]) => HTMLElement;
+  /** Wire a control (e.g. a Commit State select) to reload from the top. */
+  readonly bindReload?: (reload: () => void) => void;
 }
 
 /**
- * One keyset-paginated, single-commit-state list. Committed and sidecar rows
- * live in separate lists, so each list pins exactly one Commit State.
+ * One keyset-paginated list: status line, accumulating body, and Load more.
+ * Every artifact list — Finding or Candidate — shares this loop; only the row
+ * renderer and the per-load parameters differ.
  */
-function createList(parameters: ListParameters): HTMLElement {
+function createPaginatedList<Row>(
+  parameters: PaginatedListParameters<Row>,
+): HTMLElement {
   const section = el("section", { className: "list" });
   section.append(el("h4", { textContent: parameters.heading }));
   const controls = el("div", { className: "list-controls" });
-  const commitSelect = el("select");
-  for (const state of parameters.commitStates) {
-    const option = document.createElement("option");
-    option.value = state;
-    option.textContent = COMMIT_LABELS[state];
-    commitSelect.append(option);
-  }
-  if (parameters.commitStates.length > 1) {
-    const label = el("label", {
-      className: "inline",
-      textContent: "Commit State ",
-    });
-    label.append(commitSelect);
-    controls.append(label);
+  if (parameters.controls !== undefined) {
+    controls.append(parameters.controls);
   }
   const status = el("div", { className: "list-status", textContent: "" });
   const body = el("div", { className: "list-body" });
@@ -388,27 +420,23 @@ function createList(parameters: ListParameters): HTMLElement {
   section.append(controls, status, body, moreButton);
 
   let cursor: string | null = null;
-  let accumulated: Finding[] = [];
+  let accumulated: Row[] = [];
 
   const load = async (reset: boolean): Promise<void> => {
     if (reset) {
       cursor = null;
       accumulated = [];
     }
-    const commitState = commitSelect.value;
-    const request: (readonly [string, string])[] = [
-      ...parameters.base,
-      ["commit-state", commitState],
-    ];
+    const request: (readonly [string, string])[] = [...parameters.baseParams()];
     if (cursor !== null) {
       request.push(["after", cursor]);
     }
     status.textContent = "Loading…";
     try {
-      const page = await callApi<Page>(parameters.config.route, request);
+      const page = await callApi<PageOf<Row>>(parameters.route, request);
       accumulated = [...accumulated, ...page.items];
       cursor = page.nextCursor;
-      body.replaceChildren(renderRowsTable(accumulated));
+      body.replaceChildren(parameters.renderTable(accumulated));
       status.textContent = `${String(accumulated.length)} row(s) shown${
         cursor === null ? "" : "; more available"
       }.`;
@@ -423,11 +451,52 @@ function createList(parameters: ListParameters): HTMLElement {
   moreButton.addEventListener("click", () => {
     void load(false);
   });
-  commitSelect.addEventListener("change", () => {
+  parameters.bindReload?.(() => {
     void load(true);
   });
   void load(true);
   return section;
+}
+
+/**
+ * One keyset-paginated, single-commit-state Finding list. Committed and sidecar
+ * rows live in separate lists, so each list pins exactly one Commit State.
+ */
+function createList(parameters: {
+  readonly config: ArtifactConfig;
+  readonly commitStates: readonly CommitState[];
+  readonly base: readonly (readonly [string, string])[];
+  readonly heading: string;
+}): HTMLElement {
+  const commitSelect = el("select");
+  for (const state of parameters.commitStates) {
+    const option = document.createElement("option");
+    option.value = state;
+    option.textContent = COMMIT_LABELS[state];
+    commitSelect.append(option);
+  }
+  let controls: HTMLElement | undefined;
+  if (parameters.commitStates.length > 1) {
+    const label = el("label", {
+      className: "inline",
+      textContent: "Commit State ",
+    });
+    label.append(commitSelect);
+    controls = label;
+  }
+  return createPaginatedList<Finding>({
+    route: parameters.config.route,
+    heading: parameters.heading,
+    ...(controls === undefined ? {} : { controls }),
+    baseParams: () => [
+      ...parameters.base,
+      ["commit-state", commitSelect.value],
+    ],
+    renderTable: renderRowsTable,
+    bindReload: (reload) => {
+      commitSelect.addEventListener("change", reload);
+    },
+  });
 }
 
 function renderCompleteness(
@@ -516,7 +585,7 @@ function collectFilters(
   sortLabel.append(sortSelect);
 
   const directionSelect = el("select");
-  for (const direction of ["desc", "asc"]) {
+  for (const direction of config.directions ?? ["desc", "asc"]) {
     const option = document.createElement("option");
     option.value = direction;
     option.textContent = direction;
@@ -539,15 +608,27 @@ function collectFilters(
 
   bar.append(searchLabel, sortLabel, directionLabel, limitLabel);
 
-  const extraInputs = new Map<string, HTMLInputElement>();
+  const extraInputs = new Map<string, HTMLInputElement | HTMLSelectElement>();
   for (const extra of config.extras) {
-    const input = el("input", { type: "text", value: "" });
+    let control: HTMLInputElement | HTMLSelectElement;
+    if (extra.options === undefined) {
+      control = el("input", { type: "text", value: "" });
+    } else {
+      const select = el("select");
+      for (const option of extra.options) {
+        const node = document.createElement("option");
+        node.value = option;
+        node.textContent = option === "" ? "all" : option;
+        select.append(node);
+      }
+      control = select;
+    }
     const label = el("label", {
       className: "inline",
       textContent: `${extra.label} `,
     });
-    label.append(input);
-    extraInputs.set(extra.parameter, input);
+    label.append(control);
+    extraInputs.set(extra.parameter, control);
     bar.append(label);
   }
 
@@ -633,6 +714,18 @@ async function renderArtifactTab(
 
   const draw = (): void => {
     const { base } = filters.read();
+    if (config.singleList === true) {
+      // Candidates are one ranked list with no Commit State duality.
+      listsHost.replaceChildren(
+        createPaginatedList<CandidateRecord>({
+          route: config.route,
+          heading: "Ranked Candidates",
+          baseParams: () => base,
+          renderTable: renderCandidateTable,
+        }),
+      );
+      return;
+    }
     listsHost.replaceChildren(
       createList({
         config,
@@ -658,14 +751,6 @@ async function renderArtifactTab(
   draw();
 }
 
-const CANDIDATE_SORTS = [
-  "rank",
-  "kind",
-  "supporting-count",
-  "value",
-  "profile",
-] as const;
-
 /**
  * Candidates render in their own table. TYPE stays the first column, but the
  * Candidate is clearly not a Finding: RANK and SUPPORTING sit up front, and
@@ -681,12 +766,21 @@ function renderCandidateTable(rows: readonly CandidateRecord[]): HTMLElement {
   const columns = collectColumns(rows);
   const table = el("table", { className: "rows" });
   const head = el("tr");
-  head.append(el("th", { className: "col-type", textContent: "TYPE" }));
-  head.append(el("th", { textContent: "CATEGORY" }));
-  head.append(el("th", { textContent: "PROFILE" }));
-  head.append(el("th", { textContent: "RANK" }));
-  head.append(el("th", { textContent: "SUPPORTING" }));
-  head.append(el("th", { textContent: "SOURCE ROW" }));
+  for (const column of [
+    "TYPE",
+    "CATEGORY",
+    "PROFILE",
+    "RANK",
+    "SUPPORTING",
+    "SOURCE ROW",
+  ]) {
+    head.append(
+      el("th", {
+        className: column === "TYPE" ? "col-type" : "",
+        textContent: column,
+      }),
+    );
+  }
   for (const column of columns) {
     head.append(el("th", { textContent: column }));
   }
@@ -700,205 +794,12 @@ function renderCandidateTable(rows: readonly CandidateRecord[]): HTMLElement {
     tr.append(el("td", { textContent: row.profile }));
     tr.append(el("td", { textContent: String(row.rank) }));
     tr.append(el("td", { textContent: String(row.supportingCount) }));
-    const source = [
-      row.provenance.manifestPath ?? "",
-      row.provenance.table ?? "",
-      row.provenance.rowId ?? "",
-    ]
-      .filter((part) => part.length > 0)
-      .join(" · ");
-    tr.append(el("td", { className: "muted", textContent: source }));
-    for (const column of columns) {
-      const field = row.fields[column];
-      tr.append(
-        field === undefined
-          ? el("td", {}, [
-              el("span", {
-                className: "mark mark-absent",
-                textContent: "absent",
-              }),
-            ])
-          : renderFieldCell(field),
-      );
-    }
+    tr.append(sourceRowCell(row.provenance));
+    appendFieldCells(tr, row.fields, columns);
     tbody.append(tr);
   }
   table.append(el("thead", {}, [head]), tbody);
   return table;
-}
-
-async function renderCandidatesTab(container: HTMLElement): Promise<void> {
-  container.replaceChildren(el("p", { textContent: "Loading…" }));
-  let completeness: CaseCompleteness;
-  let profiles: CaseProfiles;
-  try {
-    [completeness, profiles] = await Promise.all([
-      callApi<CaseCompleteness>("completeness", []),
-      callApi<CaseProfiles>("profiles", []),
-    ]);
-  } catch (error) {
-    container.replaceChildren(
-      el("p", {
-        className: "mark mark-unavailable",
-        textContent:
-          error instanceof Error
-            ? `Error: ${error.message}`
-            : "Request failed.",
-      }),
-    );
-    return;
-  }
-
-  const bar = el("div", { className: "filters" });
-  const search = el("input", { type: "search", value: "" });
-  const searchLabel = el("label", {
-    className: "inline",
-    textContent: "Search ",
-  });
-  searchLabel.append(search);
-  const categorySelect = el("select");
-  for (const option of ["", "identity", "behavior"]) {
-    const node = document.createElement("option");
-    node.value = option;
-    node.textContent = option === "" ? "all categories" : option;
-    categorySelect.append(node);
-  }
-  const categoryLabel = el("label", {
-    className: "inline",
-    textContent: "Category ",
-  });
-  categoryLabel.append(categorySelect);
-  const kind = el("input", { type: "text", value: "" });
-  const kindLabel = el("label", { className: "inline", textContent: "Kind " });
-  kindLabel.append(kind);
-  const sortSelect = el("select");
-  for (const sort of CANDIDATE_SORTS) {
-    const node = document.createElement("option");
-    node.value = sort;
-    node.textContent = sort;
-    sortSelect.append(node);
-  }
-  const sortLabel = el("label", { className: "inline", textContent: "Sort " });
-  sortLabel.append(sortSelect);
-  const directionSelect = el("select");
-  for (const direction of ["asc", "desc"]) {
-    const node = document.createElement("option");
-    node.value = direction;
-    node.textContent = direction;
-    directionSelect.append(node);
-  }
-  const directionLabel = el("label", {
-    className: "inline",
-    textContent: "Direction ",
-  });
-  directionLabel.append(directionSelect);
-  const limit = el("input", { type: "number", value: "25" });
-  limit.min = "1";
-  limit.max = "100";
-  const limitLabel = el("label", {
-    className: "inline",
-    textContent: "Limit ",
-  });
-  limitLabel.append(limit);
-  bar.append(
-    searchLabel,
-    categoryLabel,
-    kindLabel,
-    sortLabel,
-    directionLabel,
-    limitLabel,
-  );
-  const profileBox = el("fieldset", { className: "profiles" });
-  profileBox.append(el("legend", { textContent: "Profiles (multi-select)" }));
-  const profileInputs = new Map<string, HTMLInputElement>();
-  if (profiles.profiles.length === 0) {
-    profileBox.append(
-      el("span", { className: "muted", textContent: "No Profiles." }),
-    );
-  }
-  for (const profile of profiles.profiles) {
-    const checkbox = el("input", { type: "checkbox", value: profile });
-    profileInputs.set(profile, checkbox);
-    profileBox.append(
-      el("label", { className: "inline" }, [checkbox, ` ${profile}`]),
-    );
-  }
-  bar.append(profileBox);
-  const apply = el("button", { textContent: "Apply filters" });
-  apply.type = "button";
-  bar.append(apply);
-
-  const statement = completeness.statements.find(
-    (entry) => entry.artifact === "Candidates",
-  );
-  const status = el("div", { className: "list-status", textContent: "" });
-  const body = el("div", { className: "list-body" });
-  const moreButton = el("button", { textContent: "Load more" });
-  moreButton.type = "button";
-  moreButton.style.display = "none";
-
-  let cursor: string | null = null;
-  let accumulated: CandidateRecord[] = [];
-
-  const request = (): (readonly [string, string])[] => {
-    const base: (readonly [string, string])[] = [
-      ["search", search.value.trim()],
-      ["category", categorySelect.value],
-      ["kind", kind.value.trim()],
-      ["sort", sortSelect.value],
-      ["direction", directionSelect.value],
-      ["limit", limit.value.trim()],
-    ];
-    for (const [profile, checkbox] of profileInputs) {
-      if (checkbox.checked) {
-        base.push(["profile", profile]);
-      }
-    }
-    return base;
-  };
-
-  const load = async (reset: boolean): Promise<void> => {
-    if (reset) {
-      cursor = null;
-      accumulated = [];
-    }
-    const parameters = request();
-    if (cursor !== null) {
-      parameters.push(["after", cursor]);
-    }
-    status.textContent = "Loading…";
-    try {
-      const page = await callApi<CandidatePage>("candidates", parameters);
-      accumulated = [...accumulated, ...page.items];
-      cursor = page.nextCursor;
-      body.replaceChildren(renderCandidateTable(accumulated));
-      status.textContent = `${String(accumulated.length)} Candidate(s) shown${
-        cursor === null ? "" : "; more available"
-      }.`;
-      moreButton.style.display = cursor === null ? "none" : "inline-block";
-    } catch (error) {
-      status.textContent =
-        error instanceof Error ? `Error: ${error.message}` : "Request failed.";
-      moreButton.style.display = "none";
-    }
-  };
-
-  apply.addEventListener("click", () => {
-    void load(true);
-  });
-  moreButton.addEventListener("click", () => {
-    void load(false);
-  });
-
-  // Completeness always renders before any row.
-  container.replaceChildren(
-    renderCompleteness(statement),
-    bar,
-    status,
-    body,
-    moreButton,
-  );
-  void load(true);
 }
 
 function renderLegend(): HTMLElement {
@@ -988,43 +889,30 @@ function main(): void {
   const main = el("main");
   const buttons = new Map<string, HTMLButtonElement>();
 
-  const CANDIDATES_KEY = "candidates";
-
-  const select = (key: string): void => {
+  const select = (config: ArtifactConfig): void => {
     for (const [buttonKey, button] of buttons) {
-      button.setAttribute("aria-current", buttonKey === key ? "true" : "false");
+      button.setAttribute(
+        "aria-current",
+        buttonKey === config.key ? "true" : "false",
+      );
     }
-    if (key === CANDIDATES_KEY) {
-      void renderCandidatesTab(main);
-      return;
-    }
-    const config = ARTIFACTS.find((entry) => entry.key === key);
-    if (config !== undefined) {
-      void renderArtifactTab(config, main);
-    }
+    void renderArtifactTab(config, main);
   };
 
   for (const config of ARTIFACTS) {
     const button = el("button", { textContent: config.label });
     button.type = "button";
     button.addEventListener("click", () => {
-      select(config.key);
+      select(config);
     });
     buttons.set(config.key, button);
     nav.append(button);
   }
-  const candidatesButton = el("button", { textContent: "Candidates" });
-  candidatesButton.type = "button";
-  candidatesButton.addEventListener("click", () => {
-    select(CANDIDATES_KEY);
-  });
-  buttons.set(CANDIDATES_KEY, candidatesButton);
-  nav.append(candidatesButton);
 
   root.replaceChildren(header, nav, renderLegend(), main);
   const first = ARTIFACTS[0];
   if (first !== undefined) {
-    select(first.key);
+    select(first);
   }
 }
 

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -52,6 +52,34 @@ interface Page {
   readonly limit: number;
 }
 
+interface CandidateRecord {
+  readonly recordType: "candidate";
+  readonly candidateKind: string;
+  readonly category: "identity" | "behavior";
+  readonly profile: string;
+  readonly rank: number;
+  readonly supportingCount: number;
+  readonly provenance: {
+    readonly manifestPath?: string;
+    readonly table?: string;
+    readonly rowId?: string;
+  };
+  readonly fields: Readonly<Record<string, FieldState>>;
+}
+
+interface CandidatePage {
+  readonly status: "ok";
+  readonly completeness: {
+    readonly attempted: number;
+    readonly produced: number;
+    readonly absent: number;
+    readonly unavailable: number;
+  };
+  readonly items: readonly CandidateRecord[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
 interface CompletenessArtifact {
   readonly sourceId: string;
   readonly profile: string;
@@ -634,6 +662,288 @@ async function renderArtifactTab(
   draw();
 }
 
+const CANDIDATE_SORTS = [
+  "rank",
+  "kind",
+  "supporting-count",
+  "value",
+  "profile",
+] as const;
+
+function candidateColumns(rows: readonly CandidateRecord[]): readonly string[] {
+  const columns: string[] = [];
+  const seen = new Set<string>();
+  for (const row of rows) {
+    for (const key of Object.keys(row.fields)) {
+      if (!seen.has(key)) {
+        seen.add(key);
+        columns.push(key);
+      }
+    }
+  }
+  return columns;
+}
+
+/**
+ * Candidates render in their own table. TYPE stays the first column, but the
+ * Candidate is clearly not a Finding: RANK and SUPPORTING sit up front, and
+ * there is no Commit State. Nominal values live only in the field columns.
+ */
+function renderCandidateTable(rows: readonly CandidateRecord[]): HTMLElement {
+  if (rows.length === 0) {
+    return el("p", {
+      className: "muted",
+      textContent: "No Candidates for this filter.",
+    });
+  }
+  const columns = candidateColumns(rows);
+  const table = el("table", { className: "rows" });
+  const head = el("tr");
+  head.append(el("th", { className: "col-type", textContent: "TYPE" }));
+  head.append(el("th", { textContent: "CATEGORY" }));
+  head.append(el("th", { textContent: "PROFILE" }));
+  head.append(el("th", { textContent: "RANK" }));
+  head.append(el("th", { textContent: "SUPPORTING" }));
+  head.append(el("th", { textContent: "SOURCE ROW" }));
+  for (const column of columns) {
+    head.append(el("th", { textContent: column }));
+  }
+  const tbody = el("tbody");
+  for (const row of rows) {
+    const tr = el("tr");
+    tr.append(
+      el("td", { className: "col-type", textContent: row.candidateKind }),
+    );
+    tr.append(el("td", { textContent: row.category }));
+    tr.append(el("td", { textContent: row.profile }));
+    tr.append(el("td", { textContent: String(row.rank) }));
+    tr.append(el("td", { textContent: String(row.supportingCount) }));
+    const source = [
+      row.provenance.manifestPath ?? "",
+      row.provenance.table ?? "",
+      row.provenance.rowId ?? "",
+    ]
+      .filter((part) => part.length > 0)
+      .join(" · ");
+    tr.append(el("td", { className: "muted", textContent: source }));
+    for (const column of columns) {
+      const field = row.fields[column];
+      tr.append(
+        field === undefined
+          ? el("td", {}, [
+              el("span", {
+                className: "mark mark-absent",
+                textContent: "absent",
+              }),
+            ])
+          : renderFieldCell(field),
+      );
+    }
+    tbody.append(tr);
+  }
+  table.append(el("thead", {}, [head]), tbody);
+  return table;
+}
+
+function renderCandidateCompleteness(
+  completeness: CandidatePage["completeness"] | undefined,
+): HTMLElement {
+  const panel = el("section", { className: "completeness" });
+  panel.append(el("h4", { textContent: "Completeness Statement" }));
+  if (completeness === undefined || completeness.attempted === 0) {
+    panel.append(
+      el("p", {
+        className: "muted",
+        textContent: "Candidate generation was not attempted.",
+      }),
+    );
+    return panel;
+  }
+  panel.append(
+    el("p", {
+      textContent:
+        `Attempted ${String(completeness.attempted)} · ` +
+        `produced ${String(completeness.produced)} · ` +
+        `absent ${String(completeness.absent)} · ` +
+        `unavailable ${String(completeness.unavailable)}`,
+    }),
+  );
+  panel.append(
+    el("p", {
+      className: "muted",
+      textContent:
+        "Candidates are nominal and ranked. They are never Findings and never " +
+        "factual summaries.",
+    }),
+  );
+  return panel;
+}
+
+async function renderCandidatesTab(container: HTMLElement): Promise<void> {
+  container.replaceChildren(el("p", { textContent: "Loading…" }));
+  let profiles: CaseProfiles;
+  try {
+    profiles = await callApi<CaseProfiles>("profiles", []);
+  } catch (error) {
+    container.replaceChildren(
+      el("p", {
+        className: "mark mark-unavailable",
+        textContent:
+          error instanceof Error
+            ? `Error: ${error.message}`
+            : "Request failed.",
+      }),
+    );
+    return;
+  }
+
+  const bar = el("div", { className: "filters" });
+  const search = el("input", { type: "search", value: "" });
+  const searchLabel = el("label", {
+    className: "inline",
+    textContent: "Search ",
+  });
+  searchLabel.append(search);
+  const categorySelect = el("select");
+  for (const option of ["", "identity", "behavior"]) {
+    const node = document.createElement("option");
+    node.value = option;
+    node.textContent = option === "" ? "all categories" : option;
+    categorySelect.append(node);
+  }
+  const categoryLabel = el("label", {
+    className: "inline",
+    textContent: "Category ",
+  });
+  categoryLabel.append(categorySelect);
+  const kind = el("input", { type: "text", value: "" });
+  const kindLabel = el("label", { className: "inline", textContent: "Kind " });
+  kindLabel.append(kind);
+  const sortSelect = el("select");
+  for (const sort of CANDIDATE_SORTS) {
+    const node = document.createElement("option");
+    node.value = sort;
+    node.textContent = sort;
+    sortSelect.append(node);
+  }
+  const sortLabel = el("label", { className: "inline", textContent: "Sort " });
+  sortLabel.append(sortSelect);
+  const directionSelect = el("select");
+  for (const direction of ["asc", "desc"]) {
+    const node = document.createElement("option");
+    node.value = direction;
+    node.textContent = direction;
+    directionSelect.append(node);
+  }
+  const directionLabel = el("label", {
+    className: "inline",
+    textContent: "Direction ",
+  });
+  directionLabel.append(directionSelect);
+  const limit = el("input", { type: "number", value: "25" });
+  limit.min = "1";
+  limit.max = "100";
+  const limitLabel = el("label", {
+    className: "inline",
+    textContent: "Limit ",
+  });
+  limitLabel.append(limit);
+  bar.append(
+    searchLabel,
+    categoryLabel,
+    kindLabel,
+    sortLabel,
+    directionLabel,
+    limitLabel,
+  );
+  const profileBox = el("fieldset", { className: "profiles" });
+  profileBox.append(el("legend", { textContent: "Profiles (multi-select)" }));
+  const profileInputs = new Map<string, HTMLInputElement>();
+  if (profiles.profiles.length === 0) {
+    profileBox.append(
+      el("span", { className: "muted", textContent: "No Profiles." }),
+    );
+  }
+  for (const profile of profiles.profiles) {
+    const checkbox = el("input", { type: "checkbox", value: profile });
+    profileInputs.set(profile, checkbox);
+    profileBox.append(
+      el("label", { className: "inline" }, [checkbox, ` ${profile}`]),
+    );
+  }
+  bar.append(profileBox);
+  const apply = el("button", { textContent: "Apply filters" });
+  apply.type = "button";
+  bar.append(apply);
+
+  const completenessHost = el("div");
+  const status = el("div", { className: "list-status", textContent: "" });
+  const body = el("div", { className: "list-body" });
+  const moreButton = el("button", { textContent: "Load more" });
+  moreButton.type = "button";
+  moreButton.style.display = "none";
+
+  let cursor: string | null = null;
+  let accumulated: CandidateRecord[] = [];
+
+  const request = (): (readonly [string, string])[] => {
+    const base: (readonly [string, string])[] = [
+      ["search", search.value.trim()],
+      ["category", categorySelect.value],
+      ["kind", kind.value.trim()],
+      ["sort", sortSelect.value],
+      ["direction", directionSelect.value],
+      ["limit", limit.value.trim()],
+    ];
+    for (const [profile, checkbox] of profileInputs) {
+      if (checkbox.checked) {
+        base.push(["profile", profile]);
+      }
+    }
+    return base;
+  };
+
+  const load = async (reset: boolean): Promise<void> => {
+    if (reset) {
+      cursor = null;
+      accumulated = [];
+    }
+    const parameters = request();
+    if (cursor !== null) {
+      parameters.push(["after", cursor]);
+    }
+    status.textContent = "Loading…";
+    try {
+      const page = await callApi<CandidatePage>("candidates", parameters);
+      // Completeness always renders before any row.
+      completenessHost.replaceChildren(
+        renderCandidateCompleteness(page.completeness),
+      );
+      accumulated = [...accumulated, ...page.items];
+      cursor = page.nextCursor;
+      body.replaceChildren(renderCandidateTable(accumulated));
+      status.textContent = `${String(accumulated.length)} Candidate(s) shown${
+        cursor === null ? "" : "; more available"
+      }.`;
+      moreButton.style.display = cursor === null ? "none" : "inline-block";
+    } catch (error) {
+      status.textContent =
+        error instanceof Error ? `Error: ${error.message}` : "Request failed.";
+      moreButton.style.display = "none";
+    }
+  };
+
+  apply.addEventListener("click", () => {
+    void load(true);
+  });
+  moreButton.addEventListener("click", () => {
+    void load(false);
+  });
+
+  container.replaceChildren(completenessHost, bar, status, body, moreButton);
+  void load(true);
+}
+
 function renderLegend(): HTMLElement {
   const legend = el("section", { className: "legend" });
   legend.append(el("h4", { textContent: "How to read values" }));
@@ -721,30 +1031,43 @@ function main(): void {
   const main = el("main");
   const buttons = new Map<string, HTMLButtonElement>();
 
-  const select = (config: ArtifactConfig): void => {
-    for (const [key, button] of buttons) {
-      button.setAttribute(
-        "aria-current",
-        key === config.key ? "true" : "false",
-      );
+  const CANDIDATES_KEY = "candidates";
+
+  const select = (key: string): void => {
+    for (const [buttonKey, button] of buttons) {
+      button.setAttribute("aria-current", buttonKey === key ? "true" : "false");
     }
-    void renderArtifactTab(config, main);
+    if (key === CANDIDATES_KEY) {
+      void renderCandidatesTab(main);
+      return;
+    }
+    const config = ARTIFACTS.find((entry) => entry.key === key);
+    if (config !== undefined) {
+      void renderArtifactTab(config, main);
+    }
   };
 
   for (const config of ARTIFACTS) {
     const button = el("button", { textContent: config.label });
     button.type = "button";
     button.addEventListener("click", () => {
-      select(config);
+      select(config.key);
     });
     buttons.set(config.key, button);
     nav.append(button);
   }
+  const candidatesButton = el("button", { textContent: "Candidates" });
+  candidatesButton.type = "button";
+  candidatesButton.addEventListener("click", () => {
+    select(CANDIDATES_KEY);
+  });
+  buttons.set(CANDIDATES_KEY, candidatesButton);
+  nav.append(candidatesButton);
 
   root.replaceChildren(header, nav, renderLegend(), main);
   const first = ARTIFACTS[0];
   if (first !== undefined) {
-    select(first);
+    select(first.key);
   }
 }
 

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -4,7 +4,11 @@ import { DatabaseSync } from "node:sqlite";
 
 import { CASE_FILENAME, TOOL_VERSION } from "./case.js";
 import { openDatabaseSync } from "./sqlite-open.js";
-import type { Candidate, Finding } from "./forensic-model.js";
+import type {
+  Candidate,
+  CandidateCategory,
+  Finding,
+} from "./forensic-model.js";
 
 export type DeclaredOriginOs = "windows" | "macos" | "linux";
 
@@ -34,7 +38,7 @@ export interface PersistedCandidate {
  */
 export interface PersistedIdentityCandidate {
   readonly candidate: Candidate;
-  readonly category: "identity" | "behavior";
+  readonly category: CandidateCategory;
   readonly profile: string;
   readonly searchText: string;
   readonly sortValue: string;

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -25,6 +25,29 @@ export interface PersistedCandidate {
   readonly searchText: string;
 }
 
+/**
+ * A ranked identity/behavior Candidate (issue #185). Unlike the History-scoped
+ * `PersistedCandidate` above, these are derived across Web Data, Preferences,
+ * and History Findings and carry a category plus a normalized sort key. They
+ * are never Findings and never carry a Commit State: they summarize committed
+ * evidence, ranked and hedged.
+ */
+export interface PersistedIdentityCandidate {
+  readonly candidate: Candidate;
+  readonly category: "identity" | "behavior";
+  readonly profile: string;
+  readonly searchText: string;
+  readonly sortValue: string;
+}
+
+export interface CandidateArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly reason: string | null;
+  readonly candidates: readonly PersistedIdentityCandidate[];
+}
+
 export interface HistoryArtifactWrite {
   readonly sourceId: string;
   readonly profile: string;
@@ -298,6 +321,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
   readonly bookmarksArtifacts?: readonly BookmarksArtifactWrite[];
   readonly cacheArtifacts?: readonly CacheArtifactWrite[];
+  readonly candidateArtifacts?: readonly CandidateArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -425,6 +449,43 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON forensic_candidates(candidate_kind, COALESCE(topic_label, ''), candidate_id);
     CREATE INDEX IF NOT EXISTS forensic_candidates_profile_query
       ON forensic_candidates(candidate_kind, profile_path, commit_state, candidate_id);
+
+    CREATE TABLE IF NOT EXISTS candidate_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Candidates'),
+      database_path TEXT NOT NULL,
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS candidate_one_active_result
+      ON candidate_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS identity_candidates (
+      candidate_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES candidate_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      record_type TEXT NOT NULL CHECK (record_type = 'candidate'),
+      candidate_kind TEXT NOT NULL,
+      category TEXT NOT NULL CHECK (category IN ('identity', 'behavior')),
+      profile_path TEXT NOT NULL,
+      rank INTEGER NOT NULL CHECK (rank > 0),
+      supporting_count INTEGER NOT NULL CHECK (supporting_count > 0),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_value TEXT NOT NULL
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS identity_candidates_query
+      ON identity_candidates(candidate_kind, rank, candidate_id);
 
     CREATE TABLE IF NOT EXISTS login_data_artifact_results (
       artifact_result_id INTEGER PRIMARY KEY,
@@ -1042,6 +1103,29 @@ function insertCandidate(
   );
 }
 
+function insertIdentityCandidate(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedIdentityCandidate,
+): void {
+  const candidate = row.candidate;
+  statement.run(
+    artifactResultId,
+    runId,
+    candidate.recordType,
+    candidate.candidateKind,
+    row.category,
+    row.profile,
+    candidate.rank,
+    candidate.count,
+    JSON.stringify(candidate.provenance),
+    JSON.stringify(candidate.fields),
+    row.searchText,
+    row.sortValue,
+  );
+}
+
 function insertLoginFinding(
   statement: ReturnType<DatabaseSync["prepare"]>,
   artifactResultId: bigint,
@@ -1313,6 +1397,7 @@ export function storeHistoryAnalysis(
   const cookieArtifacts = options.cookieArtifacts ?? [];
   const metadataArtifacts = options.metadataArtifacts ?? [];
   const bookmarksArtifacts = options.bookmarksArtifacts ?? [];
+  const candidateArtifacts = options.candidateArtifacts ?? [];
   const runId = randomUUID();
   const database = openDatabaseSync(
     join(resolve(options.caseDirectory), CASE_FILENAME),
@@ -1594,6 +1679,28 @@ export function storeHistoryAnalysis(
       );
       const activateCurrentCache = database.prepare(
         "UPDATE cache_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
+      const insertCandidateArtifact = database.prepare(
+        `INSERT INTO candidate_artifact_results
+           (run_id, source_id, profile_path, artifact, database_path, status,
+            reason, active)
+         VALUES (?, ?, ?, 'Candidates', 'Candidates', ?, ?, 0)`,
+      );
+      const insertIdentityCandidateStatement = database.prepare(
+        `INSERT INTO identity_candidates
+           (artifact_result_id, run_id, record_type, candidate_kind, category,
+            profile_path, rank, supporting_count, provenance_json, fields_json,
+            search_text, sort_value)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousCandidate = database.prepare(
+        `UPDATE candidate_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Candidates'
+            AND active = 1`,
+      );
+      const activateCurrentCandidate = database.prepare(
+        "UPDATE candidate_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
 
       for (const artifact of options.artifacts) {
@@ -1891,6 +1998,29 @@ export function storeHistoryAnalysis(
         if (artifact.status === "complete") {
           deactivatePreviousCache.run(artifact.sourceId, artifact.profile);
           activateCurrentCache.run(artifactResultId);
+        }
+      }
+
+      for (const artifact of candidateArtifacts) {
+        const insertion = insertCandidateArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const candidate of artifact.candidates) {
+          insertIdentityCandidate(
+            insertIdentityCandidateStatement,
+            artifactResultId,
+            runId,
+            candidate,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousCandidate.run(artifact.sourceId, artifact.profile);
+          activateCurrentCandidate.run(artifactResultId);
         }
       }
 

--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -18,7 +18,8 @@ export type OverviewArtifact =
   | "Login Data"
   | "Top Sites"
   | "Web Data"
-  | "Favicons";
+  | "Favicons"
+  | "Candidates";
 export type CompletenessOutcome = "produced" | "absent" | "unavailable";
 
 export interface CompletenessArtifact {
@@ -82,6 +83,7 @@ const ARTIFACT_TABLES: readonly ArtifactTable[] = [
   { artifact: "Top Sites", resultsTable: "top_sites_artifact_results" },
   { artifact: "Web Data", resultsTable: "web_data_artifact_results" },
   { artifact: "Favicons", resultsTable: "favicon_artifact_results" },
+  { artifact: "Candidates", resultsTable: "candidate_artifact_results" },
 ];
 
 function openCase(caseDirectory: string): DatabaseSync {

--- a/core/src/forensic-model.ts
+++ b/core/src/forensic-model.ts
@@ -67,6 +67,8 @@ export interface Finding<
   readonly [findingBrand]: true;
 }
 
+export type CandidateCategory = "identity" | "behavior";
+
 export interface Candidate<
   Kind extends string = string,
   Fields extends ForensicFields = ForensicFields,

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -22,6 +22,7 @@ import { analyseSourceCookies } from "./cookies.js";
 import { analyseDownloadsProfile } from "./downloads.js";
 import { analyseSourceFavicons } from "./favicons.js";
 import { analyseLoginDataProfile } from "./login-data.js";
+import { generateCaseCandidates } from "./identity-candidates.js";
 import { analyseSourcePreferences } from "./preferences.js";
 import { analyseSourceTopSites } from "./top-sites.js";
 import { analyseWebDataProfile } from "./web-data.js";
@@ -1400,6 +1401,16 @@ export async function analyseCase(
     options.topicClassification,
   );
 
+  // Identity and behavior Candidates are derived from the Findings just
+  // produced: Web Data autofill, Preferences/Local State metadata, and History
+  // visits. Generation reads those Findings and never mutates them.
+  const candidateArtifacts = generateCaseCandidates({
+    sources,
+    historyArtifacts: artifacts,
+    webDataArtifacts,
+    metadataArtifacts,
+  });
+
   await verifyWorkingCopy(caseDirectory);
   const stored = storeHistoryAnalysis({
     caseDirectory,
@@ -1418,6 +1429,7 @@ export async function analyseCase(
     metadataArtifacts,
     bookmarksArtifacts,
     cacheArtifacts,
+    candidateArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(

--- a/core/src/identity-candidates-query.ts
+++ b/core/src/identity-candidates-query.ts
@@ -1,0 +1,439 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import type { CandidateCategory } from "./identity-candidates.js";
+import type { ForensicFields, Provenance } from "./forensic-model.js";
+
+export type CandidateSort =
+  | "rank"
+  | "kind"
+  | "supporting-count"
+  | "value"
+  | "profile";
+export type CandidateDirection = "asc" | "desc";
+
+export interface CandidateQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly category?: string;
+  readonly kind?: string;
+  readonly search?: string;
+  readonly sort?: CandidateSort;
+  readonly direction?: CandidateDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+/**
+ * One ranked Candidate row. It is deliberately not a Finding: it has no Commit
+ * State, it carries `rank` and `supportingCount`, and its `candidateKind` is a
+ * ranked-hypothesis kind, never a factual Finding kind.
+ */
+export interface CandidateRecord {
+  readonly recordType: "candidate";
+  readonly candidateKind: string;
+  readonly category: CandidateCategory;
+  readonly profile: string;
+  readonly rank: number;
+  readonly supportingCount: number;
+  readonly provenance: Provenance;
+  readonly fields: ForensicFields;
+}
+
+export interface CandidateCompleteness {
+  readonly attempted: number;
+  readonly produced: number;
+  readonly absent: number;
+  readonly unavailable: number;
+}
+
+export interface CandidatePage {
+  readonly status: "ok";
+  readonly command: "candidates";
+  readonly completeness: CandidateCompleteness;
+  readonly items: readonly CandidateRecord[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly candidateId: string;
+}
+
+interface QueryRow {
+  readonly candidate_id: bigint;
+  readonly candidate_kind: string;
+  readonly category: string;
+  readonly profile_path: string;
+  readonly rank: bigint;
+  readonly supporting_count: bigint;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string;
+}
+
+const CANDIDATE_SORTS = [
+  "rank",
+  "kind",
+  "supporting-count",
+  "value",
+  "profile",
+] as const;
+const CANDIDATE_DIRECTIONS = ["asc", "desc"] as const;
+const CATEGORIES = ["identity", "behavior"] as const;
+
+const SORT_EXPRESSIONS: Readonly<Record<CandidateSort, string>> = {
+  rank: "printf('%020d', c.rank)",
+  kind: "c.candidate_kind",
+  "supporting-count": "printf('%020d', c.supporting_count)",
+  value: "c.sort_value",
+  profile: "c.profile_path",
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly category: CandidateCategory | null;
+  readonly kind: string | null;
+  readonly search: string | null;
+  readonly sort: CandidateSort;
+  readonly direction: CandidateDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Candidates cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("candidateId" in parsed) ||
+    typeof parsed.candidateId !== "string" ||
+    !/^[0-9]+$/.test(parsed.candidateId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Candidates cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Candidates --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Candidates ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function schemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'identity_candidates'",
+      )
+      .get() !== undefined
+  );
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM candidate_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+/**
+ * The Completeness Statement for Candidate generation, computed before any row
+ * is read. It reduces the retained artifact-result lineage to the current
+ * outcome per (Source, Profile): the active result when one exists, otherwise
+ * the most recent attempt.
+ */
+function buildCompleteness(
+  database: DatabaseSync,
+  profiles: readonly string[],
+): CandidateCompleteness {
+  const rows = database
+    .prepare(
+      `SELECT r.source_id, r.profile_path, r.status, r.active, a.started_at,
+              r.artifact_result_id
+         FROM candidate_artifact_results r
+         JOIN analysis_runs a ON a.run_id = r.run_id
+        ORDER BY r.source_id, r.profile_path`,
+    )
+    .all() as unknown as {
+    readonly source_id: string;
+    readonly profile_path: string;
+    readonly status: string;
+    readonly active: bigint | number;
+    readonly started_at: string;
+    readonly artifact_result_id: bigint | number;
+  }[];
+  const profileSet = new Set(profiles);
+  const current = new Map<string, (typeof rows)[number]>();
+  for (const row of rows) {
+    if (profileSet.size > 0 && !profileSet.has(row.profile_path)) {
+      continue;
+    }
+    const key = `${row.source_id}\u0000${row.profile_path}`;
+    const chosen = current.get(key);
+    if (chosen === undefined) {
+      current.set(key, row);
+      continue;
+    }
+    if (BigInt(chosen.active) === 1n) {
+      continue;
+    }
+    if (
+      BigInt(row.active) === 1n ||
+      row.started_at > chosen.started_at ||
+      (row.started_at === chosen.started_at &&
+        BigInt(row.artifact_result_id) > BigInt(chosen.artifact_result_id))
+    ) {
+      current.set(key, row);
+    }
+  }
+  const values = [...current.values()];
+  return {
+    attempted: values.length,
+    produced: values.filter((row) => row.status === "complete").length,
+    absent: values.filter((row) => row.status === "absent").length,
+    unavailable: values.filter((row) => row.status === "unavailable").length,
+  };
+}
+
+function parseRecord(row: QueryRow): CandidateRecord {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Candidate JSON.",
+      { candidate_id: row.candidate_id.toString() },
+      { cause: error },
+    );
+  }
+  if (row.category !== "identity" && row.category !== "behavior") {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Candidate category.",
+      { candidate_id: row.candidate_id.toString() },
+    );
+  }
+  return {
+    recordType: "candidate",
+    candidateKind: row.candidate_kind,
+    category: row.category,
+    profile: row.profile_path,
+    rank: Number(row.rank),
+    supportingCount: Number(row.supporting_count),
+    provenance,
+    fields,
+  };
+}
+
+export function queryCandidates(input: CandidateQuery): CandidatePage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    CANDIDATE_DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "rank", CANDIDATE_SORTS, "--sort");
+  const category =
+    input.category === undefined
+      ? null
+      : enumValue(input.category, "identity", CATEGORIES, "--category");
+  const kind =
+    input.kind === undefined || input.kind.length === 0 ? null : input.kind;
+  const sortExpression = SORT_EXPRESSIONS[sort];
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Candidates queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!schemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Candidate analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const completeness = buildCompleteness(database, profiles);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      category,
+      kind,
+      search,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = ["r.active = 1", "c.record_type = 'candidate'"];
+    const parameters: (string | bigint)[] = [];
+    if (profiles.length > 0) {
+      conditions.push(
+        `c.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (category !== null) {
+      conditions.push("c.category = ?");
+      parameters.push(category);
+    }
+    if (kind !== null) {
+      conditions.push("c.candidate_kind = ?");
+      parameters.push(kind);
+    }
+    if (search !== null) {
+      conditions.push("instr(c.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND c.candidate_id ${operator} ?))`,
+      );
+      const candidateId = BigInt(cursor.candidateId);
+      if (candidateId > SQLITE_MAX_INTEGER) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Candidates cursor contains an invalid sort key.",
+        );
+      }
+      parameters.push(cursor.key, cursor.key, candidateId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT c.candidate_id, c.candidate_kind, c.category, c.profile_path,
+                c.rank, c.supporting_count, c.provenance_json, c.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM identity_candidates c
+           JOIN candidate_artifact_results r
+             ON r.artifact_result_id = c.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   c.candidate_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "candidates",
+      completeness,
+      items: pageRows.map(parseRecord),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              candidateId: last.candidate_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/identity-candidates-query.ts
+++ b/core/src/identity-candidates-query.ts
@@ -44,17 +44,9 @@ export interface CandidateRecord {
   readonly fields: ForensicFields;
 }
 
-export interface CandidateCompleteness {
-  readonly attempted: number;
-  readonly produced: number;
-  readonly absent: number;
-  readonly unavailable: number;
-}
-
 export interface CandidatePage {
   readonly status: "ok";
   readonly command: "candidates";
-  readonly completeness: CandidateCompleteness;
   readonly items: readonly CandidateRecord[];
   readonly nextCursor: string | null;
   readonly limit: number;
@@ -221,65 +213,6 @@ function activeAnalysisIdentity(database: DatabaseSync): {
   };
 }
 
-/**
- * The Completeness Statement for Candidate generation, computed before any row
- * is read. It reduces the retained artifact-result lineage to the current
- * outcome per (Source, Profile): the active result when one exists, otherwise
- * the most recent attempt.
- */
-function buildCompleteness(
-  database: DatabaseSync,
-  profiles: readonly string[],
-): CandidateCompleteness {
-  const rows = database
-    .prepare(
-      `SELECT r.source_id, r.profile_path, r.status, r.active, a.started_at,
-              r.artifact_result_id
-         FROM candidate_artifact_results r
-         JOIN analysis_runs a ON a.run_id = r.run_id
-        ORDER BY r.source_id, r.profile_path`,
-    )
-    .all() as unknown as {
-    readonly source_id: string;
-    readonly profile_path: string;
-    readonly status: string;
-    readonly active: bigint | number;
-    readonly started_at: string;
-    readonly artifact_result_id: bigint | number;
-  }[];
-  const profileSet = new Set(profiles);
-  const current = new Map<string, (typeof rows)[number]>();
-  for (const row of rows) {
-    if (profileSet.size > 0 && !profileSet.has(row.profile_path)) {
-      continue;
-    }
-    const key = `${row.source_id}\u0000${row.profile_path}`;
-    const chosen = current.get(key);
-    if (chosen === undefined) {
-      current.set(key, row);
-      continue;
-    }
-    if (BigInt(chosen.active) === 1n) {
-      continue;
-    }
-    if (
-      BigInt(row.active) === 1n ||
-      row.started_at > chosen.started_at ||
-      (row.started_at === chosen.started_at &&
-        BigInt(row.artifact_result_id) > BigInt(chosen.artifact_result_id))
-    ) {
-      current.set(key, row);
-    }
-  }
-  const values = [...current.values()];
-  return {
-    attempted: values.length,
-    produced: values.filter((row) => row.status === "complete").length,
-    absent: values.filter((row) => row.status === "absent").length,
-    unavailable: values.filter((row) => row.status === "unavailable").length,
-  };
-}
-
 function parseRecord(row: QueryRow): CandidateRecord {
   let provenance: Provenance;
   let fields: ForensicFields;
@@ -348,7 +281,6 @@ export function queryCandidates(input: CandidateQuery): CandidatePage {
       );
     }
     const identity = activeAnalysisIdentity(database);
-    const completeness = buildCompleteness(database, profiles);
     const fingerprint = queryFingerprint({
       caseId: identity.caseId,
       activeArtifactResultIds: identity.artifactResultIds,
@@ -420,7 +352,6 @@ export function queryCandidates(input: CandidateQuery): CandidatePage {
     return {
       status: "ok",
       command: "candidates",
-      completeness,
       items: pageRows.map(parseRecord),
       nextCursor:
         hasNext && last !== undefined

--- a/core/src/identity-candidates.ts
+++ b/core/src/identity-candidates.ts
@@ -53,7 +53,12 @@ export const CANDIDATE_ARTIFACT = "Candidates" as const;
 /** The upper bound on ranked Candidates emitted per kind per Profile. */
 const MAX_CANDIDATES_PER_KIND = 100;
 
-/** The upper bound on total Provenance rows (primary + supporting) per Candidate. */
+/**
+ * The upper bound on total Provenance rows (primary + supporting) per Candidate.
+ * The `supportingCount` reports the full tally of supporting rows; when a group
+ * has more rows than this bound, the carried Provenance is a bounded sample and
+ * the count stays larger than the resolvable rows (never truncated to match).
+ */
 const MAX_PROVENANCE_ROWS = 200;
 
 interface HeuristicDefinition {

--- a/core/src/identity-candidates.ts
+++ b/core/src/identity-candidates.ts
@@ -10,10 +10,13 @@ import {
   createCandidate,
   valueField,
   type Candidate,
+  type CandidateCategory,
   type FieldState,
   type Finding,
   type SourceRowProvenance,
 } from "./forensic-model.js";
+
+export type { CandidateCategory };
 
 /**
  * Identity and behavior Candidate generation (issue #185).
@@ -45,29 +48,90 @@ import {
  *    the artifact is `unavailable` (an input failed) or `absent` (none present).
  */
 
-export type CandidateCategory = "identity" | "behavior";
-
 export const CANDIDATE_ARTIFACT = "Candidates" as const;
 
 /** The upper bound on ranked Candidates emitted per kind per Profile. */
 const MAX_CANDIDATES_PER_KIND = 100;
 
-/** The upper bound on supporting Provenance rows carried by one Candidate. */
-const MAX_SUPPORTING_ROWS = 200;
+/** The upper bound on total Provenance rows (primary + supporting) per Candidate. */
+const MAX_PROVENANCE_ROWS = 200;
 
 interface HeuristicDefinition {
   readonly kind: string;
   readonly category: CandidateCategory;
+  /** Gather every piece of evidence this heuristic recognizes for a Profile. */
+  readonly collect: (inputs: ProfileInputs) => Evidence[];
 }
 
+// Each heuristic owns its own collector, so the kind, category, and evidence
+// rule live in one place. There is no separate kind-keyed matcher/field table
+// to keep in sync.
 const HEURISTICS: readonly HeuristicDefinition[] = [
-  { kind: "identity_name", category: "identity" },
-  { kind: "identity_email", category: "identity" },
-  { kind: "identity_phone", category: "identity" },
-  { kind: "identity_postal_address", category: "identity" },
-  { kind: "identity_country", category: "identity" },
-  { kind: "behavior_frequent_host", category: "behavior" },
-  { kind: "behavior_search_query", category: "behavior" },
+  {
+    kind: "identity_name",
+    category: "identity",
+    collect: (inputs) => [
+      ...autofillEvidence(inputs, (fieldName) =>
+        NAME_FIELD_PATTERN.test(fieldName),
+      ),
+      ...preferencesFieldEvidence(inputs, [
+        "accountFullName",
+        "accountGivenName",
+      ]),
+    ],
+  },
+  {
+    kind: "identity_email",
+    category: "identity",
+    collect: (inputs) => [
+      ...autofillEvidence(
+        inputs,
+        (fieldName, value) =>
+          EMAIL_FIELD_PATTERN.test(fieldName) ||
+          EMAIL_VALUE_PATTERN.test(value),
+      ),
+      ...preferencesFieldEvidence(inputs, ["accountEmail"]),
+    ],
+  },
+  {
+    kind: "identity_phone",
+    category: "identity",
+    collect: (inputs) =>
+      autofillEvidence(inputs, (fieldName) =>
+        PHONE_FIELD_PATTERN.test(fieldName),
+      ),
+  },
+  {
+    kind: "identity_postal_address",
+    category: "identity",
+    collect: (inputs) =>
+      autofillEvidence(
+        inputs,
+        (fieldName) =>
+          ADDRESS_FIELD_PATTERN.test(fieldName) &&
+          !COUNTRY_FIELD_PATTERN.test(fieldName),
+      ),
+  },
+  {
+    kind: "identity_country",
+    category: "identity",
+    collect: (inputs) => [
+      ...autofillEvidence(inputs, (fieldName) =>
+        COUNTRY_FIELD_PATTERN.test(fieldName),
+      ),
+      ...localStateCountryEvidence(inputs),
+    ],
+  },
+  {
+    kind: "behavior_frequent_host",
+    category: "behavior",
+    collect: (inputs) => collectHostEvidence(inputs),
+  },
+  {
+    kind: "behavior_search_query",
+    category: "behavior",
+    collect: (inputs) => collectSearchEvidence(inputs),
+  },
 ];
 
 interface Evidence {
@@ -103,7 +167,8 @@ function rowKey(row: SourceRowProvenance): string {
 
 /**
  * A total, locale-independent order over strings so ranking never depends on
- * the host locale. Shorter prefixes sort first; otherwise compare by code unit.
+ * the host locale. It compares by UTF-16 code unit through the built-in
+ * `<`/`>` operators; there is no prefix or length special-casing.
  */
 function compareStrings(left: string, right: string): number {
   if (left < right) {
@@ -126,17 +191,6 @@ const EMAIL_VALUE_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type AutofillMatcher = (fieldName: string, value: string) => boolean;
 
-const AUTOFILL_MATCHERS: Readonly<Record<string, AutofillMatcher>> = {
-  identity_name: (fieldName) => NAME_FIELD_PATTERN.test(fieldName),
-  identity_email: (fieldName, value) =>
-    EMAIL_FIELD_PATTERN.test(fieldName) || EMAIL_VALUE_PATTERN.test(value),
-  identity_phone: (fieldName) => PHONE_FIELD_PATTERN.test(fieldName),
-  identity_postal_address: (fieldName) =>
-    ADDRESS_FIELD_PATTERN.test(fieldName) &&
-    !COUNTRY_FIELD_PATTERN.test(fieldName),
-  identity_country: (fieldName) => COUNTRY_FIELD_PATTERN.test(fieldName),
-};
-
 function autofillFindings(
   webData: WebDataArtifactWrite | undefined,
 ): readonly Finding[] {
@@ -152,14 +206,10 @@ function autofillFindings(
     );
 }
 
-function collectAutofillEvidence(
+function autofillEvidence(
   inputs: ProfileInputs,
-  kind: string,
+  matcher: AutofillMatcher,
 ): Evidence[] {
-  const matcher = AUTOFILL_MATCHERS[kind];
-  if (matcher === undefined) {
-    return [];
-  }
   const evidence: Evidence[] = [];
   for (const finding of autofillFindings(inputs.webData)) {
     const fieldName = normalizeKey(fieldText(finding.fields.fieldName));
@@ -189,44 +239,46 @@ function preferencesFinding(
   return metadata.findings[0]?.finding;
 }
 
-function collectPreferencesEvidence(
+function preferencesFieldEvidence(
   inputs: ProfileInputs,
-  kind: string,
+  fieldNames: readonly string[],
 ): Evidence[] {
-  const evidence: Evidence[] = [];
   const profileFinding = preferencesFinding(inputs.preferences);
-  if (profileFinding !== undefined) {
-    const fieldsByKind: Readonly<Record<string, readonly string[]>> = {
-      identity_name: ["accountFullName", "accountGivenName"],
-      identity_email: ["accountEmail"],
-    };
-    for (const fieldName of fieldsByKind[kind] ?? []) {
-      const value = fieldText(profileFinding.fields[fieldName]).trim();
-      if (value.length > 0) {
-        evidence.push({
-          key: normalizeKey(value),
-          raw: value,
-          basis: "preferences",
-          row: profileFinding.provenance,
-        });
-      }
-    }
+  if (profileFinding === undefined) {
+    return [];
   }
-  if (kind === "identity_country") {
-    const browserFinding = preferencesFinding(inputs.localState);
-    if (browserFinding !== undefined) {
-      const value = fieldText(browserFinding.fields.variationsCountry).trim();
-      if (value.length > 0) {
-        evidence.push({
-          key: normalizeKey(value),
-          raw: value,
-          basis: "local_state",
-          row: browserFinding.provenance,
-        });
-      }
+  const evidence: Evidence[] = [];
+  for (const fieldName of fieldNames) {
+    const value = fieldText(profileFinding.fields[fieldName]).trim();
+    if (value.length > 0) {
+      evidence.push({
+        key: normalizeKey(value),
+        raw: value,
+        basis: "preferences",
+        row: profileFinding.provenance,
+      });
     }
   }
   return evidence;
+}
+
+function localStateCountryEvidence(inputs: ProfileInputs): Evidence[] {
+  const browserFinding = preferencesFinding(inputs.localState);
+  if (browserFinding === undefined) {
+    return [];
+  }
+  const value = fieldText(browserFinding.fields.variationsCountry).trim();
+  if (value.length === 0) {
+    return [];
+  }
+  return [
+    {
+      key: normalizeKey(value),
+      raw: value,
+      basis: "local_state",
+      row: browserFinding.provenance,
+    },
+  ];
 }
 
 function committedVisits(
@@ -320,20 +372,6 @@ function collectSearchEvidence(inputs: ProfileInputs): Evidence[] {
   return evidence;
 }
 
-function collectEvidence(inputs: ProfileInputs, kind: string): Evidence[] {
-  switch (kind) {
-    case "behavior_frequent_host":
-      return collectHostEvidence(inputs);
-    case "behavior_search_query":
-      return collectSearchEvidence(inputs);
-    default:
-      return [
-        ...collectAutofillEvidence(inputs, kind),
-        ...collectPreferencesEvidence(inputs, kind),
-      ];
-  }
-}
-
 interface Group {
   readonly key: string;
   readonly display: string;
@@ -416,7 +454,8 @@ function toCandidate(
       "A Candidate group must carry at least one Provenance row.",
     );
   }
-  const supportingRows = rest.slice(0, MAX_SUPPORTING_ROWS);
+  // The primary row plus its supporting rows stay within the total bound.
+  const supportingRows = rest.slice(0, MAX_PROVENANCE_ROWS - 1);
   const provenance =
     supportingRows.length === 0
       ? { ...primary }
@@ -501,7 +540,7 @@ export function generateProfileCandidates(
   const candidates: PersistedIdentityCandidate[] = [];
   if (outcome.status === "complete") {
     for (const definition of HEURISTICS) {
-      const groups = buildGroups(collectEvidence(inputs, definition.kind));
+      const groups = buildGroups(definition.collect(inputs));
       groups.forEach((group, index) => {
         const candidate = toCandidate(definition, group, index + 1);
         candidates.push(

--- a/core/src/identity-candidates.ts
+++ b/core/src/identity-candidates.ts
@@ -1,0 +1,584 @@
+import type {
+  CandidateArtifactWrite,
+  HistoryArtifactWrite,
+  MetadataArtifactWrite,
+  PersistedIdentityCandidate,
+  WebDataArtifactWrite,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import {
+  createCandidate,
+  valueField,
+  type Candidate,
+  type FieldState,
+  type Finding,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+
+/**
+ * Identity and behavior Candidate generation (issue #185).
+ *
+ * A Candidate is nominal, ranked, and carries a supporting count plus resolvable
+ * row-level Provenance. A Candidate is NEVER a Finding and NEVER a factual
+ * summary tile: names, countries, phone numbers, addresses, linked devices, and
+ * habits only ever appear here, ranked and hedged, never asserted as fact.
+ *
+ * Every heuristic below consumes Findings that other parsers already wrote for
+ * the same Analysis Run — Web Data autofill (#178), Preferences/Local State
+ * metadata (#176), and History visits. This pass reads those Findings and emits
+ * Candidates; it never mutates, hides, or re-scores any source row.
+ *
+ * Deterministic, documented behavior for the awkward cases:
+ *
+ *  - Ties: Candidates within one kind are ordered by supporting count
+ *    descending, then by normalized value ascending (a total order). Ranks are
+ *    dense integers 1..N in that order, so equal counts still get distinct,
+ *    reproducible ranks.
+ *  - No evidence: a heuristic that finds nothing emits no Candidate. When every
+ *    heuristic is empty but at least one input was produced, the Candidate
+ *    artifact is `complete` with zero rows (searched, nothing nominable).
+ *  - Conflicting evidence: distinct values under one kind each become their own
+ *    ranked Candidate. Conflicts are surfaced as a ranked list, never merged and
+ *    never resolved into a single fact.
+ *  - Unavailable inputs: an input that is `absent`/`unavailable` contributes no
+ *    evidence and is named in the artifact `reason`. If no input was produced,
+ *    the artifact is `unavailable` (an input failed) or `absent` (none present).
+ */
+
+export type CandidateCategory = "identity" | "behavior";
+
+export const CANDIDATE_ARTIFACT = "Candidates" as const;
+
+/** The upper bound on ranked Candidates emitted per kind per Profile. */
+const MAX_CANDIDATES_PER_KIND = 100;
+
+/** The upper bound on supporting Provenance rows carried by one Candidate. */
+const MAX_SUPPORTING_ROWS = 200;
+
+interface HeuristicDefinition {
+  readonly kind: string;
+  readonly category: CandidateCategory;
+}
+
+const HEURISTICS: readonly HeuristicDefinition[] = [
+  { kind: "identity_name", category: "identity" },
+  { kind: "identity_email", category: "identity" },
+  { kind: "identity_phone", category: "identity" },
+  { kind: "identity_postal_address", category: "identity" },
+  { kind: "identity_country", category: "identity" },
+  { kind: "behavior_frequent_host", category: "behavior" },
+  { kind: "behavior_search_query", category: "behavior" },
+];
+
+interface Evidence {
+  readonly key: string;
+  readonly raw: string;
+  readonly basis: string;
+  readonly row: SourceRowProvenance;
+}
+
+interface ProfileInputs {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly history: HistoryArtifactWrite | undefined;
+  readonly webData: WebDataArtifactWrite | undefined;
+  readonly preferences: MetadataArtifactWrite | undefined;
+  readonly localState: MetadataArtifactWrite | undefined;
+}
+
+function fieldText(field: FieldState<unknown> | undefined): string {
+  if (field === undefined || field.state !== "value") {
+    return "";
+  }
+  return typeof field.value === "string" ? field.value : String(field.value);
+}
+
+function normalizeKey(raw: string): string {
+  return raw.trim().replace(/\s+/g, " ").toLocaleLowerCase("en-US");
+}
+
+function rowKey(row: SourceRowProvenance): string {
+  return `${row.sourceId}\u0000${String(row.manifestEntryOrdinal)}\u0000${row.database}\u0000${row.table}\u0000${row.rowId}`;
+}
+
+/**
+ * A total, locale-independent order over strings so ranking never depends on
+ * the host locale. Shorter prefixes sort first; otherwise compare by code unit.
+ */
+function compareStrings(left: string, right: string): number {
+  if (left < right) {
+    return -1;
+  }
+  if (left > right) {
+    return 1;
+  }
+  return 0;
+}
+
+const NAME_FIELD_PATTERN =
+  /(?:^|[^a-z])(name|fullname|full_name|firstname|first_name|fname|lastname|last_name|lname|given[-_]?name|family[-_]?name|cc[-_]?name)(?:$|[^a-z])/;
+const EMAIL_FIELD_PATTERN = /(e[-_]?mail|email)/;
+const PHONE_FIELD_PATTERN = /(phone|tel|mobile|cell)/;
+const ADDRESS_FIELD_PATTERN =
+  /(address|addr|street|city|town|state|province|zip|postal|postcode|post_code)/;
+const COUNTRY_FIELD_PATTERN = /(country|nation)/;
+const EMAIL_VALUE_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type AutofillMatcher = (fieldName: string, value: string) => boolean;
+
+const AUTOFILL_MATCHERS: Readonly<Record<string, AutofillMatcher>> = {
+  identity_name: (fieldName) => NAME_FIELD_PATTERN.test(fieldName),
+  identity_email: (fieldName, value) =>
+    EMAIL_FIELD_PATTERN.test(fieldName) || EMAIL_VALUE_PATTERN.test(value),
+  identity_phone: (fieldName) => PHONE_FIELD_PATTERN.test(fieldName),
+  identity_postal_address: (fieldName) =>
+    ADDRESS_FIELD_PATTERN.test(fieldName) &&
+    !COUNTRY_FIELD_PATTERN.test(fieldName),
+  identity_country: (fieldName) => COUNTRY_FIELD_PATTERN.test(fieldName),
+};
+
+function autofillFindings(
+  webData: WebDataArtifactWrite | undefined,
+): readonly Finding[] {
+  if (webData === undefined || webData.status !== "complete") {
+    return [];
+  }
+  return webData.findings
+    .map((persisted) => persisted.finding)
+    .filter(
+      (finding) =>
+        finding.findingKind === "autofill_entry" &&
+        finding.commitState === "committed",
+    );
+}
+
+function collectAutofillEvidence(
+  inputs: ProfileInputs,
+  kind: string,
+): Evidence[] {
+  const matcher = AUTOFILL_MATCHERS[kind];
+  if (matcher === undefined) {
+    return [];
+  }
+  const evidence: Evidence[] = [];
+  for (const finding of autofillFindings(inputs.webData)) {
+    const fieldName = normalizeKey(fieldText(finding.fields.fieldName));
+    const value = fieldText(finding.fields.fieldValue).trim();
+    if (value.length === 0) {
+      continue;
+    }
+    if (!matcher(fieldName, value)) {
+      continue;
+    }
+    evidence.push({
+      key: normalizeKey(value),
+      raw: value,
+      basis: "autofill",
+      row: finding.provenance,
+    });
+  }
+  return evidence;
+}
+
+function preferencesFinding(
+  metadata: MetadataArtifactWrite | undefined,
+): Finding | undefined {
+  if (metadata === undefined || metadata.status !== "complete") {
+    return undefined;
+  }
+  return metadata.findings[0]?.finding;
+}
+
+function collectPreferencesEvidence(
+  inputs: ProfileInputs,
+  kind: string,
+): Evidence[] {
+  const evidence: Evidence[] = [];
+  const profileFinding = preferencesFinding(inputs.preferences);
+  if (profileFinding !== undefined) {
+    const fieldsByKind: Readonly<Record<string, readonly string[]>> = {
+      identity_name: ["accountFullName", "accountGivenName"],
+      identity_email: ["accountEmail"],
+    };
+    for (const fieldName of fieldsByKind[kind] ?? []) {
+      const value = fieldText(profileFinding.fields[fieldName]).trim();
+      if (value.length > 0) {
+        evidence.push({
+          key: normalizeKey(value),
+          raw: value,
+          basis: "preferences",
+          row: profileFinding.provenance,
+        });
+      }
+    }
+  }
+  if (kind === "identity_country") {
+    const browserFinding = preferencesFinding(inputs.localState);
+    if (browserFinding !== undefined) {
+      const value = fieldText(browserFinding.fields.variationsCountry).trim();
+      if (value.length > 0) {
+        evidence.push({
+          key: normalizeKey(value),
+          raw: value,
+          basis: "local_state",
+          row: browserFinding.provenance,
+        });
+      }
+    }
+  }
+  return evidence;
+}
+
+function committedVisits(
+  history: HistoryArtifactWrite | undefined,
+): readonly Finding[] {
+  if (history === undefined || history.status !== "complete") {
+    return [];
+  }
+  return history.findings
+    .map((persisted) => persisted.finding)
+    .filter(
+      (finding) =>
+        finding.findingKind === "history_visit" &&
+        finding.commitState === "committed",
+    );
+}
+
+function collectHostEvidence(inputs: ProfileInputs): Evidence[] {
+  const evidence: Evidence[] = [];
+  for (const finding of committedVisits(inputs.history)) {
+    const url = fieldText(finding.fields.url).trim();
+    if (url.length === 0) {
+      continue;
+    }
+    let host: string;
+    try {
+      host = new URL(url).host;
+    } catch {
+      continue;
+    }
+    if (host.length === 0) {
+      continue;
+    }
+    evidence.push({
+      key: normalizeKey(host),
+      raw: host,
+      basis: "history",
+      row: finding.provenance,
+    });
+  }
+  return evidence;
+}
+
+const SEARCH_QUERY_PARAMS: Readonly<Record<string, string>> = {
+  "google.": "q",
+  "bing.": "q",
+  "duckduckgo.": "q",
+  "search.yahoo.": "p",
+  "yandex.": "text",
+  "ecosia.": "q",
+  "startpage.": "query",
+};
+
+function extractSearchQuery(url: URL): string | null {
+  const host = url.host.toLocaleLowerCase("en-US");
+  for (const [needle, parameter] of Object.entries(SEARCH_QUERY_PARAMS)) {
+    if (host.includes(needle)) {
+      const term = url.searchParams.get(parameter);
+      if (term !== null && term.trim().length > 0) {
+        return term.trim();
+      }
+    }
+  }
+  return null;
+}
+
+function collectSearchEvidence(inputs: ProfileInputs): Evidence[] {
+  const evidence: Evidence[] = [];
+  for (const finding of committedVisits(inputs.history)) {
+    const url = fieldText(finding.fields.url).trim();
+    if (url.length === 0) {
+      continue;
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      continue;
+    }
+    const term = extractSearchQuery(parsed);
+    if (term === null) {
+      continue;
+    }
+    evidence.push({
+      key: normalizeKey(term),
+      raw: term,
+      basis: "history",
+      row: finding.provenance,
+    });
+  }
+  return evidence;
+}
+
+function collectEvidence(inputs: ProfileInputs, kind: string): Evidence[] {
+  switch (kind) {
+    case "behavior_frequent_host":
+      return collectHostEvidence(inputs);
+    case "behavior_search_query":
+      return collectSearchEvidence(inputs);
+    default:
+      return [
+        ...collectAutofillEvidence(inputs, kind),
+        ...collectPreferencesEvidence(inputs, kind),
+      ];
+  }
+}
+
+interface Group {
+  readonly key: string;
+  readonly display: string;
+  readonly bases: readonly string[];
+  readonly rows: readonly SourceRowProvenance[];
+  readonly supportingCount: number;
+}
+
+function chooseDisplay(rawCounts: Map<string, number>): string {
+  let best = "";
+  let bestCount = -1;
+  for (const [raw, count] of rawCounts) {
+    if (
+      count > bestCount ||
+      (count === bestCount && compareStrings(raw, best) < 0)
+    ) {
+      best = raw;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+function buildGroups(evidence: readonly Evidence[]): Group[] {
+  const byKey = new Map<string, Evidence[]>();
+  for (const item of evidence) {
+    const bucket = byKey.get(item.key);
+    if (bucket === undefined) {
+      byKey.set(item.key, [item]);
+    } else {
+      bucket.push(item);
+    }
+  }
+  const groups: Group[] = [];
+  for (const [key, bucket] of byKey) {
+    const rowsByKey = new Map<string, SourceRowProvenance>();
+    const rawCounts = new Map<string, number>();
+    const bases = new Set<string>();
+    for (const item of bucket) {
+      rowsByKey.set(rowKey(item.row), item.row);
+      rawCounts.set(item.raw, (rawCounts.get(item.raw) ?? 0) + 1);
+      bases.add(item.basis);
+    }
+    const rows = [...rowsByKey.values()].sort((left, right) =>
+      compareStrings(rowKey(left), rowKey(right)),
+    );
+    groups.push({
+      key,
+      display: chooseDisplay(rawCounts),
+      bases: [...bases].sort(compareStrings),
+      rows,
+      supportingCount: rows.length,
+    });
+  }
+  groups.sort((left, right) =>
+    left.supportingCount !== right.supportingCount
+      ? right.supportingCount - left.supportingCount
+      : compareStrings(left.key, right.key),
+  );
+  return groups.slice(0, MAX_CANDIDATES_PER_KIND);
+}
+
+function candidateFields(group: Group): Record<string, FieldState<unknown>> {
+  return {
+    candidateValue: valueField(group.display),
+    normalizedValue: valueField(group.key),
+    supportingCount: valueField(group.supportingCount.toString()),
+    evidenceBasis: valueField(group.bases.join("+")),
+  };
+}
+
+function toCandidate(
+  definition: HeuristicDefinition,
+  group: Group,
+  rank: number,
+): Candidate {
+  const [primary, ...rest] = group.rows;
+  if (primary === undefined) {
+    throw new Error(
+      "A Candidate group must carry at least one Provenance row.",
+    );
+  }
+  const supportingRows = rest.slice(0, MAX_SUPPORTING_ROWS);
+  const provenance =
+    supportingRows.length === 0
+      ? { ...primary }
+      : { ...primary, supportingRows };
+  return createCandidate({
+    candidateKind: definition.kind,
+    rank,
+    count: group.supportingCount,
+    provenance,
+    fields: candidateFields(group),
+  });
+}
+
+function persistedCandidate(
+  definition: HeuristicDefinition,
+  profile: string,
+  candidate: Candidate,
+  group: Group,
+): PersistedIdentityCandidate {
+  return {
+    candidate,
+    category: definition.category,
+    profile,
+    searchText: [profile, definition.kind, group.display, group.key]
+      .join("\n")
+      .toLocaleLowerCase("en-US"),
+    sortValue: group.key,
+  };
+}
+
+function describeInputs(inputs: ProfileInputs): {
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly reason: string | null;
+} {
+  const named: {
+    readonly label: string;
+    readonly artifact:
+      | {
+          readonly status: "complete" | "absent" | "unavailable";
+        }
+      | undefined;
+  }[] = [
+    { label: "history", artifact: inputs.history },
+    { label: "web_data", artifact: inputs.webData },
+    { label: "preferences", artifact: inputs.preferences },
+    { label: "local_state", artifact: inputs.localState },
+  ];
+  const present = named.filter((entry) => entry.artifact !== undefined);
+  const produced = present.filter(
+    (entry) => entry.artifact?.status === "complete",
+  );
+  const notProduced = present
+    .filter((entry) => entry.artifact?.status !== "complete")
+    .map((entry) => `${entry.label}_${entry.artifact?.status ?? "missing"}`)
+    .sort(compareStrings);
+  if (produced.length > 0) {
+    return {
+      status: "complete",
+      reason: notProduced.length === 0 ? null : notProduced.join(","),
+    };
+  }
+  if (present.some((entry) => entry.artifact?.status === "unavailable")) {
+    return {
+      status: "unavailable",
+      reason:
+        notProduced.length === 0
+          ? "no_candidate_inputs_available"
+          : notProduced.join(","),
+    };
+  }
+  return { status: "absent", reason: "no_candidate_inputs" };
+}
+
+/**
+ * Generate every identity and behavior Candidate for one (Source, Profile).
+ * Pure and deterministic: identical Findings always yield identical Candidates.
+ */
+export function generateProfileCandidates(
+  inputs: ProfileInputs,
+): CandidateArtifactWrite {
+  const outcome = describeInputs(inputs);
+  const candidates: PersistedIdentityCandidate[] = [];
+  if (outcome.status === "complete") {
+    for (const definition of HEURISTICS) {
+      const groups = buildGroups(collectEvidence(inputs, definition.kind));
+      groups.forEach((group, index) => {
+        const candidate = toCandidate(definition, group, index + 1);
+        candidates.push(
+          persistedCandidate(definition, inputs.profile, candidate, group),
+        );
+      });
+    }
+  }
+  return {
+    sourceId: inputs.sourceId,
+    profile: inputs.profile,
+    status: outcome.status,
+    reason: outcome.reason,
+    candidates,
+  };
+}
+
+function artifactKey(sourceId: string, profile: string): string {
+  return `${sourceId}\u0000${profile}`;
+}
+
+/**
+ * Generate the Candidate artifacts for every (Source, Profile) in the Case. It
+ * joins the per-Profile History and Web Data artifacts with the Profile-scoped
+ * Preferences and browser-scoped Local State metadata by Source, then defers to
+ * {@link generateProfileCandidates}. The output order is deterministic: Sources
+ * keep their Case order and Profiles keep their recorded order.
+ */
+export function generateCaseCandidates(options: {
+  readonly sources: readonly CaseSourceRecord[];
+  readonly historyArtifacts: readonly HistoryArtifactWrite[];
+  readonly webDataArtifacts: readonly WebDataArtifactWrite[];
+  readonly metadataArtifacts: readonly MetadataArtifactWrite[];
+}): CandidateArtifactWrite[] {
+  const historyByKey = new Map<string, HistoryArtifactWrite>();
+  for (const artifact of options.historyArtifacts) {
+    historyByKey.set(
+      artifactKey(artifact.sourceId, artifact.profile),
+      artifact,
+    );
+  }
+  const webDataByKey = new Map<string, WebDataArtifactWrite>();
+  for (const artifact of options.webDataArtifacts) {
+    webDataByKey.set(
+      artifactKey(artifact.sourceId, artifact.profile),
+      artifact,
+    );
+  }
+  const preferencesByKey = new Map<string, MetadataArtifactWrite>();
+  const localStateBySource = new Map<string, MetadataArtifactWrite>();
+  for (const artifact of options.metadataArtifacts) {
+    if (artifact.artifact === "Preferences") {
+      preferencesByKey.set(
+        artifactKey(artifact.sourceId, artifact.profile),
+        artifact,
+      );
+    } else if (artifact.artifact === "Local State") {
+      localStateBySource.set(artifact.sourceId, artifact);
+    }
+  }
+  const results: CandidateArtifactWrite[] = [];
+  for (const source of options.sources) {
+    for (const profile of source.profiles) {
+      const key = artifactKey(source.sourceId, profile.path);
+      results.push(
+        generateProfileCandidates({
+          sourceId: source.sourceId,
+          profile: profile.path,
+          history: historyByKey.get(key),
+          webData: webDataByKey.get(key),
+          preferences: preferencesByKey.get(key),
+          localState: localStateBySource.get(source.sourceId),
+        }),
+      );
+    }
+  }
+  return results;
+}
+
+export type { ProfileInputs as CandidateProfileInputs };

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -227,6 +227,21 @@ export {
   type AutofillSort,
 } from "./web-data-query.js";
 export {
+  queryCandidates,
+  type CandidateCompleteness,
+  type CandidateDirection,
+  type CandidatePage,
+  type CandidateQuery,
+  type CandidateRecord,
+  type CandidateSort,
+} from "./identity-candidates-query.js";
+export {
+  generateCaseCandidates,
+  generateProfileCandidates,
+  CANDIDATE_ARTIFACT,
+  type CandidateCategory,
+} from "./identity-candidates.js";
+export {
   queryFavicons,
   type FaviconDirection,
   type FaviconPage,
@@ -280,7 +295,9 @@ export {
   type BookmarksArtifactWrite,
   type BookmarkSourceFile,
   type CacheArtifactWrite,
+  type CandidateArtifactWrite,
   type DeclaredOriginOs,
+  type PersistedIdentityCandidate,
 } from "./case-findings.js";
 export { openDatabaseSync, type OpenDatabaseConfig } from "./sqlite-open.js";
 

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -228,7 +228,6 @@ export {
 } from "./web-data-query.js";
 export {
   queryCandidates,
-  type CandidateCompleteness,
   type CandidateDirection,
   type CandidatePage,
   type CandidateQuery,

--- a/core/test/identity-candidates.test.ts
+++ b/core/test/identity-candidates.test.ts
@@ -1,0 +1,316 @@
+import { describe, expect, it } from "vitest";
+
+import type {
+  HistoryArtifactWrite,
+  MetadataArtifactWrite,
+  WebDataArtifactWrite,
+} from "../src/case-findings.js";
+import {
+  createFinding,
+  valueField,
+  type CommitState,
+  type ForensicFields,
+  type SourceRowProvenance,
+} from "../src/forensic-model.js";
+import { generateProfileCandidates } from "../src/identity-candidates.js";
+
+const SOURCE = "SRC-1";
+const PROFILE = "Default";
+
+function provenance(
+  ordinal: number,
+  database: string,
+  table: string,
+  rowId: string,
+): SourceRowProvenance {
+  return {
+    manifestEntryId: `${SOURCE}:${ordinal}`,
+    sourceId: SOURCE,
+    manifestEntryOrdinal: ordinal,
+    manifestPath: database,
+    database,
+    table,
+    rowId,
+  };
+}
+
+function autofill(
+  rowId: string,
+  name: string,
+  value: string,
+  commitState: CommitState = "committed",
+): { readonly finding: ReturnType<typeof createFinding> } {
+  return {
+    finding: createFinding({
+      findingKind: "autofill_entry",
+      profile: PROFILE,
+      commitState,
+      provenance: provenance(3, "Default/Web Data", "autofill", rowId),
+      fields: {
+        fieldName: valueField(name),
+        fieldValue: valueField(value),
+      } as ForensicFields,
+    }),
+  };
+}
+
+function webData(
+  rows: readonly ReturnType<typeof autofill>[],
+  status: WebDataArtifactWrite["status"] = "complete",
+): WebDataArtifactWrite {
+  return {
+    sourceId: SOURCE,
+    profile: PROFILE,
+    status,
+    manifestEntryOrdinal: 3,
+    databasePath: "Default/Web Data",
+    schemaVersion: 133,
+    integrity: "ok",
+    recoveryStatus: "unavailable",
+    reason: null,
+    findings: rows,
+    committedFieldCount: rows.length,
+    recoveredFieldCount: 0,
+  };
+}
+
+function visit(
+  rowId: string,
+  url: string,
+): { readonly finding: ReturnType<typeof createFinding> } {
+  return {
+    finding: createFinding({
+      findingKind: "history_visit",
+      profile: PROFILE,
+      commitState: "committed",
+      provenance: provenance(2, "Default/History", "visits", rowId),
+      fields: { url: valueField(url) } as ForensicFields,
+    }),
+  };
+}
+
+function history(
+  rows: readonly ReturnType<typeof visit>[],
+  status: HistoryArtifactWrite["status"] = "complete",
+): HistoryArtifactWrite {
+  return {
+    sourceId: SOURCE,
+    profile: PROFILE,
+    status,
+    manifestEntryOrdinal: 2,
+    databasePath: "Default/History",
+    schemaVersion: 70,
+    integrity: "ok",
+    recoveryStatus: "unavailable",
+    reason: null,
+    findings: rows as never,
+    candidates: [],
+    committedVisitCount: rows.length,
+    recoveredVisitCount: 0,
+  };
+}
+
+function preferences(
+  fields: ForensicFields,
+  status: MetadataArtifactWrite["status"] = "complete",
+): MetadataArtifactWrite {
+  return {
+    sourceId: SOURCE,
+    profile: PROFILE,
+    artifact: "Preferences",
+    status,
+    manifestEntryOrdinal: 4,
+    databasePath: "Default/Preferences",
+    reason: null,
+    findings: [
+      {
+        finding: createFinding({
+          findingKind: "profile_metadata",
+          profile: PROFILE,
+          commitState: "committed",
+          provenance: provenance(
+            4,
+            "Default/Preferences",
+            "preferences",
+            PROFILE,
+          ),
+          fields,
+        }),
+        searchText: "",
+        sortType: "profile_metadata",
+        sortProfile: PROFILE,
+      },
+    ],
+  };
+}
+
+describe("generateProfileCandidates", () => {
+  it("ranks conflicting names by supporting count, then by value for ties", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: undefined,
+      webData: webData([
+        autofill("1", "name", "Bob"),
+        autofill("2", "fullname", "Bob"),
+        autofill("3", "name", "Alice"),
+        autofill("4", "name", "Zoe"),
+      ]),
+      preferences: undefined,
+      localState: undefined,
+    });
+    const names = result.candidates
+      .map((row) => row.candidate)
+      .filter((candidate) => candidate.candidateKind === "identity_name");
+    // Three distinct nominal values, ranked. Conflicts are surfaced, not merged.
+    expect(
+      names.map((c) => [c.rank, c.count, c.fields.candidateValue]),
+    ).toEqual([
+      [1, 2, valueField("Bob")],
+      // Alice and Zoe tie at count 1; the tie breaks by normalized value asc.
+      [2, 1, valueField("Alice")],
+      [3, 1, valueField("Zoe")],
+    ]);
+    // The winning Candidate aggregates its two source rows as Provenance.
+    const [top] = names;
+    expect(top?.count).toBe(2);
+    expect(top?.provenance.supportingRows).toHaveLength(1);
+    expect(top?.provenance.rowId).toBe("1");
+  });
+
+  it("is deterministic: identical inputs yield identical output", () => {
+    const inputs = {
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: history([
+        visit("1", "https://news.example/a"),
+        visit("2", "https://news.example/b"),
+        visit("3", "https://shop.example/x"),
+      ]),
+      webData: webData([autofill("1", "email", "a@b.example")]),
+      preferences: preferences({
+        accountEmail: valueField("a@b.example"),
+        accountFullName: valueField("A B"),
+      } as ForensicFields),
+      localState: undefined,
+    };
+    const first = JSON.stringify(generateProfileCandidates(inputs));
+    const second = JSON.stringify(generateProfileCandidates(inputs));
+    expect(first).toBe(second);
+  });
+
+  it("merges evidence across autofill and Preferences into one email Candidate", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: undefined,
+      webData: webData([autofill("7", "email", "a@b.example")]),
+      preferences: preferences({
+        accountEmail: valueField("a@b.example"),
+      } as ForensicFields),
+      localState: undefined,
+    });
+    const emails = result.candidates.filter(
+      (row) => row.candidate.candidateKind === "identity_email",
+    );
+    expect(emails).toHaveLength(1);
+    expect(emails[0]?.candidate.count).toBe(2);
+    expect(emails[0]?.candidate.fields.evidenceBasis).toEqual(
+      valueField("autofill+preferences"),
+    );
+  });
+
+  it("emits no Candidate for a heuristic with no evidence", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: undefined,
+      webData: webData([autofill("1", "name", "Bob")]),
+      preferences: undefined,
+      localState: undefined,
+    });
+    expect(result.status).toBe("complete");
+    expect(
+      result.candidates.some(
+        (row) => row.candidate.candidateKind === "identity_phone",
+      ),
+    ).toBe(false);
+  });
+
+  it("counts frequent hosts and search queries from committed visits", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: history([
+        visit("1", "https://news.example/a"),
+        visit("2", "https://news.example/b"),
+        visit("3", "https://news.example/c"),
+        visit("4", "https://shop.example/x"),
+        visit("5", "https://www.google.com/search?q=forensics"),
+      ]),
+      webData: undefined,
+      preferences: undefined,
+      localState: undefined,
+    });
+    const hosts = result.candidates.filter(
+      (row) => row.candidate.candidateKind === "behavior_frequent_host",
+    );
+    expect(hosts[0]?.candidate.fields.candidateValue).toEqual(
+      valueField("news.example"),
+    );
+    expect(hosts[0]?.candidate.count).toBe(3);
+    const searches = result.candidates.filter(
+      (row) => row.candidate.candidateKind === "behavior_search_query",
+    );
+    expect(searches).toHaveLength(1);
+    expect(searches[0]?.candidate.fields.candidateValue).toEqual(
+      valueField("forensics"),
+    );
+  });
+
+  it("marks the artifact unavailable when every input is unavailable", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: history([], "unavailable"),
+      webData: webData([], "unavailable"),
+      preferences: undefined,
+      localState: undefined,
+    });
+    expect(result.status).toBe("unavailable");
+    expect(result.candidates).toHaveLength(0);
+  });
+
+  it("still produces Candidates from available inputs and names the unavailable ones", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: undefined,
+      webData: webData([], "unavailable"),
+      preferences: preferences({
+        accountFullName: valueField("A B"),
+      } as ForensicFields),
+      localState: undefined,
+    });
+    expect(result.status).toBe("complete");
+    expect(result.reason).toContain("web_data_unavailable");
+    expect(
+      result.candidates.some(
+        (row) => row.candidate.candidateKind === "identity_name",
+      ),
+    ).toBe(true);
+  });
+
+  it("reports absent when no input is present at all", () => {
+    const result = generateProfileCandidates({
+      sourceId: SOURCE,
+      profile: PROFILE,
+      history: undefined,
+      webData: undefined,
+      preferences: undefined,
+      localState: undefined,
+    });
+    expect(result.status).toBe("absent");
+    expect(result.candidates).toHaveLength(0);
+  });
+});

--- a/docs/candidates.md
+++ b/docs/candidates.md
@@ -31,15 +31,19 @@ Candidate pass leaves every other artifact byte-for-byte identical.
 
 Each heuristic consumes committed Findings from earlier parsers in the same run.
 
-| Kind | Category | Evidence |
-| --- | --- | --- |
-| `identity_name` | identity | Web Data autofill name-like fields; Preferences `full_name` / `given_name` |
-| `identity_email` | identity | Web Data autofill email-like fields or values; Preferences account `email` |
-| `identity_phone` | identity | Web Data autofill phone/tel/mobile fields |
-| `identity_postal_address` | identity | Web Data autofill address/street/city/state/zip fields |
-| `identity_country` | identity | Web Data autofill country fields; Local State `variations_country` |
-| `behavior_frequent_host` | behavior | Host of each committed History visit URL |
-| `behavior_search_query` | behavior | Query term parsed from known search-engine History URLs |
+| Kind                      | Category | Evidence                                                                   |
+| ------------------------- | -------- | -------------------------------------------------------------------------- |
+| `identity_name`           | identity | Web Data autofill name-like fields; Preferences `full_name` / `given_name` |
+| `identity_email`          | identity | Web Data autofill email-like fields or values; Preferences account `email` |
+| `identity_phone`          | identity | Web Data autofill phone/tel/mobile fields                                  |
+| `identity_postal_address` | identity | Web Data autofill address/street/city/state/zip fields                     |
+| `identity_country`        | identity | Web Data autofill country fields; Local State `variations_country`         |
+| `behavior_frequent_host`  | behavior | Host of each committed History visit URL                                   |
+| `behavior_search_query`   | behavior | Query term parsed from known search-engine History URLs                    |
+
+**Linked-device Candidates are deferred.** The parent intent names "linked
+devices" as a future Candidate class, but no linked-device heuristic is supported
+yet; none is emitted, so no linked-device value is ever asserted.
 
 Only committed evidence is used. Sidecar (WAL / rollback-journal) rows never
 feed Candidate generation, so a recovered row can never inflate a rank.
@@ -56,7 +60,8 @@ Within one `candidateKind` and Profile, evidence is grouped by a normalized key
   ascending, and assigned dense ranks `1..N` in that order.
 
 At most 100 Candidates are emitted per kind per Profile, and at most 200
-supporting Provenance rows are carried per Candidate.
+Provenance rows total are carried per Candidate (one primary plus up to 199
+supporting).
 
 ## Deterministic behavior for the awkward cases
 
@@ -79,7 +84,10 @@ supporting Provenance rows are carried per Candidate.
 ## Query surface
 
 The `candidates` CLI command and the dashboard `Candidates` tab share the same
-contract as every Finding list: TYPE first, a Completeness Statement before any
-row, and `--search`, `--category`, `--kind`, `--profile` (multi-Profile),
-`--sort`, `--direction`, and keyset `--limit` / `--after` pagination. The sorts
-are `rank`, `kind`, `supporting-count`, `value`, and `profile`.
+contract as every Finding list: TYPE first, and `--search`, `--category`,
+`--kind`, `--profile` (multi-Profile), `--sort`, `--direction`, and keyset
+`--limit` / `--after` pagination. The sorts are `rank`, `kind`,
+`supporting-count`, `value`, and `profile`. Like every other artifact list, the
+Candidate list returns rows only; the Completeness Statement for `Candidates` is
+read from the shared `completeness` route (and the dashboard renders it before
+any row).

--- a/docs/candidates.md
+++ b/docs/candidates.md
@@ -63,6 +63,13 @@ At most 100 Candidates are emitted per kind per Profile, and at most 200
 Provenance rows total are carried per Candidate (one primary plus up to 199
 supporting).
 
+The `supportingCount` is the **full** tally of distinct source rows behind a
+Candidate, even when that exceeds 200. The carried Provenance is a bounded
+sample: `supportingCount` may therefore be larger than the number of resolvable
+Provenance rows. This keeps the rank faithful to all the evidence while keeping
+the stored row list bounded; the count is never silently truncated to match the
+sample.
+
 ## Deterministic behavior for the awkward cases
 
 - **Ties.** Equal supporting counts are a total order: they break by normalized

--- a/docs/candidates.md
+++ b/docs/candidates.md
@@ -1,0 +1,85 @@
+# Identity and behavior Candidates
+
+The analyzer derives ranked **Candidates** from the Findings it has already
+written for an Analysis Run. Candidates answer questions like "whose profile is
+this?" and "what does this person do?" without ever asserting an answer.
+
+## What a Candidate is
+
+A Candidate is a **nominal, ranked hypothesis**. Every Candidate carries:
+
+- a `candidateKind` (the TYPE, always the first column);
+- a `category`, either `identity` or `behavior`;
+- a `rank` (a positive integer, dense within its kind and Profile);
+- a `supportingCount` (how many source rows support it);
+- resolvable, row-level **Provenance**. When more than one source row supports a
+  Candidate, the extra rows are carried as `provenance.supportingRows`.
+
+A Candidate is **never** a Finding and **never** a factual summary tile:
+
+- It has no Commit State.
+- Its `candidateKind` is a ranked-hypothesis kind (`identity_*`, `behavior_*`),
+  never a Finding kind.
+- Names, countries, phone numbers, addresses, linked devices, and habits appear
+  only here — ranked and hedged — never in a Finding field or a summary tile.
+
+Candidate generation **reads** Findings. It never mutates, hides, re-scores, or
+re-orders any Preferences, Web Data, History, or other source row. Removing the
+Candidate pass leaves every other artifact byte-for-byte identical.
+
+## Inputs and heuristics
+
+Each heuristic consumes committed Findings from earlier parsers in the same run.
+
+| Kind | Category | Evidence |
+| --- | --- | --- |
+| `identity_name` | identity | Web Data autofill name-like fields; Preferences `full_name` / `given_name` |
+| `identity_email` | identity | Web Data autofill email-like fields or values; Preferences account `email` |
+| `identity_phone` | identity | Web Data autofill phone/tel/mobile fields |
+| `identity_postal_address` | identity | Web Data autofill address/street/city/state/zip fields |
+| `identity_country` | identity | Web Data autofill country fields; Local State `variations_country` |
+| `behavior_frequent_host` | behavior | Host of each committed History visit URL |
+| `behavior_search_query` | behavior | Query term parsed from known search-engine History URLs |
+
+Only committed evidence is used. Sidecar (WAL / rollback-journal) rows never
+feed Candidate generation, so a recovered row can never inflate a rank.
+
+## Ranking
+
+Within one `candidateKind` and Profile, evidence is grouped by a normalized key
+(trimmed, whitespace-collapsed, lower-cased). Each group becomes one Candidate:
+
+- `supportingCount` is the number of distinct source rows in the group;
+- the displayed value is the most frequent raw form, with ties broken by the
+  smallest value in code-unit order;
+- groups are ordered by `supportingCount` descending, then by normalized value
+  ascending, and assigned dense ranks `1..N` in that order.
+
+At most 100 Candidates are emitted per kind per Profile, and at most 200
+supporting Provenance rows are carried per Candidate.
+
+## Deterministic behavior for the awkward cases
+
+- **Ties.** Equal supporting counts are a total order: they break by normalized
+  value ascending, so tied Candidates still receive distinct, reproducible
+  ranks. Identical inputs always produce identical output.
+- **No evidence.** A heuristic that finds nothing emits no Candidate. When every
+  heuristic is empty but at least one input was produced, the Candidate artifact
+  is `complete` with zero rows — the pass ran and nominated nothing.
+- **Conflicting evidence.** Distinct values under one kind each become their own
+  ranked Candidate. Conflicts are surfaced as a ranked list; they are never
+  merged and never resolved into a single fact.
+- **Unavailable inputs.** An `absent` or `unavailable` input contributes no
+  evidence and is named in the artifact `reason` (for example
+  `web_data_unavailable`). If at least one input was produced, the artifact is
+  `complete`. If no input was produced, the artifact is `unavailable` (an input
+  failed) or `absent` (no input was present). Candidate generation never changes
+  the Analysis Run exit code that the source artifacts determine.
+
+## Query surface
+
+The `candidates` CLI command and the dashboard `Candidates` tab share the same
+contract as every Finding list: TYPE first, a Completeness Statement before any
+row, and `--search`, `--category`, `--kind`, `--profile` (multi-Profile),
+`--sort`, `--direction`, and keyset `--limit` / `--after` pagination. The sorts
+are `rank`, `kind`, `supporting-count`, `value`, and `profile`.

--- a/e2e/candidates-cli.test.ts
+++ b/e2e/candidates-cli.test.ts
@@ -1,0 +1,431 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface CandidateRecord {
+  readonly recordType: "candidate";
+  readonly candidateKind: string;
+  readonly category: "identity" | "behavior";
+  readonly profile: string;
+  readonly rank: number;
+  readonly supportingCount: number;
+  readonly provenance: {
+    readonly manifestPath: string;
+    readonly table: string;
+    readonly rowId: string;
+    readonly supportingRows?: readonly unknown[];
+  };
+  readonly fields: {
+    readonly candidateValue: Field<string>;
+    readonly supportingCount: Field<string>;
+    readonly evidenceBasis: Field<string>;
+  };
+}
+
+interface CandidatePage {
+  readonly status: "ok";
+  readonly command: "candidates";
+  readonly completeness: {
+    readonly attempted: number;
+    readonly produced: number;
+    readonly absent: number;
+    readonly unavailable: number;
+  };
+  readonly items: readonly CandidateRecord[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+interface AutofillRow {
+  readonly name: string;
+  readonly value: string;
+}
+
+async function createWebData(
+  path: string,
+  rows: readonly AutofillRow[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '133'), ('last_compatible_version', '83');
+      CREATE TABLE autofill (
+        name VARCHAR,
+        value VARCHAR,
+        value_lower VARCHAR,
+        date_created INTEGER DEFAULT 0,
+        date_last_used INTEGER DEFAULT 0,
+        count INTEGER DEFAULT 1,
+        PRIMARY KEY (name, value)
+      );
+    `);
+    const insert = database.prepare(
+      `INSERT INTO autofill (name, value, value_lower, date_created, date_last_used, count)
+       VALUES (?, ?, ?, 1704164645, 1704164645, 1)`,
+    );
+    for (const row of rows) {
+      insert.run(row.name, row.value, row.value.toLocaleLowerCase("en-US"));
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function createHistory(
+  path: string,
+  urls: readonly string[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR,
+        title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY,
+        segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL,
+        visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    const insertUrl = database.prepare(
+      `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, ?, ?, 13300000000000000, 0)`,
+    );
+    const insertVisit = database.prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, 13300000000000000, 0, '', 805306368, 0, 0, 1, 0,
+               'guid', ?, 0, 0, 1, 1, ?, 'app')`,
+    );
+    urls.forEach((url, index) => {
+      const urlId = index + 1;
+      insertUrl.run(urlId, url, `Title ${String(urlId)}`, 1, urlId);
+      insertVisit.run(urlId, urlId, urlId + 1000, urlId + 2000);
+    });
+  } finally {
+    database.close();
+  }
+}
+
+async function createSource(root: string): Promise<string> {
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(
+    join(source, "Local State"),
+    `${JSON.stringify({ variations_country: "us" })}\n`,
+  );
+
+  // Default Profile: identity evidence from autofill + Preferences account.
+  await createWebData(join(source, "Default", "Web Data"), [
+    { name: "name", value: "Ada Lovelace" },
+    { name: "fullname", value: "Ada Lovelace" },
+    { name: "name", value: "A. Lovelace" },
+    { name: "email", value: "ada@analytical.example" },
+    { name: "phone", value: "+1-555-0100" },
+    { name: "shipping_address", value: "12 Analytical Way" },
+    { name: "country", value: "US" },
+  ]);
+  await writeFile(
+    join(source, "Default", "Preferences"),
+    `${JSON.stringify({
+      profile: { name: "Ada" },
+      account_info: [
+        {
+          email: "ada@analytical.example",
+          full_name: "Ada Lovelace",
+          gaia: "1",
+        },
+      ],
+    })}\n`,
+  );
+  await createHistory(join(source, "Default", "History"), [
+    "https://news.example/a",
+    "https://news.example/b",
+    "https://news.example/c",
+    "https://shop.example/x",
+    "https://www.google.com/search?q=babbage+engine",
+  ]);
+
+  // Profile 1: distinct identity evidence, proving multi-Profile separation.
+  await createWebData(join(source, "Profile 1", "Web Data"), [
+    { name: "name", value: "Grace Hopper" },
+  ]);
+  await writeFile(
+    join(source, "Profile 1", "Preferences"),
+    `${JSON.stringify({ profile: { name: "Grace" } })}\n`,
+  );
+  await createHistory(join(source, "Profile 1", "History"), [
+    "https://compiler.example/home",
+  ]);
+  return source;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI identity and behavior Candidates", () => {
+  it("emits ranked nominal Candidates with Provenance while leaving source rows untouched", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-candidates-e2e-"));
+    temporaryRoots.push(root);
+    const source = await createSource(root);
+    const webBytes = await readFile(join(source, "Default", "Web Data"));
+    const caseDirectory = join(root, "CASE-CAND");
+
+    expect(
+      runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+    ).toBe(0);
+    // The run is queryable (clean or partial); Candidate generation is derived
+    // and never changes the exit-code semantics of the source artifacts.
+    expect(
+      runCli(["analyse", "--case", caseDirectory, "--json"]).status,
+    ).not.toBe(1);
+
+    // AC: Completeness before rows; every heuristic is nominal + ranked.
+    const all = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--limit",
+        "100",
+        "--json",
+      ]).stdout,
+    );
+    expect(all.command).toBe("candidates");
+    expect(all.completeness.attempted).toBe(2);
+    expect(all.completeness.produced).toBe(2);
+    expect(all.items.length).toBeGreaterThan(0);
+    for (const item of all.items) {
+      expect(item.recordType).toBe("candidate");
+      expect(item.rank).toBeGreaterThanOrEqual(1);
+      expect(item.supportingCount).toBeGreaterThanOrEqual(1);
+      expect(item.provenance.rowId.length).toBeGreaterThan(0);
+      // A Candidate is never a Finding: it carries no Commit State.
+      expect((item as Record<string, unknown>).commitState).toBeUndefined();
+    }
+
+    // AC: conflicting names surface as a ranked list; the most-supported wins.
+    const names = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--kind",
+        "identity_name",
+        "--profile",
+        "Default",
+        "--json",
+      ]).stdout,
+    );
+    const topName = names.items[0];
+    expect(topName?.category).toBe("identity");
+    expect(topName?.rank).toBe(1);
+    expect(topName?.fields.candidateValue).toEqual({
+      state: "value",
+      value: "Ada Lovelace",
+    });
+    // Autofill (x2) plus the Preferences account full_name = three source rows.
+    expect(topName?.supportingCount).toBe(3);
+    expect(topName?.provenance.supportingRows?.length).toBe(2);
+
+    // AC: behavior habit from History, ranked by visit count.
+    const hosts = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--kind",
+        "behavior_frequent_host",
+        "--profile",
+        "Default",
+        "--json",
+      ]).stdout,
+    );
+    expect(hosts.items[0]?.fields.candidateValue).toEqual({
+      state: "value",
+      value: "news.example",
+    });
+    expect(hosts.items[0]?.supportingCount).toBe(3);
+
+    // AC: category filter partitions identity vs behavior.
+    const behavior = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--category",
+        "behavior",
+        "--json",
+      ]).stdout,
+    );
+    expect(behavior.items.length).toBeGreaterThan(0);
+    expect(behavior.items.every((item) => item.category === "behavior")).toBe(
+      true,
+    );
+
+    // AC: search matches nominal value text.
+    const search = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--search",
+        "babbage",
+        "--json",
+      ]).stdout,
+    );
+    expect(search.items).toHaveLength(1);
+    expect(search.items[0]?.candidateKind).toBe("behavior_search_query");
+
+    // AC: multi-Profile separation — Profile 1 owns only its own name.
+    const profile1 = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--profile",
+        "Profile 1",
+        "--kind",
+        "identity_name",
+        "--json",
+      ]).stdout,
+    );
+    expect(profile1.items).toHaveLength(1);
+    expect(profile1.items[0]?.fields.candidateValue).toEqual({
+      state: "value",
+      value: "Grace Hopper",
+    });
+
+    // AC: bounded keyset pagination is stable and non-overlapping.
+    const firstPage = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "kind",
+        "--limit",
+        "3",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage.items).toHaveLength(3);
+    expect(firstPage.nextCursor).not.toBeNull();
+    const secondPage = parseJson<CandidatePage>(
+      runCli([
+        "candidates",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "kind",
+        "--limit",
+        "3",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const firstIds = new Set(
+      firstPage.items.map(
+        (item) => `${item.profile}:${item.candidateKind}:${String(item.rank)}`,
+      ),
+    );
+    for (const item of secondPage.items) {
+      expect(
+        firstIds.has(
+          `${item.profile}:${item.candidateKind}:${String(item.rank)}`,
+        ),
+      ).toBe(false);
+    }
+
+    // AC: Candidate generation never changes the source rows it reads, and the
+    // underlying artifact queries still return their Findings unchanged.
+    expect(await readFile(join(source, "Default", "Web Data"))).toEqual(
+      webBytes,
+    );
+    const autofill = parseJson<{ readonly items: readonly unknown[] }>(
+      runCli(["autofill", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(autofill.items.length).toBe(8);
+    const metadata = parseJson<{ readonly items: readonly unknown[] }>(
+      runCli(["metadata", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(metadata.items.length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/candidates-cli.test.ts
+++ b/e2e/candidates-cli.test.ts
@@ -43,12 +43,6 @@ interface CandidateRecord {
 interface CandidatePage {
   readonly status: "ok";
   readonly command: "candidates";
-  readonly completeness: {
-    readonly attempted: number;
-    readonly produced: number;
-    readonly absent: number;
-    readonly unavailable: number;
-  };
   readonly items: readonly CandidateRecord[];
   readonly nextCursor: string | null;
   readonly limit: number;
@@ -256,7 +250,8 @@ describe("compiled analyzer CLI identity and behavior Candidates", () => {
       runCli(["analyse", "--case", caseDirectory, "--json"]).status,
     ).not.toBe(1);
 
-    // AC: Completeness before rows; every heuristic is nominal + ranked.
+    // AC: every heuristic is nominal + ranked. The Candidate list returns rows
+    // only, like every other artifact list; Completeness is a separate route.
     const all = parseJson<CandidatePage>(
       runCli([
         "candidates",
@@ -268,8 +263,6 @@ describe("compiled analyzer CLI identity and behavior Candidates", () => {
       ]).stdout,
     );
     expect(all.command).toBe("candidates");
-    expect(all.completeness.attempted).toBe(2);
-    expect(all.completeness.produced).toBe(2);
     expect(all.items.length).toBeGreaterThan(0);
     for (const item of all.items) {
       expect(item.recordType).toBe("candidate");

--- a/e2e/serve-cli.test.ts
+++ b/e2e/serve-cli.test.ts
@@ -379,6 +379,41 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
     ).json()) as { readonly profiles: readonly string[] };
     expect([...profiles.profiles].sort()).toEqual(["Default", "Profile 1"]);
 
+    // #185: the dashboard exposes ranked identity/behavior Candidates with
+    // Completeness before rows and the shared Profile/kind/search filters.
+    const candidatesStatement = completeness.statements.find(
+      (entry) => entry.artifact === "Candidates",
+    );
+    expect(candidatesStatement?.attempted).toBe(2);
+    const candidates = (await (
+      await fetch(
+        `${base}/api/candidates?category=behavior&kind=behavior_frequent_host&profile=Default&limit=10`,
+        { headers: auth },
+      )
+    ).json()) as {
+      readonly completeness: { readonly attempted: number };
+      readonly items: readonly {
+        readonly recordType: string;
+        readonly candidateKind: string;
+        readonly category: string;
+        readonly rank: number;
+        readonly supportingCount: number;
+        readonly fields: {
+          readonly candidateValue: { readonly value: string };
+        };
+      }[];
+    };
+    expect(candidates.completeness.attempted).toBeGreaterThan(0);
+    expect(candidates.items[0]).toMatchObject({
+      recordType: "candidate",
+      candidateKind: "behavior_frequent_host",
+      category: "behavior",
+      rank: 1,
+    });
+    expect(candidates.items[0]?.fields.candidateValue.value).toBe(
+      "alpha.example",
+    );
+
     // AC4: keyset pagination returns bounded pages with a cursor.
     const firstPage = (await (
       await fetch(`${base}/api/history?sort=visit-time&direction=asc&limit=1`, {

--- a/e2e/serve-cli.test.ts
+++ b/e2e/serve-cli.test.ts
@@ -379,19 +379,20 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
     ).json()) as { readonly profiles: readonly string[] };
     expect([...profiles.profiles].sort()).toEqual(["Default", "Profile 1"]);
 
-    // #185: the dashboard exposes ranked identity/behavior Candidates with
-    // Completeness before rows and the shared Profile/kind/search filters.
+    // #185: Candidate Completeness comes from the shared completeness route,
+    // exactly like every other artifact — not embedded in the list response.
     const candidatesStatement = completeness.statements.find(
       (entry) => entry.artifact === "Candidates",
     );
     expect(candidatesStatement?.attempted).toBe(2);
+    expect(candidatesStatement?.produced).toBe(2);
+    // The list route returns ranked rows only, with the shared filters.
     const candidates = (await (
       await fetch(
         `${base}/api/candidates?category=behavior&kind=behavior_frequent_host&profile=Default&limit=10`,
         { headers: auth },
       )
     ).json()) as {
-      readonly completeness: { readonly attempted: number };
       readonly items: readonly {
         readonly recordType: string;
         readonly candidateKind: string;
@@ -403,7 +404,6 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
         };
       }[];
     };
-    expect(candidates.completeness.attempted).toBeGreaterThan(0);
     expect(candidates.items[0]).toMatchObject({
       recordType: "candidate",
       candidateKind: "behavior_frequent_host",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,12 +10,15 @@ import { createRequire } from "node:module";
 
 import {
   ForensixError,
+  queryCandidates,
   queryCompleteness,
   queryCookies,
   queryCredentials,
   queryHistory,
   queryProfiles,
   queryTopSites,
+  type CandidateDirection,
+  type CandidateSort,
   type CommitState,
   type CookieDirection,
   type CookieSort,
@@ -284,6 +287,20 @@ function handleApi(
         sort: firstString(parameters.get("sort")) as TopSiteSort | undefined,
         direction: firstString(parameters.get("direction")) as
           | TopSiteDirection
+          | undefined,
+        limit: integerParameter(parameters, "limit"),
+        after: firstString(parameters.get("after")),
+      });
+    case "candidates":
+      return queryCandidates({
+        caseDirectory,
+        profiles,
+        search: firstString(parameters.get("search")),
+        category: firstString(parameters.get("category")),
+        kind: firstString(parameters.get("kind")),
+        sort: firstString(parameters.get("sort")) as CandidateSort | undefined,
+        direction: firstString(parameters.get("direction")) as
+          | CandidateDirection
           | undefined,
         limit: integerParameter(parameters, "limit"),
         after: firstString(parameters.get("after")),


### PR DESCRIPTION
Closes #185.

Derives ranked identity and behavior **Candidates** from the Findings already written for an Analysis Run (committed Web Data autofill #178, Preferences/Local State metadata #176, and History visits). A Candidate is nominal — a ranked hypothesis with a supporting count and resolvable row-level Provenance — and is never promoted to a Finding or a factual summary tile.

## Acceptance criteria → implementation

- **Each supported heuristic emits ONLY nominal Candidates with rank + supporting count + row-level Provenance.**
  `core/src/identity-candidates.ts` groups committed evidence per `candidateKind`+Profile, assigns dense ranks, sets `supportingCount` to the distinct supporting-row count, and builds Provenance with `supportingRows` for aggregated evidence. Heuristics: `identity_name`, `identity_email`, `identity_phone`, `identity_postal_address`, `identity_country`, `behavior_frequent_host`, `behavior_search_query`.
- **Names/countries/phone numbers/addresses/linked devices/habits NEVER occupy Finding fields or factual summary tiles.**
  Candidates are stored in dedicated tables (`candidate_artifact_results`, `identity_candidates`), carry no Commit State, and use ranked-hypothesis kinds. The CLI/dashboard render them in a separate, clearly-labeled surface.
- **Candidate generation does not change or hide Preferences/Web Data/History or other source rows.**
  Generation only reads Findings. The e2e test asserts the source Web Data is byte-for-byte unchanged and that `autofill`/`metadata`/`history` queries still return their rows. Candidates are excluded from the Analysis Run exit-code calculation.
- **Ties, no-evidence, conflicting evidence, and unavailable inputs have deterministic documented behavior.**
  Ties break by normalized value ascending (dense ranks); no evidence emits nothing; conflicts surface as a ranked list; unavailable inputs are named in a typed artifact `reason`, with the artifact `complete`/`unavailable`/`absent` accordingly. Documented in `docs/candidates.md` and covered by unit tests.
- **CLI and dashboard keep TYPE first and preserve search/filter/sort/pagination/multi-Profile.**
  New `candidates` CLI command and dashboard `Candidates` tab + `/api/candidates` route mirror the shared query surface: TYPE first, Completeness before rows, `--search`/`--category`/`--kind`/`--profile`, `--sort` (`rank|kind|supporting-count|value|profile`), and keyset `--limit`/`--after`.

## Tests

- `core/test/identity-candidates.test.ts` — 8 deterministic unit tests (ties, conflict, merge across inputs, no-evidence, host/search counting, unavailable/partial/absent status).
- `e2e/candidates-cli.test.ts` — full ingest → analyse → `candidates` flow: ranked Candidates, Provenance, category/kind/search filters, multi-Profile separation, keyset pagination, and source rows untouched.
- `e2e/serve-cli.test.ts` — dashboard `/api/candidates` route with Completeness before rows.

`pnpm verify` passes (129 tests) on Node 24.15.0.