### PR TITLE
feat(cache): detect and extract blockfile, Simple, and SQL cache backends

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -11,6 +11,7 @@ import {
   ingestSource,
   queryAutofill,
   queryBookmarks,
+  queryCache,
   queryCookies,
   queryCredentials,
   queryDownloads,
@@ -24,6 +25,9 @@ import {
   type BookmarkDirection,
   type BookmarkSort,
   type BookmarkSource,
+  type CacheDirection,
+  type CacheRecordType,
+  type CacheSort,
   type CommitState,
   type CookieDirection,
   type CookieSort,
@@ -88,6 +92,12 @@ const USAGE = `Usage:
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <icon-url|page-url|last-updated|width|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix cache --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--record-type <finding|candidate>] [--backend <simple>]
+                   [--sort <key|last-used|size|entry-hash|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix downloads --case <case-directory>
@@ -163,6 +173,8 @@ const VALUE_OPTIONS = new Set([
   "--danger",
   "--type",
   "--source",
+  "--record-type",
+  "--backend",
   "--sort",
   "--direction",
   "--limit",
@@ -777,6 +789,54 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as FaviconSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | FaviconDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "cache") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--record-type",
+        "--backend",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The cache command accepts no positional values.",
+      );
+    }
+    const result = queryCache({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      recordType: enumOption(parsed, "--record-type", [
+        "finding",
+        "candidate",
+      ] as const) as CacheRecordType | undefined,
+      backend: optionValue(parsed, "--backend"),
+      sort: enumOption(parsed, "--sort", [
+        "key",
+        "last-used",
+        "size",
+        "entry-hash",
+        "profile",
+      ] as const) as CacheSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | CacheDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/core/src/cache-format.ts
+++ b/core/src/cache-format.ts
@@ -1,0 +1,538 @@
+import { createHash } from "node:crypto";
+import { crc32 as zlibCrc32 } from "node:zlib";
+
+/**
+ * Pure, filesystem-free readers for the three Chromium HTTP-cache backends.
+ *
+ * A Chrome cache directory (`<Profile>/Cache/Cache_Data`, `Code Cache/...`,
+ * `GPUCache`) is a directory of files, not a SQLite database. Which backend
+ * wrote it is decided by the bytes on disk, never by the Source platform, so
+ * detection here reads magic numbers and file names rather than assuming an OS.
+ *
+ * The formats mirrored below are the recorded Chromium on-disk contracts:
+ *   - blockfile: `net/disk_cache/blockfile/disk_format.h` (`index` + `data_*`).
+ *   - Simple Cache: `net/disk_cache/simple/simple_entry_format.h` (entry files)
+ *     and `simple_index_file.cc` (`index-dir/the-real-index`).
+ *   - SQL Cache: a SQLite database (`SQLite format 3\0` header).
+ *
+ * Only the Simple Cache backend is extracted to exact entry Findings; blockfile
+ * and SQL Cache are detected and reported with an explicit unavailable reason.
+ */
+
+export type CacheBackend = "blockfile" | "simple" | "sql" | "unknown";
+
+// Blockfile `index` file magic and version, and the `data_*` block-file magic.
+// disk_format.h: kIndexMagic / kBlockMagic. Read as little-endian uint32.
+export const BLOCKFILE_INDEX_MAGIC = 0xc103cac3;
+export const BLOCKFILE_BLOCK_MAGIC = 0xc104cac3;
+
+// simple_entry_format.h magic numbers, read as little-endian uint64.
+export const SIMPLE_INITIAL_MAGIC = 0xfcfb6d1ba7725c30n;
+export const SIMPLE_FINAL_MAGIC = 0xf4fa6f45970d41d8n;
+export const SIMPLE_SPARSE_MAGIC = 0xeb97bf016553676bn;
+
+// simple_index_file.h kSimpleIndexMagicNumber, read as little-endian uint64.
+export const SIMPLE_INDEX_MAGIC = 0x656e74657220796fn;
+
+// SimpleFileEOF::Flags.
+const FLAG_HAS_CRC32 = 1 << 0;
+const FLAG_HAS_KEY_SHA256 = 1 << 1;
+
+const SIMPLE_HEADER_BYTES = 24;
+const SIMPLE_EOF_BYTES = 24;
+const SIMPLE_KEY_SHA256_BYTES = 32;
+
+// Microseconds between the 1601-01-01 Windows epoch (base::Time internal value
+// origin) and the 1970 Unix epoch. base::Time::ToInternalValue() emits this.
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+const SQLITE_MAGIC = Buffer.from("SQLite format 3\u0000", "latin1");
+
+// A Simple Cache entry file is `<16 hex hash>_<stream index>`, where stream
+// index 0/1 are dense streams and `s` is the sparse stream.
+const SIMPLE_ENTRY_FILE = /^[0-9a-f]{16}_[01s]$/;
+
+/**
+ * One shallow directory entry handed to detection: a path relative to the cache
+ * data directory (posix separators) plus the leading bytes of the file. Only
+ * the head is needed to read a magic number, so a caller never buffers a whole
+ * cache into memory just to classify it.
+ */
+export interface CacheDirEntry {
+  readonly relativePath: string;
+  readonly head: Uint8Array;
+}
+
+export interface BackendDetection {
+  readonly backend: CacheBackend;
+  /** A short, stable label naming the on-disk evidence that decided `backend`. */
+  readonly evidence: string;
+}
+
+function viewOf(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+}
+
+function readUint32LE(bytes: Uint8Array, offset: number): number | null {
+  if (offset < 0 || offset + 4 > bytes.length) {
+    return null;
+  }
+  return viewOf(bytes).getUint32(offset, true);
+}
+
+function readUint64LE(bytes: Uint8Array, offset: number): bigint | null {
+  if (offset < 0 || offset + 8 > bytes.length) {
+    return null;
+  }
+  return viewOf(bytes).getBigUint64(offset, true);
+}
+
+function readInt64LE(bytes: Uint8Array, offset: number): bigint | null {
+  if (offset < 0 || offset + 8 > bytes.length) {
+    return null;
+  }
+  return viewOf(bytes).getBigInt64(offset, true);
+}
+
+function startsWith(bytes: Uint8Array, prefix: Uint8Array): boolean {
+  if (bytes.length < prefix.length) {
+    return false;
+  }
+  for (let index = 0; index < prefix.length; index += 1) {
+    if (bytes[index] !== prefix[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Decide the cache backend from directory contents alone. Detection is
+ * deterministic and platform-independent: a blockfile `index` magic wins first
+ * because it is the most specific signal, then Simple Cache (its real index or
+ * any entry-file magic), then a SQLite header. When nothing matches, the
+ * backend is `unknown` and the caller reports an explicit unavailable reason
+ * rather than an empty result.
+ */
+export function detectCacheBackend(
+  entries: readonly CacheDirEntry[],
+): BackendDetection {
+  const byPath = new Map<string, CacheDirEntry>();
+  for (const entry of entries) {
+    byPath.set(entry.relativePath, entry);
+  }
+
+  const indexFile = byPath.get("index");
+  if (indexFile !== undefined) {
+    const magic = readUint32LE(indexFile.head, 0);
+    if (magic === BLOCKFILE_INDEX_MAGIC) {
+      return { backend: "blockfile", evidence: "index_magic" };
+    }
+  }
+  for (const entry of entries) {
+    if (readUint32LE(entry.head, 0) === BLOCKFILE_INDEX_MAGIC) {
+      return { backend: "blockfile", evidence: "index_magic" };
+    }
+  }
+
+  if (byPath.has("index-dir/the-real-index")) {
+    return { backend: "simple", evidence: "the_real_index" };
+  }
+  for (const entry of entries) {
+    const name = entry.relativePath.split("/").at(-1) ?? "";
+    if (
+      SIMPLE_ENTRY_FILE.test(name) &&
+      readUint64LE(entry.head, 0) === SIMPLE_INITIAL_MAGIC
+    ) {
+      return { backend: "simple", evidence: "simple_entry_magic" };
+    }
+  }
+
+  for (const entry of entries) {
+    if (startsWith(entry.head, SQLITE_MAGIC)) {
+      return { backend: "sql", evidence: "sqlite_header" };
+    }
+  }
+
+  return { backend: "unknown", evidence: "no_backend_signature" };
+}
+
+/**
+ * Paul Hsieh's SuperFastHash, byte-for-byte the function Chromium persists as
+ * `SimpleFileHeader.key_hash` via `base::PersistentHash`. It must not change,
+ * so it is reproduced exactly here to validate a recorded key against its
+ * header without trusting the header blindly.
+ */
+export function superFastHash(data: Uint8Array): number {
+  let length = data.length;
+  if (length <= 0) {
+    return 0;
+  }
+  let hash = length >>> 0;
+  const remainder = length & 3;
+  length >>= 2;
+  let offset = 0;
+  const get16 = (at: number): number =>
+    (data[at] ?? 0) | ((data[at + 1] ?? 0) << 8);
+  for (; length > 0; length -= 1) {
+    hash = (hash + get16(offset)) >>> 0;
+    const tmp = (((get16(offset + 2) << 11) >>> 0) ^ hash) >>> 0;
+    hash = (((hash << 16) >>> 0) ^ tmp) >>> 0;
+    offset += 4;
+    hash = (hash + (hash >>> 11)) >>> 0;
+  }
+  const signedByte = (at: number): number => ((data[at] ?? 0) << 24) >> 24;
+  switch (remainder) {
+    case 3:
+      hash = (hash + get16(offset)) >>> 0;
+      hash = (hash ^ ((hash << 16) >>> 0)) >>> 0;
+      hash = (hash ^ ((signedByte(offset + 2) << 18) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 11)) >>> 0;
+      break;
+    case 2:
+      hash = (hash + get16(offset)) >>> 0;
+      hash = (hash ^ ((hash << 11) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 17)) >>> 0;
+      break;
+    case 1:
+      hash = (hash + signedByte(offset)) >>> 0;
+      hash = (hash ^ ((hash << 10) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 1)) >>> 0;
+      break;
+    default:
+      break;
+  }
+  hash = (hash ^ ((hash << 3) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 5)) >>> 0;
+  hash = (hash ^ ((hash << 4) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 17)) >>> 0;
+  hash = (hash ^ ((hash << 10) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 6)) >>> 0;
+  return hash >>> 0;
+}
+
+/**
+ * The 16-hex Simple Cache entry hash of a key: the first eight bytes of
+ * SHA-1(key) read as a little-endian uint64, exactly `simple_util`'s
+ * `GetEntryHashKey`. Used to link an entry file name to the key it stores and
+ * to the record for that hash in the real index.
+ */
+export function entryHashHexFromKey(key: Uint8Array): string {
+  const digest = createHash("sha1").update(key).digest();
+  const value = readUint64LE(digest, 0) as bigint;
+  return value.toString(16).padStart(16, "0");
+}
+
+function internalMicrosToUtc(internalMicros: bigint): string | null {
+  const unixMicros = internalMicros - WINDOWS_EPOCH_OFFSET_MICROS;
+  const seconds =
+    unixMicros >= 0n
+      ? unixMicros / 1_000_000n
+      : (unixMicros - 999_999n) / 1_000_000n;
+  const micros = unixMicros - seconds * 1_000_000n;
+  const milliseconds = Number(seconds * 1000n + micros / 1000n);
+  if (!Number.isSafeInteger(milliseconds)) {
+    return null;
+  }
+  const date = new Date(milliseconds);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return `${date.toISOString().slice(0, -5)}.${micros
+    .toString()
+    .padStart(6, "0")}Z`;
+}
+
+export interface SimpleStream {
+  readonly size: number;
+  readonly data: Uint8Array;
+  readonly declaredCrc32: number | null;
+  readonly crc32Valid: boolean | null;
+}
+
+export type SimpleEntryParse =
+  | {
+      readonly ok: true;
+      readonly version: number;
+      readonly key: Uint8Array;
+      readonly keyText: string | null;
+      readonly keyLength: number;
+      readonly headerKeyHash: number;
+      readonly keyHashValid: boolean;
+      readonly keySha256: string | null;
+      readonly stream0: SimpleStream;
+      readonly stream1: SimpleStream;
+      readonly entryHashFromKey: string;
+    }
+  | { readonly ok: false; readonly reason: SimpleEntryFailure };
+
+export type SimpleEntryFailure =
+  | "not_simple_magic"
+  | "truncated"
+  | "bad_stream0_eof"
+  | "bad_stream1_eof"
+  | "inconsistent_layout";
+
+interface ParsedEof {
+  readonly flags: number;
+  readonly crc32: number;
+  readonly streamSize: number;
+}
+
+function parseEof(bytes: Uint8Array, offset: number): ParsedEof | null {
+  if (offset < 0 || offset + SIMPLE_EOF_BYTES > bytes.length) {
+    return null;
+  }
+  const magic = readUint64LE(bytes, offset);
+  if (magic !== SIMPLE_FINAL_MAGIC) {
+    return null;
+  }
+  return {
+    flags: readUint32LE(bytes, offset + 8) as number,
+    crc32: readUint32LE(bytes, offset + 12) as number,
+    streamSize: readUint32LE(bytes, offset + 16) as number,
+  };
+}
+
+function stream(
+  data: Uint8Array,
+  eof: ParsedEof,
+  slice: Uint8Array,
+): SimpleStream {
+  const hasCrc = (eof.flags & FLAG_HAS_CRC32) !== 0;
+  const declaredCrc32 = hasCrc ? eof.crc32 : null;
+  return {
+    size: slice.length,
+    data: slice,
+    declaredCrc32,
+    crc32Valid: hasCrc ? zlibCrc32(slice) >>> 0 === eof.crc32 : null,
+  };
+}
+
+/**
+ * Parse a Simple Cache stream-0/stream-1 entry file (`<hash>_0`). The layout is
+ * read from both ends per the recorded contract: the header carries the key and
+ * its hash, while the two trailing SimpleFileEOF records fix each stream's
+ * bounds. Stream 1 is the cached response body (the extractable payload);
+ * stream 0 is the serialized response metadata.
+ */
+export function parseSimpleEntryFile(bytes: Uint8Array): SimpleEntryParse {
+  if (bytes.length < SIMPLE_HEADER_BYTES) {
+    return { ok: false, reason: "truncated" };
+  }
+  if (readUint64LE(bytes, 0) !== SIMPLE_INITIAL_MAGIC) {
+    return { ok: false, reason: "not_simple_magic" };
+  }
+  const version = readUint32LE(bytes, 8) as number;
+  const keyLength = readUint32LE(bytes, 12) as number;
+  const headerKeyHash = readUint32LE(bytes, 16) as number;
+  const keyStart = SIMPLE_HEADER_BYTES;
+  const keyEnd = keyStart + keyLength;
+  if (keyEnd > bytes.length) {
+    return { ok: false, reason: "truncated" };
+  }
+  const key = bytes.subarray(keyStart, keyEnd);
+
+  const eof0Offset = bytes.length - SIMPLE_EOF_BYTES;
+  const eof0 = parseEof(bytes, eof0Offset);
+  if (eof0 === null) {
+    return { ok: false, reason: "bad_stream0_eof" };
+  }
+  const sha256Length =
+    (eof0.flags & FLAG_HAS_KEY_SHA256) !== 0 ? SIMPLE_KEY_SHA256_BYTES : 0;
+  const stream0End = eof0Offset - sha256Length;
+  const stream0Start = stream0End - eof0.streamSize;
+  const eof1Offset = stream0Start - SIMPLE_EOF_BYTES;
+  if (stream0Start < keyEnd || eof1Offset < keyEnd) {
+    return { ok: false, reason: "inconsistent_layout" };
+  }
+  const eof1 = parseEof(bytes, eof1Offset);
+  if (eof1 === null) {
+    return { ok: false, reason: "bad_stream1_eof" };
+  }
+  const stream1Start = keyEnd;
+  const stream1End = eof1Offset;
+  if (stream1End < stream1Start) {
+    return { ok: false, reason: "inconsistent_layout" };
+  }
+
+  const keySha256 =
+    sha256Length === 0
+      ? null
+      : Buffer.from(bytes.subarray(stream0End, eof0Offset)).toString("hex");
+
+  return {
+    ok: true,
+    version,
+    key,
+    keyText: decodeKeyText(key),
+    keyLength,
+    headerKeyHash,
+    keyHashValid: superFastHash(key) === headerKeyHash,
+    keySha256,
+    stream0: stream(bytes, eof0, bytes.subarray(stream0Start, stream0End)),
+    stream1: stream(bytes, eof1, bytes.subarray(stream1Start, stream1End)),
+    entryHashFromKey: entryHashHexFromKey(key),
+  };
+}
+
+function decodeKeyText(key: Uint8Array): string | null {
+  const text = Buffer.from(key).toString("utf8");
+  // A cache key is printable ASCII/UTF-8 in practice; a replacement character
+  // signals a non-text key, which stays available as raw bytes rather than
+  // being coerced into a lossy string.
+  return text.includes("\uFFFD") ? null : text;
+}
+
+export interface SimpleIndexRecord {
+  readonly lastUsedInternalMicros: bigint;
+  readonly lastUsedUtc: string | null;
+  readonly entrySizeBytes: bigint;
+  readonly inMemoryData: number;
+}
+
+export type SimpleIndexParse =
+  | {
+      readonly ok: true;
+      readonly version: number;
+      readonly declaredEntryCount: bigint;
+      readonly cacheSizeBytes: bigint;
+      readonly writeReason: number;
+      readonly cacheLastModifiedUtc: string | null;
+      readonly crc32Valid: boolean;
+      readonly records: ReadonlyMap<string, SimpleIndexRecord>;
+    }
+  | { readonly ok: false; readonly reason: SimpleIndexFailure };
+
+export type SimpleIndexFailure =
+  | "truncated"
+  | "bad_header"
+  | "bad_magic"
+  | "crc_mismatch"
+  | "entry_count_overflow"
+  | "malformed_entries";
+
+// simple_index_file.cc caps the index at a million entries; a larger declared
+// count is treated as corruption rather than trusted into a huge allocation.
+const MAX_INDEX_ENTRIES = 1_000_000;
+
+/**
+ * Parse `index-dir/the-real-index`, the serialized `base::Pickle` that records
+ * each live entry hash with its `EntryMetadata` (last-used time and 256-byte
+ * granular size). The pickle CRC is validated so a corrupt index is reported
+ * rather than mined for bogus timestamps. Presence in this map is the ground
+ * truth for whether an on-disk entry file is live or doomed/orphaned.
+ */
+export function parseSimpleIndex(bytes: Uint8Array): SimpleIndexParse {
+  if (bytes.length < 8) {
+    return { ok: false, reason: "truncated" };
+  }
+  const payloadSize = readUint32LE(bytes, 0) as number;
+  const declaredCrc = readUint32LE(bytes, 4) as number;
+  const payloadStart = 8;
+  if (payloadStart + payloadSize > bytes.length) {
+    return { ok: false, reason: "bad_header" };
+  }
+  const payload = bytes.subarray(payloadStart, payloadStart + payloadSize);
+  if (zlibCrc32(payload) >>> 0 !== declaredCrc) {
+    return { ok: false, reason: "crc_mismatch" };
+  }
+
+  let cursor = 0;
+  const readU32 = (): number | null => {
+    const value = readUint32LE(payload, cursor);
+    cursor += 4;
+    return value;
+  };
+  const readU64 = (): bigint | null => {
+    const value = readUint64LE(payload, cursor);
+    cursor += 8;
+    return value;
+  };
+  const readI64 = (): bigint | null => {
+    const value = readInt64LE(payload, cursor);
+    cursor += 8;
+    return value;
+  };
+
+  const magic = readU64();
+  const version = readU32();
+  const entryCount = readU64();
+  const cacheSize = readU64();
+  const writeReason = readU32();
+  if (
+    magic === null ||
+    version === null ||
+    entryCount === null ||
+    cacheSize === null ||
+    writeReason === null
+  ) {
+    return { ok: false, reason: "bad_header" };
+  }
+  if (magic !== SIMPLE_INDEX_MAGIC) {
+    return { ok: false, reason: "bad_magic" };
+  }
+  if (entryCount > BigInt(MAX_INDEX_ENTRIES)) {
+    return { ok: false, reason: "entry_count_overflow" };
+  }
+
+  const records = new Map<string, SimpleIndexRecord>();
+  for (let index = 0n; index < entryCount; index += 1n) {
+    const hashKey = readU64();
+    const internalLastUsed = readI64();
+    const packed = readU64();
+    if (hashKey === null || internalLastUsed === null || packed === null) {
+      return { ok: false, reason: "malformed_entries" };
+    }
+    const entrySizeBytes = (packed >> 8n) << 8n;
+    const hashHex = BigInt.asUintN(64, hashKey).toString(16).padStart(16, "0");
+    records.set(hashHex, {
+      lastUsedInternalMicros: internalLastUsed,
+      lastUsedUtc:
+        internalLastUsed === 0n ? null : internalMicrosToUtc(internalLastUsed),
+      entrySizeBytes,
+      inMemoryData: Number(packed & 0x3n),
+    });
+  }
+  const cacheModified = readI64();
+  if (cacheModified === null) {
+    return { ok: false, reason: "malformed_entries" };
+  }
+
+  return {
+    ok: true,
+    version,
+    declaredEntryCount: entryCount,
+    cacheSizeBytes: cacheSize,
+    writeReason,
+    cacheLastModifiedUtc:
+      cacheModified === 0n ? null : internalMicrosToUtc(cacheModified),
+    crc32Valid: true,
+    records,
+  };
+}
+
+export interface BlockfileIndexHeader {
+  readonly ok: true;
+  readonly version: number;
+  readonly numEntries: number;
+}
+
+export function parseBlockfileIndexHeader(
+  bytes: Uint8Array,
+): BlockfileIndexHeader | { readonly ok: false } {
+  if (bytes.length < 12 || readUint32LE(bytes, 0) !== BLOCKFILE_INDEX_MAGIC) {
+    return { ok: false };
+  }
+  return {
+    ok: true,
+    version: readUint32LE(bytes, 4) as number,
+    numEntries: readUint32LE(bytes, 8) as number,
+  };
+}
+
+export function internalMicrosToUtcOrNull(
+  internalMicros: bigint,
+): string | null {
+  return internalMicros === 0n ? null : internalMicrosToUtc(internalMicros);
+}

--- a/core/src/cache-format.ts
+++ b/core/src/cache-format.ts
@@ -21,15 +21,12 @@ import { crc32 as zlibCrc32 } from "node:zlib";
 
 export type CacheBackend = "blockfile" | "simple" | "sql" | "unknown";
 
-// Blockfile `index` file magic and version, and the `data_*` block-file magic.
-// disk_format.h: kIndexMagic / kBlockMagic. Read as little-endian uint32.
+// Blockfile `index` file magic. disk_format.h: kIndexMagic. LE uint32.
 export const BLOCKFILE_INDEX_MAGIC = 0xc103cac3;
-export const BLOCKFILE_BLOCK_MAGIC = 0xc104cac3;
 
 // simple_entry_format.h magic numbers, read as little-endian uint64.
 export const SIMPLE_INITIAL_MAGIC = 0xfcfb6d1ba7725c30n;
 export const SIMPLE_FINAL_MAGIC = 0xf4fa6f45970d41d8n;
-export const SIMPLE_SPARSE_MAGIC = 0xeb97bf016553676bn;
 
 // simple_index_file.h kSimpleIndexMagicNumber, read as little-endian uint64.
 export const SIMPLE_INDEX_MAGIC = 0x656e74657220796fn;
@@ -529,10 +526,4 @@ export function parseBlockfileIndexHeader(
     version: readUint32LE(bytes, 4) as number,
     numEntries: readUint32LE(bytes, 8) as number,
   };
-}
-
-export function internalMicrosToUtcOrNull(
-  internalMicros: bigint,
-): string | null {
-  return internalMicros === 0n ? null : internalMicrosToUtc(internalMicros);
 }

--- a/core/src/cache-format.ts
+++ b/core/src/cache-format.ts
@@ -1,6 +1,11 @@
 import { createHash } from "node:crypto";
 import { crc32 as zlibCrc32 } from "node:zlib";
 
+import {
+  WINDOWS_EPOCH_OFFSET_MICROS,
+  utcFromUnixMicros,
+} from "./forensic-time.js";
+
 /**
  * Pure, filesystem-free readers for the three Chromium HTTP-cache backends.
  *
@@ -38,10 +43,6 @@ const FLAG_HAS_KEY_SHA256 = 1 << 1;
 const SIMPLE_HEADER_BYTES = 24;
 const SIMPLE_EOF_BYTES = 24;
 const SIMPLE_KEY_SHA256_BYTES = 32;
-
-// Microseconds between the 1601-01-01 Windows epoch (base::Time internal value
-// origin) and the 1970 Unix epoch. base::Time::ToInternalValue() emits this.
-const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
 
 const SQLITE_MAGIC = Buffer.from("SQLite format 3\u0000", "latin1");
 
@@ -114,25 +115,15 @@ function startsWith(bytes: Uint8Array, prefix: Uint8Array): boolean {
 export function detectCacheBackend(
   entries: readonly CacheDirEntry[],
 ): BackendDetection {
-  const byPath = new Map<string, CacheDirEntry>();
-  for (const entry of entries) {
-    byPath.set(entry.relativePath, entry);
-  }
-
-  const indexFile = byPath.get("index");
-  if (indexFile !== undefined) {
-    const magic = readUint32LE(indexFile.head, 0);
-    if (magic === BLOCKFILE_INDEX_MAGIC) {
-      return { backend: "blockfile", evidence: "index_magic" };
-    }
-  }
   for (const entry of entries) {
     if (readUint32LE(entry.head, 0) === BLOCKFILE_INDEX_MAGIC) {
       return { backend: "blockfile", evidence: "index_magic" };
     }
   }
 
-  if (byPath.has("index-dir/the-real-index")) {
+  if (
+    entries.some((entry) => entry.relativePath === "index-dir/the-real-index")
+  ) {
     return { backend: "simple", evidence: "the_real_index" };
   }
   for (const entry of entries) {
@@ -220,24 +211,11 @@ export function entryHashHexFromKey(key: Uint8Array): string {
   return value.toString(16).padStart(16, "0");
 }
 
+// A base::Time internal value is microseconds since the 1601 Windows epoch;
+// shift it to the Unix epoch and render it with the canonical History-family
+// converter so cache timestamps can never drift from the other artifacts.
 function internalMicrosToUtc(internalMicros: bigint): string | null {
-  const unixMicros = internalMicros - WINDOWS_EPOCH_OFFSET_MICROS;
-  const seconds =
-    unixMicros >= 0n
-      ? unixMicros / 1_000_000n
-      : (unixMicros - 999_999n) / 1_000_000n;
-  const micros = unixMicros - seconds * 1_000_000n;
-  const milliseconds = Number(seconds * 1000n + micros / 1000n);
-  if (!Number.isSafeInteger(milliseconds)) {
-    return null;
-  }
-  const date = new Date(milliseconds);
-  if (Number.isNaN(date.getTime())) {
-    return null;
-  }
-  return `${date.toISOString().slice(0, -5)}.${micros
-    .toString()
-    .padStart(6, "0")}Z`;
+  return utcFromUnixMicros(internalMicros - WINDOWS_EPOCH_OFFSET_MICROS);
 }
 
 export interface SimpleStream {

--- a/core/src/cache-query.ts
+++ b/core/src/cache-query.ts
@@ -84,11 +84,90 @@ const FINDING_SORT_SQL: Readonly<Record<CacheSort, SortDefinition>> = {
   profile: { expression: "c.profile_path", kind: "text" },
 };
 
-const CANDIDATE_SORT_SQL: Readonly<Record<string, SortDefinition>> = {
+const CANDIDATE_SORT_SQL: Readonly<
+  Record<(typeof CANDIDATE_SORTS)[number], SortDefinition>
+> = {
   key: { expression: "COALESCE(c.sort_key, '')", kind: "text" },
   "last-used": { expression: "COALESCE(c.sort_last_used, '')", kind: "text" },
   profile: { expression: "c.profile_path", kind: "text" },
 };
+
+/**
+ * Everything that differs between a Finding query and a Candidate query, keyed
+ * by record type and resolved once. Findings and Candidates share the same
+ * cache tables' shape but diverge in table, id column, kind filter, sortable
+ * columns, and how a row is rehydrated — collecting that here keeps the query
+ * body a single code path instead of a cluster of parallel ternaries.
+ */
+interface RecordTypeConfig {
+  readonly table: string;
+  readonly idColumn: string;
+  readonly kindFilter: {
+    readonly column: string;
+    readonly value: string;
+  } | null;
+  readonly sorts: readonly string[];
+  readonly defaultSort: string;
+  readonly sortSql: Readonly<Record<string, SortDefinition>>;
+  readonly selectExtra: string;
+  readonly parse: (
+    row: QueryRow,
+    provenance: Provenance,
+    fields: ForensicFields,
+  ) => Finding | Candidate;
+}
+
+const RECORD_TYPE_CONFIG: Readonly<Record<CacheRecordType, RecordTypeConfig>> =
+  {
+    finding: {
+      table: "cache_findings",
+      idColumn: "finding_id",
+      kindFilter: { column: "finding_kind", value: CACHE_FINDING_KIND },
+      sorts: FINDING_SORTS,
+      defaultSort: "key",
+      sortSql: FINDING_SORT_SQL,
+      selectExtra:
+        "c.finding_kind AS finding_kind, c.commit_state AS commit_state",
+      parse: (row, provenance, fields) => {
+        if (
+          row.commit_state !== "committed" &&
+          row.commit_state !== "wal_resident" &&
+          row.commit_state !== "journal_resident"
+        ) {
+          throw new ForensixError(
+            "CASE_INVALID",
+            "Case contains an invalid Commit State.",
+            { row_id: row.row_id.toString() },
+          );
+        }
+        return createFinding({
+          findingKind: row.finding_kind as string,
+          profile: row.profile_path,
+          commitState: row.commit_state,
+          provenance,
+          fields,
+        });
+      },
+    },
+    candidate: {
+      table: "cache_candidates",
+      idColumn: "candidate_id",
+      kindFilter: null,
+      sorts: CANDIDATE_SORTS,
+      defaultSort: "last-used",
+      sortSql: CANDIDATE_SORT_SQL,
+      selectExtra:
+        "c.candidate_kind AS candidate_kind, c.rank AS rank, c.supporting_count AS supporting_count",
+      parse: (row, provenance, fields) =>
+        createCandidate({
+          candidateKind: row.candidate_kind as string,
+          rank: Number(row.rank),
+          count: Number(row.supporting_count),
+          provenance,
+          fields,
+        }),
+    },
+  };
 
 const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
 const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
@@ -208,7 +287,7 @@ function activeIdentity(database: DatabaseSync): {
 
 function parseRecord(
   row: QueryRow,
-  recordType: CacheRecordType,
+  config: RecordTypeConfig,
 ): Finding | Candidate {
   let provenance: Provenance;
   let fields: ForensicFields;
@@ -223,33 +302,7 @@ function parseRecord(
       { cause: error },
     );
   }
-  if (recordType === "candidate") {
-    return createCandidate({
-      candidateKind: row.candidate_kind as string,
-      rank: Number(row.rank),
-      count: Number(row.supporting_count),
-      provenance,
-      fields,
-    });
-  }
-  if (
-    row.commit_state !== "committed" &&
-    row.commit_state !== "wal_resident" &&
-    row.commit_state !== "journal_resident"
-  ) {
-    throw new ForensixError(
-      "CASE_INVALID",
-      "Case contains an invalid Commit State.",
-      { row_id: row.row_id.toString() },
-    );
-  }
-  return createFinding({
-    findingKind: row.finding_kind as string,
-    profile: row.profile_path,
-    commitState: row.commit_state,
-    provenance,
-    fields,
-  });
+  return config.parse(row, provenance, fields);
 }
 
 export function queryCache(input: CacheQuery): CachePage {
@@ -265,17 +318,14 @@ export function queryCache(input: CacheQuery): CachePage {
     CACHE_DIRECTIONS,
     "--direction",
   );
-  const sortValues = recordType === "finding" ? FINDING_SORTS : CANDIDATE_SORTS;
+  const config = RECORD_TYPE_CONFIG[recordType];
   const sort = enumValue(
     input.sort,
-    recordType === "finding" ? "key" : "last-used",
-    sortValues,
+    config.defaultSort,
+    config.sorts,
     "--sort",
   );
-  const sortDefinition =
-    recordType === "finding"
-      ? FINDING_SORT_SQL[sort]
-      : (CANDIDATE_SORT_SQL[sort] as SortDefinition);
+  const sortDefinition = config.sortSql[sort] as SortDefinition;
   const sortExpression = sortDefinition.expression;
   const limit = normalizeLimit(input.limit);
   const profiles = [...new Set(input.profiles ?? [])].sort();
@@ -289,12 +339,7 @@ export function queryCache(input: CacheQuery): CachePage {
   const search = input.search?.toLocaleLowerCase("en-US") ?? null;
   const backend = input.backend ?? null;
 
-  const table =
-    recordType === "finding" ? "cache_findings" : "cache_candidates";
-  const idColumn = recordType === "finding" ? "finding_id" : "candidate_id";
-  const kindColumn =
-    recordType === "finding" ? "finding_kind" : "candidate_kind";
-  const kindValue = recordType === "finding" ? CACHE_FINDING_KIND : null;
+  const { table, idColumn, kindFilter, selectExtra } = config;
 
   const database = openCase(input.caseDirectory);
   try {
@@ -320,9 +365,9 @@ export function queryCache(input: CacheQuery): CachePage {
 
     const conditions = ["r.active = 1", "c.record_type = ?"];
     const parameters: (string | bigint)[] = [recordType];
-    if (kindValue !== null) {
-      conditions.push(`c.${kindColumn} = ?`);
-      parameters.push(kindValue);
+    if (kindFilter !== null) {
+      conditions.push(`c.${kindFilter.column} = ?`);
+      parameters.push(kindFilter.value);
     }
     if (profiles.length > 0) {
       conditions.push(
@@ -370,10 +415,6 @@ export function queryCache(input: CacheQuery): CachePage {
 
     parameters.push(BigInt(limit + 1));
     const sqlDirection = direction === "asc" ? "ASC" : "DESC";
-    const selectExtra =
-      recordType === "finding"
-        ? "c.finding_kind AS finding_kind, c.commit_state AS commit_state"
-        : "c.candidate_kind AS candidate_kind, c.rank AS rank, c.supporting_count AS supporting_count";
     const rows = database
       .prepare(
         `SELECT c.${idColumn} AS row_id, c.profile_path,
@@ -396,7 +437,7 @@ export function queryCache(input: CacheQuery): CachePage {
       status: "ok",
       command: "cache",
       recordType,
-      items: pageRows.map((row) => parseRecord(row, recordType)),
+      items: pageRows.map((row) => parseRecord(row, config)),
       nextCursor:
         hasNext && last !== undefined
           ? encodeCursor({

--- a/core/src/cache-query.ts
+++ b/core/src/cache-query.ts
@@ -1,0 +1,414 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createCandidate,
+  createFinding,
+  type Candidate,
+  type Finding,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+
+export type CacheDirection = "asc" | "desc";
+export type CacheRecordType = "finding" | "candidate";
+export type CacheSort = "key" | "last-used" | "size" | "entry-hash" | "profile";
+
+export interface CacheQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly recordType?: CacheRecordType;
+  readonly backend?: string;
+  readonly sort?: CacheSort;
+  readonly direction?: CacheDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface CachePage {
+  readonly status: "ok";
+  readonly command: "cache";
+  readonly recordType: CacheRecordType;
+  readonly items: readonly (Finding | Candidate)[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly rowId: string;
+}
+
+interface QueryRow {
+  readonly row_id: bigint;
+  readonly finding_kind?: string;
+  readonly candidate_kind?: string;
+  readonly profile_path: string;
+  readonly commit_state?: string;
+  readonly rank?: bigint;
+  readonly supporting_count?: bigint;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const CACHE_DIRECTIONS = ["asc", "desc"] as const;
+const CACHE_RECORD_TYPES = ["finding", "candidate"] as const;
+const FINDING_SORTS = [
+  "key",
+  "last-used",
+  "size",
+  "entry-hash",
+  "profile",
+] as const;
+const CANDIDATE_SORTS = ["key", "last-used", "profile"] as const;
+const CACHE_FINDING_KIND = "cache_entry";
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+const FINDING_SORT_SQL: Readonly<Record<CacheSort, SortDefinition>> = {
+  key: { expression: "COALESCE(c.sort_key, '')", kind: "text" },
+  "last-used": { expression: "COALESCE(c.sort_last_used, '')", kind: "text" },
+  size: { expression: "COALESCE(c.sort_size, -1)", kind: "integer" },
+  "entry-hash": { expression: "c.sort_entry_hash", kind: "text" },
+  profile: { expression: "c.profile_path", kind: "text" },
+};
+
+const CANDIDATE_SORT_SQL: Readonly<Record<string, SortDefinition>> = {
+  key: { expression: "COALESCE(c.sort_key, '')", kind: "text" },
+  "last-used": { expression: "COALESCE(c.sort_last_used, '')", kind: "text" },
+  profile: { expression: "c.profile_path", kind: "text" },
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function queryFingerprint(input: Record<string, unknown>): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Cache cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("rowId" in parsed) ||
+    typeof parsed.rowId !== "string" ||
+    !/^[0-9]+$/.test(parsed.rowId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Cache cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Cache --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Cache ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function cacheSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'cache_findings'",
+      )
+      .get() !== undefined
+  );
+}
+
+function activeIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM cache_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function parseRecord(
+  row: QueryRow,
+  recordType: CacheRecordType,
+): Finding | Candidate {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Cache record JSON.",
+      { row_id: row.row_id.toString() },
+      { cause: error },
+    );
+  }
+  if (recordType === "candidate") {
+    return createCandidate({
+      candidateKind: row.candidate_kind as string,
+      rank: Number(row.rank),
+      count: Number(row.supporting_count),
+      provenance,
+      fields,
+    });
+  }
+  if (
+    row.commit_state !== "committed" &&
+    row.commit_state !== "wal_resident" &&
+    row.commit_state !== "journal_resident"
+  ) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains an invalid Commit State.",
+      { row_id: row.row_id.toString() },
+    );
+  }
+  return createFinding({
+    findingKind: row.finding_kind as string,
+    profile: row.profile_path,
+    commitState: row.commit_state,
+    provenance,
+    fields,
+  });
+}
+
+export function queryCache(input: CacheQuery): CachePage {
+  const recordType = enumValue(
+    input.recordType,
+    "finding",
+    CACHE_RECORD_TYPES,
+    "--record-type",
+  );
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    CACHE_DIRECTIONS,
+    "--direction",
+  );
+  const sortValues = recordType === "finding" ? FINDING_SORTS : CANDIDATE_SORTS;
+  const sort = enumValue(
+    input.sort,
+    recordType === "finding" ? "key" : "last-used",
+    sortValues,
+    "--sort",
+  );
+  const sortDefinition =
+    recordType === "finding"
+      ? FINDING_SORT_SQL[sort]
+      : (CANDIDATE_SORT_SQL[sort] as SortDefinition);
+  const sortExpression = sortDefinition.expression;
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Cache queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+  const backend = input.backend ?? null;
+
+  const table =
+    recordType === "finding" ? "cache_findings" : "cache_candidates";
+  const idColumn = recordType === "finding" ? "finding_id" : "candidate_id";
+  const kindColumn =
+    recordType === "finding" ? "finding_kind" : "candidate_kind";
+  const kindValue = recordType === "finding" ? CACHE_FINDING_KIND : null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!cacheSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no Cache analysis. Run analyse first.",
+      );
+    }
+    const identity = activeIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      recordType,
+      profiles,
+      search,
+      backend,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = ["r.active = 1", "c.record_type = ?"];
+    const parameters: (string | bigint)[] = [recordType];
+    if (kindValue !== null) {
+      conditions.push(`c.${kindColumn} = ?`);
+      parameters.push(kindValue);
+    }
+    if (profiles.length > 0) {
+      conditions.push(
+        `c.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (backend !== null) {
+      conditions.push("c.backend = ?");
+      parameters.push(backend);
+    }
+    if (search !== null) {
+      conditions.push("instr(c.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND c.${idColumn} ${operator} ?))`,
+      );
+      const rowId = BigInt(cursor.rowId);
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        rowId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Cache cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, rowId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const selectExtra =
+      recordType === "finding"
+        ? "c.finding_kind AS finding_kind, c.commit_state AS commit_state"
+        : "c.candidate_kind AS candidate_kind, c.rank AS rank, c.supporting_count AS supporting_count";
+    const rows = database
+      .prepare(
+        `SELECT c.${idColumn} AS row_id, c.profile_path,
+                ${selectExtra},
+                c.provenance_json, c.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM ${table} c
+           JOIN cache_artifact_results r
+             ON r.artifact_result_id = c.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   c.${idColumn} ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "cache",
+      recordType,
+      items: pageRows.map((row) => parseRecord(row, recordType)),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              rowId: last.row_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/cache-query.ts
+++ b/core/src/cache-query.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 import { CASE_FILENAME } from "./case.js";
 import { ForensixError } from "./errors.js";
+import { SQLITE_MAX_INTEGER, SQLITE_MIN_INTEGER } from "./forensic-time.js";
 import {
   createCandidate,
   createFinding,
@@ -168,9 +169,6 @@ const RECORD_TYPE_CONFIG: Readonly<Record<CacheRecordType, RecordTypeConfig>> =
         }),
     },
   };
-
-const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
-const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
 
 function queryFingerprint(input: Record<string, unknown>): string {
   return createHash("sha256").update(JSON.stringify(input)).digest("hex");

--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -39,7 +39,6 @@ import type { ManifestEntry } from "./manifest.js";
 export const CACHE_PAYLOAD_DIRECTORY = "cache-payloads";
 
 // The Simple Cache stream-0/stream-1 entry file name for a hash.
-const ENTRY_FILE_SUFFIX = "_0";
 const SIMPLE_ENTRY_NAME = /^([0-9a-f]{16})_([01s])$/;
 const REAL_INDEX_NAME = "index-dir/the-real-index";
 
@@ -642,9 +641,15 @@ async function analyseProfileCache(options: {
 
   await writePayloads(options.caseDirectory, built.payloads);
 
+  // Cite a real stream-0 entry file as the artifact's representative Manifest
+  // ordinal, matched with the same precise regex used to group entries.
   const stream0Ordinal =
-    cache.files.find((file) => file.relativePath.endsWith(ENTRY_FILE_SUFFIX))
-      ?.ordinal ?? null;
+    cache.files.find((file) => {
+      const match = SIMPLE_ENTRY_NAME.exec(
+        file.relativePath.split("/").at(-1) ?? "",
+      );
+      return match !== null && match[2] === "0";
+    })?.ordinal ?? null;
 
   return {
     sourceId: options.source.sourceId,

--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -1,0 +1,688 @@
+import { createHash } from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import type {
+  CacheArtifactWrite,
+  PersistedCacheCandidate,
+  PersistedCacheFinding,
+} from "./case-findings.js";
+import type { CaseSourceRecord } from "./case.js";
+import { ForensixError, WorkingCopyIntegrityRefusal } from "./errors.js";
+import {
+  detectCacheBackend,
+  parseBlockfileIndexHeader,
+  parseSimpleEntryFile,
+  parseSimpleIndex,
+  type CacheDirEntry,
+  type SimpleIndexRecord,
+} from "./cache-format.js";
+import {
+  absentField,
+  createCandidate,
+  createFinding,
+  unavailableField,
+  valueField,
+  type FieldState,
+  type Provenance,
+  type SourceRowProvenance,
+} from "./forensic-model.js";
+import type { ForensicTimestamp } from "./history.js";
+import type { ManifestEntry } from "./manifest.js";
+
+/**
+ * The Case-relative directory that holds cached response bodies as separately
+ * hashed files. Payloads are content-addressed by SHA-256, so identical bytes
+ * are stored once and every record references the file by digest instead of
+ * inlining base64 into a Case or Extract row.
+ */
+export const CACHE_PAYLOAD_DIRECTORY = "cache-payloads";
+
+// The Simple Cache stream-0/stream-1 entry file name for a hash.
+const ENTRY_FILE_SUFFIX = "_0";
+const SIMPLE_ENTRY_NAME = /^([0-9a-f]{16})_([01s])$/;
+const REAL_INDEX_NAME = "index-dir/the-real-index";
+
+interface CacheEntryFile {
+  readonly manifestPath: string;
+  readonly ordinal: number;
+  readonly relativePath: string;
+  readonly copied: boolean;
+  readonly size: number | null;
+}
+
+interface PayloadFile {
+  readonly sha256: string;
+  readonly bytes: number;
+  readonly data: Uint8Array;
+}
+
+interface ProfileCache {
+  readonly cacheDataPath: string;
+  readonly files: readonly CacheEntryFile[];
+  readonly presentInManifest: boolean;
+  readonly anyCopied: boolean;
+}
+
+type ProvenanceBase = Omit<SourceRowProvenance, "table" | "rowId">;
+
+function collectProfileCache(
+  source: CaseSourceRecord,
+  profile: string,
+): ProfileCache {
+  const cacheDataPath =
+    profile === "." ? "Cache/Cache_Data" : `${profile}/Cache/Cache_Data`;
+  const prefix = `${cacheDataPath}/`;
+  const files: CacheEntryFile[] = [];
+  let presentInManifest = false;
+  let anyCopied = false;
+  source.entries.forEach((entry: ManifestEntry, ordinal: number) => {
+    if (!entry.path.startsWith(prefix) || entry.node_type === "dir") {
+      return;
+    }
+    presentInManifest = true;
+    if (entry.copied) {
+      anyCopied = true;
+    }
+    files.push({
+      manifestPath: entry.path,
+      ordinal,
+      relativePath: entry.path.slice(prefix.length),
+      copied: entry.copied,
+      size: entry.size,
+    });
+  });
+  return { cacheDataPath, files, presentInManifest, anyCopied };
+}
+
+async function readHead(
+  workingCopyPath: string,
+  file: CacheEntryFile,
+  length: number,
+): Promise<Uint8Array> {
+  const bytes = await readFile(
+    join(workingCopyPath, ...file.manifestPath.split("/")),
+  );
+  return bytes.subarray(0, length);
+}
+
+async function readWhole(
+  workingCopyPath: string,
+  file: CacheEntryFile,
+): Promise<Uint8Array> {
+  return readFile(join(workingCopyPath, ...file.manifestPath.split("/")));
+}
+
+function timestampField(
+  record: SimpleIndexRecord | undefined,
+  declaredTimezone: string,
+): FieldState<ForensicTimestamp> {
+  if (record === undefined || record.lastUsedInternalMicros === 0n) {
+    return absentField();
+  }
+  if (record.lastUsedUtc === null) {
+    return unavailableField("timestamp_out_of_range");
+  }
+  return valueField(
+    {
+      raw: record.lastUsedInternalMicros.toString(),
+      epochFamily: "1601-us",
+      utc: record.lastUsedUtc,
+      declaredTimezone,
+      resolution: "simple_index_last_used_time",
+    },
+    { synthetic: false },
+  );
+}
+
+function payloadFrom(data: Uint8Array): PayloadFile {
+  return {
+    sha256: createHash("sha256").update(data).digest("hex"),
+    bytes: data.byteLength,
+    data,
+  };
+}
+
+function payloadFields(
+  payload: PayloadFile | null,
+): Record<string, FieldState<string>> {
+  if (payload === null) {
+    return {
+      payloadSha256: absentField(),
+      payloadBytes: absentField(),
+      payloadPath: absentField(),
+    };
+  }
+  return {
+    payloadSha256: valueField(payload.sha256),
+    payloadBytes: valueField(payload.bytes.toString()),
+    payloadPath: valueField(`${CACHE_PAYLOAD_DIRECTORY}/${payload.sha256}`),
+  };
+}
+
+function booleanField(value: boolean): FieldState<string> {
+  return valueField(value ? "true" : "false");
+}
+
+async function writePayloads(
+  caseDirectory: string,
+  payloads: ReadonlyMap<string, PayloadFile>,
+): Promise<void> {
+  if (payloads.size === 0) {
+    return;
+  }
+  const directory = join(caseDirectory, CACHE_PAYLOAD_DIRECTORY);
+  await mkdir(directory, { recursive: true, mode: 0o700 });
+  for (const payload of payloads.values()) {
+    // Content-addressed by SHA-256, so a re-analysis rewrites byte-for-byte
+    // identical content and stays idempotent.
+    await writeFile(join(directory, payload.sha256), payload.data, {
+      mode: 0o600,
+    });
+  }
+}
+
+function unavailableArtifact(
+  source: CaseSourceRecord,
+  profile: string,
+  cacheDataPath: string,
+  status: "absent" | "unavailable",
+  reason: string,
+): CacheArtifactWrite {
+  return {
+    sourceId: source.sourceId,
+    profile,
+    status,
+    manifestEntryOrdinal: null,
+    databasePath: cacheDataPath,
+    backend: null,
+    reason,
+    findings: [],
+    candidates: [],
+    entryFindingCount: 0,
+    candidateCount: 0,
+    payloadFileCount: 0,
+  };
+}
+
+interface BuiltRecords {
+  readonly findings: PersistedCacheFinding[];
+  readonly candidates: PersistedCacheCandidate[];
+  readonly payloads: Map<string, PayloadFile>;
+}
+
+async function buildSimpleRecords(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly declaredTimezone: string;
+  readonly cache: ProfileCache;
+}): Promise<BuiltRecords> {
+  const { cache, profile, declaredTimezone } = options;
+  const base = (file: CacheEntryFile): ProvenanceBase => ({
+    manifestEntryId: `${options.source.sourceId}:${file.ordinal}`,
+    sourceId: options.source.sourceId,
+    manifestEntryOrdinal: file.ordinal,
+    manifestPath: file.manifestPath,
+    database: cache.cacheDataPath,
+  });
+
+  // Parse the real index first: presence of an entry hash here is the ground
+  // truth that separates a live entry (Finding) from a doomed/orphaned entry
+  // file or an evicted index reference (Candidates).
+  const indexFile = cache.files.find(
+    (file) => file.relativePath === REAL_INDEX_NAME,
+  );
+  let indexRecords: ReadonlyMap<string, SimpleIndexRecord> = new Map();
+  let indexBase: ProvenanceBase | null = null;
+  if (indexFile !== undefined && indexFile.copied) {
+    const parsed = parseSimpleIndex(
+      await readWhole(options.workingCopyPath, indexFile),
+    );
+    if (parsed.ok) {
+      indexRecords = parsed.records;
+      indexBase = base(indexFile);
+    }
+  }
+
+  // Group dense entry files by their 16-hex hash so one Finding covers an
+  // entry's `_0`/`_1`/`_s` files and the supporting count is exact.
+  const byHash = new Map<
+    string,
+    {
+      readonly stream0: CacheEntryFile | null;
+      readonly files: CacheEntryFile[];
+    }
+  >();
+  for (const file of cache.files) {
+    const name = file.relativePath.split("/").at(-1) ?? "";
+    const match = SIMPLE_ENTRY_NAME.exec(name);
+    if (match === null || !file.copied) {
+      continue;
+    }
+    const hash = match[1] as string;
+    const existing = byHash.get(hash) ?? { stream0: null, files: [] };
+    const files = [...existing.files, file];
+    byHash.set(hash, {
+      stream0: match[2] === "0" ? file : existing.stream0,
+      files,
+    });
+  }
+
+  const findings: PersistedCacheFinding[] = [];
+  const candidates: PersistedCacheCandidate[] = [];
+  const payloads = new Map<string, PayloadFile>();
+  const seenHashes = new Set<string>();
+
+  const sortedHashes = [...byHash.keys()].sort();
+  let candidateRank = 0;
+  for (const hash of sortedHashes) {
+    seenHashes.add(hash);
+    const group = byHash.get(hash);
+    if (group === undefined || group.stream0 === null) {
+      // Stream files exist for the hash but no `_0` record: nothing citable to
+      // parse, so it is a doomed/partial Candidate, never a Finding.
+      candidateRank += 1;
+      const primary = (group?.files[0] ?? null) as CacheEntryFile | null;
+      if (primary !== null) {
+        candidates.push(
+          buildUnreadableCandidate(base(primary), hash, "missing_stream0", {
+            profile,
+            count: group?.files.length ?? 1,
+            rank: candidateRank,
+          }),
+        );
+      }
+      continue;
+    }
+    const parsed = parseSimpleEntryFile(
+      await readWhole(options.workingCopyPath, group.stream0),
+    );
+    const primaryBase = base(group.stream0);
+    if (!parsed.ok) {
+      candidateRank += 1;
+      candidates.push(
+        buildUnreadableCandidate(primaryBase, hash, parsed.reason, {
+          profile,
+          count: group.files.length,
+          rank: candidateRank,
+        }),
+      );
+      continue;
+    }
+
+    const payload =
+      parsed.stream1.size > 0 ? payloadFrom(parsed.stream1.data) : null;
+    if (payload !== null) {
+      payloads.set(payload.sha256, payload);
+    }
+    const indexed = indexRecords.get(hash);
+    const record = indexed;
+    const fields = {
+      backend: valueField("simple"),
+      entryHash: valueField(hash),
+      key:
+        parsed.keyText === null
+          ? unavailableField("unsupported_value")
+          : valueField(parsed.keyText),
+      keyLength: valueField(parsed.keyLength.toString()),
+      keyHashValid: booleanField(parsed.keyHashValid),
+      entryHashMatchesFilename: booleanField(parsed.entryHashFromKey === hash),
+      keySha256:
+        parsed.keySha256 === null
+          ? absentField()
+          : valueField(parsed.keySha256),
+      version: valueField(parsed.version.toString()),
+      lastUsed: timestampField(record, declaredTimezone),
+      entrySizeBytes:
+        record === undefined
+          ? absentField()
+          : valueField(record.entrySizeBytes.toString()),
+      stream0Size: valueField(parsed.stream0.size.toString()),
+      stream1Size: valueField(parsed.stream1.size.toString()),
+      stream1Crc32Valid:
+        parsed.stream1.crc32Valid === null
+          ? absentField()
+          : booleanField(parsed.stream1.crc32Valid),
+      ...payloadFields(payload),
+    };
+
+    if (indexed === undefined) {
+      // On disk, parseable, but absent from the index: allocated-deleted or
+      // doomed. Its key and payload are preserved as evidence, but the record
+      // stays a Candidate and is never promoted to a Finding by heuristic.
+      candidateRank += 1;
+      candidates.push({
+        candidate: createCandidate({
+          candidateKind: "doomed_entry",
+          rank: candidateRank,
+          count: group.files.length,
+          provenance: withSupporting(
+            { ...primaryBase, table: "simple_entry", rowId: hash },
+            group.files
+              .filter((file) => file !== group.stream0)
+              .map((file) => ({
+                ...base(file),
+                table: "simple_entry_stream",
+                rowId: hash,
+              })),
+          ),
+          fields: {
+            ...fields,
+            state: valueField("allocated_deleted_or_doomed"),
+          },
+        }),
+        profile,
+        commitState: "committed",
+        backend: "simple",
+        candidateKind: "doomed_entry",
+        searchText: searchTextOf(profile, hash, parsed.keyText),
+        sortKey: parsed.keyText,
+        sortLastUsed: record?.lastUsedUtc ?? null,
+      });
+      continue;
+    }
+
+    const supporting: SourceRowProvenance[] = [];
+    if (indexBase !== null) {
+      supporting.push({
+        ...indexBase,
+        table: "the_real_index",
+        rowId: hash,
+      });
+    }
+    for (const file of group.files) {
+      if (file !== group.stream0) {
+        supporting.push({
+          ...base(file),
+          table: "simple_entry_stream",
+          rowId: hash,
+        });
+      }
+    }
+    const finding = createFinding({
+      findingKind: "cache_entry",
+      profile,
+      commitState: "committed",
+      provenance: withSupporting(
+        { ...primaryBase, table: "simple_entry", rowId: hash },
+        supporting,
+      ),
+      fields,
+    });
+    findings.push({
+      finding,
+      searchText: searchTextOf(profile, hash, parsed.keyText),
+      backend: "simple",
+      sortKey: parsed.keyText,
+      sortLastUsed: record?.lastUsedUtc ?? null,
+      sortSizeBytes: record?.entrySizeBytes ?? null,
+      sortEntryHash: hash,
+    });
+  }
+
+  // An index record whose entry files are not recoverable on disk is an
+  // evicted/absent-payload reference: preserved as a ranked Candidate, never a
+  // Finding, because the payload it names cannot be produced.
+  if (indexBase !== null) {
+    for (const hash of [...indexRecords.keys()].sort()) {
+      if (seenHashes.has(hash)) {
+        continue;
+      }
+      const record = indexRecords.get(hash) as SimpleIndexRecord;
+      candidateRank += 1;
+      candidates.push({
+        candidate: createCandidate({
+          candidateKind: "evicted_reference",
+          rank: candidateRank,
+          count: 1,
+          provenance: { ...indexBase, table: "the_real_index", rowId: hash },
+          fields: {
+            backend: valueField("simple"),
+            entryHash: valueField(hash),
+            state: valueField("evicted_or_absent_payload"),
+            lastUsed: timestampField(record, declaredTimezone),
+            entrySizeBytes: valueField(record.entrySizeBytes.toString()),
+            payloadSha256: absentField(),
+            payloadPath: absentField(),
+          },
+        }),
+        profile,
+        commitState: "committed",
+        backend: "simple",
+        candidateKind: "evicted_reference",
+        searchText: searchTextOf(profile, hash, null),
+        sortKey: null,
+        sortLastUsed: record.lastUsedUtc,
+      });
+    }
+  }
+
+  return { findings, candidates, payloads };
+}
+
+function buildUnreadableCandidate(
+  primaryBase: ProvenanceBase,
+  hash: string,
+  reason: string,
+  options: {
+    readonly profile: string;
+    readonly count: number;
+    readonly rank: number;
+  },
+): PersistedCacheCandidate {
+  return {
+    candidate: createCandidate({
+      candidateKind: "unreadable_entry",
+      rank: options.rank,
+      count: options.count,
+      provenance: { ...primaryBase, table: "simple_entry", rowId: hash },
+      fields: {
+        backend: valueField("simple"),
+        entryHash: valueField(hash),
+        state: valueField("unreadable_entry_file"),
+        reason: valueField(reason),
+        payloadSha256: absentField(),
+        payloadPath: absentField(),
+      },
+    }),
+    profile: options.profile,
+    commitState: "committed",
+    backend: "simple",
+    candidateKind: "unreadable_entry",
+    searchText: searchTextOf(options.profile, hash, null),
+    sortKey: null,
+    sortLastUsed: null,
+  };
+}
+
+function withSupporting(
+  primary: SourceRowProvenance,
+  supporting: readonly SourceRowProvenance[],
+): Provenance {
+  return supporting.length === 0
+    ? primary
+    : { ...primary, supportingRows: supporting };
+}
+
+function searchTextOf(
+  profile: string,
+  hash: string,
+  key: string | null,
+): string {
+  return [profile, hash, key ?? ""].join("\n").toLocaleLowerCase("en-US");
+}
+
+async function analyseProfileCache(options: {
+  readonly source: CaseSourceRecord;
+  readonly profile: string;
+  readonly workingCopyPath: string;
+  readonly caseDirectory: string;
+  readonly declaredTimezone: string;
+}): Promise<CacheArtifactWrite> {
+  const cache = collectProfileCache(options.source, options.profile);
+  if (!cache.presentInManifest) {
+    return unavailableArtifact(
+      options.source,
+      options.profile,
+      cache.cacheDataPath,
+      "absent",
+      "cache_absent",
+    );
+  }
+  if (!cache.anyCopied) {
+    // The cache exists in the Source but tier-2 bulk data was not collected, so
+    // there is nothing to extract. This is an explicit unavailable reason, not
+    // an empty result masquerading as "no cache".
+    return unavailableArtifact(
+      options.source,
+      options.profile,
+      cache.cacheDataPath,
+      "unavailable",
+      "cache_not_in_working_copy",
+    );
+  }
+
+  let detectionEntries: CacheDirEntry[];
+  try {
+    detectionEntries = await Promise.all(
+      cache.files
+        .filter((file) => file.copied)
+        .map(async (file) => ({
+          relativePath: file.relativePath,
+          head: await readHead(options.workingCopyPath, file, 16),
+        })),
+    );
+  } catch (error) {
+    return unavailableArtifact(
+      options.source,
+      options.profile,
+      cache.cacheDataPath,
+      "unavailable",
+      `cache_read_failed:${String(error)}`,
+    );
+  }
+
+  const detection = detectCacheBackend(detectionEntries);
+  if (detection.backend === "blockfile") {
+    const indexFile = cache.files.find((file) => file.relativePath === "index");
+    let numEntries: number | null = null;
+    if (indexFile !== undefined) {
+      const header = parseBlockfileIndexHeader(
+        await readHead(options.workingCopyPath, indexFile, 12),
+      );
+      numEntries = header.ok ? header.numEntries : null;
+    }
+    return {
+      ...unavailableArtifact(
+        options.source,
+        options.profile,
+        cache.cacheDataPath,
+        "unavailable",
+        numEntries === null
+          ? "cache_backend_unsupported:blockfile"
+          : `cache_backend_unsupported:blockfile:entries=${numEntries}`,
+      ),
+      backend: "blockfile",
+    };
+  }
+  if (detection.backend === "sql") {
+    return {
+      ...unavailableArtifact(
+        options.source,
+        options.profile,
+        cache.cacheDataPath,
+        "unavailable",
+        "cache_backend_unsupported:sql",
+      ),
+      backend: "sql",
+    };
+  }
+  if (detection.backend === "unknown") {
+    return {
+      ...unavailableArtifact(
+        options.source,
+        options.profile,
+        cache.cacheDataPath,
+        "unavailable",
+        "cache_backend_unrecognized",
+      ),
+      backend: "unknown",
+    };
+  }
+
+  let built: BuiltRecords;
+  try {
+    built = await buildSimpleRecords({
+      source: options.source,
+      profile: options.profile,
+      workingCopyPath: options.workingCopyPath,
+      declaredTimezone: options.declaredTimezone,
+      cache,
+    });
+  } catch (error) {
+    if (error instanceof WorkingCopyIntegrityRefusal) {
+      throw error;
+    }
+    const reason =
+      error instanceof ForensixError
+        ? `${error.code}:${error.message}`
+        : `cache_read_failed:${String(error)}`;
+    return {
+      ...unavailableArtifact(
+        options.source,
+        options.profile,
+        cache.cacheDataPath,
+        "unavailable",
+        reason,
+      ),
+      backend: "simple",
+    };
+  }
+
+  await writePayloads(options.caseDirectory, built.payloads);
+
+  const stream0Ordinal =
+    cache.files.find((file) => file.relativePath.endsWith(ENTRY_FILE_SUFFIX))
+      ?.ordinal ?? null;
+
+  return {
+    sourceId: options.source.sourceId,
+    profile: options.profile,
+    status: "complete",
+    manifestEntryOrdinal: stream0Ordinal,
+    databasePath: cache.cacheDataPath,
+    backend: "simple",
+    reason: null,
+    findings: built.findings,
+    candidates: built.candidates,
+    entryFindingCount: built.findings.length,
+    candidateCount: built.candidates.length,
+    payloadFileCount: built.payloads.size,
+  };
+}
+
+export interface CacheAnalysisInput {
+  readonly source: CaseSourceRecord;
+  readonly workingCopyPath: string;
+  readonly caseDirectory: string;
+  readonly declaredTimezone: string;
+}
+
+export async function analyseSourceCache(
+  input: CacheAnalysisInput,
+): Promise<CacheArtifactWrite[]> {
+  const artifacts: CacheArtifactWrite[] = [];
+  for (const profile of input.source.profiles) {
+    artifacts.push(
+      await analyseProfileCache({
+        source: input.source,
+        profile: profile.path,
+        workingCopyPath: input.workingCopyPath,
+        caseDirectory: input.caseDirectory,
+        declaredTimezone: input.declaredTimezone,
+      }),
+    );
+  }
+  return artifacts;
+}

--- a/core/src/cache.ts
+++ b/core/src/cache.ts
@@ -199,7 +199,6 @@ function unavailableArtifact(
     reason,
     findings: [],
     candidates: [],
-    entryFindingCount: 0,
     candidateCount: 0,
     payloadFileCount: 0,
   };
@@ -316,8 +315,7 @@ async function buildSimpleRecords(options: {
     if (payload !== null) {
       payloads.set(payload.sha256, payload);
     }
-    const indexed = indexRecords.get(hash);
-    const record = indexed;
+    const record = indexRecords.get(hash);
     const fields = {
       backend: valueField("simple"),
       entryHash: valueField(hash),
@@ -347,7 +345,7 @@ async function buildSimpleRecords(options: {
       ...payloadFields(payload),
     };
 
-    if (indexed === undefined) {
+    if (record === undefined) {
       // On disk, parseable, but absent from the index: allocated-deleted or
       // doomed. Its key and payload are preserved as evidence, but the record
       // stays a Candidate and is never promoted to a Finding by heuristic.
@@ -378,7 +376,9 @@ async function buildSimpleRecords(options: {
         candidateKind: "doomed_entry",
         searchText: searchTextOf(profile, hash, parsed.keyText),
         sortKey: parsed.keyText,
-        sortLastUsed: record?.lastUsedUtc ?? null,
+        // A doomed entry is by definition absent from the index, so it has no
+        // index-recorded last-used time to sort on.
+        sortLastUsed: null,
       });
       continue;
     }
@@ -656,7 +656,6 @@ async function analyseProfileCache(options: {
     reason: null,
     findings: built.findings,
     candidates: built.candidates,
-    entryFindingCount: built.findings.length,
     candidateCount: built.candidates.length,
     payloadFileCount: built.payloads.size,
   };

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -190,6 +190,44 @@ export interface FaviconArtifactWrite {
   readonly payloadFileCount: number;
 }
 
+export interface PersistedCacheFinding {
+  readonly finding: Finding;
+  readonly searchText: string;
+  readonly backend: string;
+  readonly sortKey: string | null;
+  readonly sortLastUsed: string | null;
+  readonly sortSizeBytes: bigint | null;
+  readonly sortEntryHash: string;
+}
+
+export interface PersistedCacheCandidate {
+  readonly candidate: Candidate;
+  readonly profile: string;
+  readonly commitState: "committed" | "wal_resident" | "journal_resident";
+  readonly backend: string;
+  readonly candidateKind: string;
+  readonly searchText: string;
+  readonly sortKey: string | null;
+  readonly sortLastUsed: string | null;
+}
+
+export interface CacheArtifactWrite {
+  readonly sourceId: string;
+  readonly profile: string;
+  readonly status: "complete" | "absent" | "unavailable";
+  readonly manifestEntryOrdinal: number | null;
+  /** The cache data directory, e.g. `Default/Cache/Cache_Data`. */
+  readonly databasePath: string;
+  /** The detected backend, or null when the cache was absent/uncollected. */
+  readonly backend: string | null;
+  readonly reason: string | null;
+  readonly findings: readonly PersistedCacheFinding[];
+  readonly candidates: readonly PersistedCacheCandidate[];
+  readonly entryFindingCount: number;
+  readonly candidateCount: number;
+  readonly payloadFileCount: number;
+}
+
 export type BookmarkSourceFile = "Bookmarks" | "Bookmarks.bak";
 
 export interface PersistedBookmarkFinding {
@@ -260,6 +298,7 @@ export interface StoreHistoryAnalysisOptions {
   readonly downloadsArtifacts?: readonly DownloadsArtifactWrite[];
   readonly metadataArtifacts?: readonly MetadataArtifactWrite[];
   readonly bookmarksArtifacts?: readonly BookmarksArtifactWrite[];
+  readonly cacheArtifacts?: readonly CacheArtifactWrite[];
 }
 
 export type AnalysisRunExitState = "complete" | "partial" | "failed";
@@ -844,6 +883,93 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ON bookmarks_findings(finding_kind, COALESCE(sort_folder, ''), finding_id);
     CREATE INDEX IF NOT EXISTS bookmarks_findings_profile_query
       ON bookmarks_findings(finding_kind, source_file, profile_path, finding_id);
+
+    CREATE TABLE IF NOT EXISTS cache_artifact_results (
+      artifact_result_id INTEGER PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL REFERENCES sources(source_id),
+      profile_path TEXT NOT NULL,
+      artifact TEXT NOT NULL CHECK (artifact = 'Cache'),
+      manifest_entry_ordinal INTEGER,
+      database_path TEXT NOT NULL,
+      backend TEXT,
+      status TEXT NOT NULL CHECK (status IN ('complete', 'absent', 'unavailable')),
+      reason TEXT,
+      active INTEGER NOT NULL DEFAULT 0 CHECK (active IN (0, 1)),
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal),
+      UNIQUE (run_id, source_id, profile_path, artifact)
+    ) STRICT;
+
+    CREATE UNIQUE INDEX IF NOT EXISTS cache_one_active_result
+      ON cache_artifact_results(source_id, profile_path, artifact)
+      WHERE active = 1;
+
+    CREATE TABLE IF NOT EXISTS cache_findings (
+      finding_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES cache_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'finding'),
+      finding_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      backend TEXT NOT NULL,
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_key TEXT,
+      sort_last_used TEXT,
+      sort_size INTEGER,
+      sort_entry_hash TEXT NOT NULL,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS cache_findings_key_query
+      ON cache_findings(finding_kind, COALESCE(sort_key, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cache_findings_last_used_query
+      ON cache_findings(finding_kind, COALESCE(sort_last_used, ''), finding_id);
+    CREATE INDEX IF NOT EXISTS cache_findings_size_query
+      ON cache_findings(finding_kind, COALESCE(sort_size, -1), finding_id);
+    CREATE INDEX IF NOT EXISTS cache_findings_hash_query
+      ON cache_findings(finding_kind, sort_entry_hash, finding_id);
+    CREATE INDEX IF NOT EXISTS cache_findings_profile_query
+      ON cache_findings(finding_kind, profile_path, finding_id);
+
+    CREATE TABLE IF NOT EXISTS cache_candidates (
+      candidate_id INTEGER PRIMARY KEY,
+      artifact_result_id INTEGER NOT NULL
+        REFERENCES cache_artifact_results(artifact_result_id),
+      run_id TEXT NOT NULL REFERENCES analysis_runs(run_id),
+      source_id TEXT NOT NULL,
+      manifest_entry_ordinal INTEGER NOT NULL,
+      record_type TEXT NOT NULL CHECK (record_type = 'candidate'),
+      candidate_kind TEXT NOT NULL,
+      profile_path TEXT NOT NULL,
+      commit_state TEXT NOT NULL CHECK (
+        commit_state IN ('committed', 'wal_resident', 'journal_resident')
+      ),
+      backend TEXT NOT NULL,
+      rank INTEGER NOT NULL CHECK (rank > 0),
+      supporting_count INTEGER NOT NULL CHECK (supporting_count > 0),
+      provenance_json TEXT NOT NULL,
+      fields_json TEXT NOT NULL,
+      search_text TEXT NOT NULL,
+      sort_key TEXT,
+      sort_last_used TEXT,
+      FOREIGN KEY (source_id, manifest_entry_ordinal)
+        REFERENCES manifest_entries(source_id, ordinal)
+    ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS cache_candidates_kind_query
+      ON cache_candidates(candidate_kind, COALESCE(sort_last_used, ''), candidate_id);
+    CREATE INDEX IF NOT EXISTS cache_candidates_profile_query
+      ON cache_candidates(profile_path, candidate_id);
   `);
 }
 
@@ -1053,6 +1179,60 @@ function insertFaviconFinding(
     row.sortPageUrl,
     row.sortLastUpdated,
     row.sortWidth,
+  );
+}
+
+function insertCacheFinding(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedCacheFinding,
+): void {
+  const finding = row.finding;
+  statement.run(
+    artifactResultId,
+    runId,
+    finding.provenance.sourceId,
+    finding.provenance.manifestEntryOrdinal,
+    finding.recordType,
+    finding.findingKind,
+    finding.profile,
+    finding.commitState,
+    row.backend,
+    JSON.stringify(finding.provenance),
+    JSON.stringify(finding.fields),
+    row.searchText,
+    row.sortKey,
+    row.sortLastUsed,
+    row.sortSizeBytes,
+    row.sortEntryHash,
+  );
+}
+
+function insertCacheCandidate(
+  statement: ReturnType<DatabaseSync["prepare"]>,
+  artifactResultId: bigint,
+  runId: string,
+  row: PersistedCacheCandidate,
+): void {
+  const candidate = row.candidate;
+  statement.run(
+    artifactResultId,
+    runId,
+    candidate.provenance.sourceId,
+    candidate.provenance.manifestEntryOrdinal,
+    candidate.recordType,
+    candidate.candidateKind,
+    row.profile,
+    row.commitState,
+    row.backend,
+    candidate.rank,
+    candidate.count,
+    JSON.stringify(candidate.provenance),
+    JSON.stringify(candidate.fields),
+    row.searchText,
+    row.sortKey,
+    row.sortLastUsed,
   );
 }
 
@@ -1364,6 +1544,37 @@ export function storeHistoryAnalysis(
       const activateCurrentBookmark = database.prepare(
         "UPDATE bookmarks_artifact_results SET active = 1 WHERE artifact_result_id = ?",
       );
+      const insertCacheArtifact = database.prepare(
+        `INSERT INTO cache_artifact_results
+           (run_id, source_id, profile_path, artifact, manifest_entry_ordinal,
+            database_path, backend, status, reason, active)
+         VALUES (?, ?, ?, 'Cache', ?, ?, ?, ?, ?, 0)`,
+      );
+      const insertCacheFindingStatement = database.prepare(
+        `INSERT INTO cache_findings
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, finding_kind, profile_path, commit_state, backend,
+            provenance_json, fields_json, search_text, sort_key, sort_last_used,
+            sort_size, sort_entry_hash)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const insertCacheCandidateStatement = database.prepare(
+        `INSERT INTO cache_candidates
+           (artifact_result_id, run_id, source_id, manifest_entry_ordinal,
+            record_type, candidate_kind, profile_path, commit_state, backend,
+            rank, supporting_count, provenance_json, fields_json, search_text,
+            sort_key, sort_last_used)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      );
+      const deactivatePreviousCache = database.prepare(
+        `UPDATE cache_artifact_results
+            SET active = 0
+          WHERE source_id = ? AND profile_path = ? AND artifact = 'Cache'
+            AND active = 1`,
+      );
+      const activateCurrentCache = database.prepare(
+        "UPDATE cache_artifact_results SET active = 1 WHERE artifact_result_id = ?",
+      );
 
       for (const artifact of options.artifacts) {
         const insertion = insertArtifact.run(
@@ -1629,6 +1840,40 @@ export function storeHistoryAnalysis(
         }
       }
 
+      for (const artifact of options.cacheArtifacts ?? []) {
+        const insertion = insertCacheArtifact.run(
+          runId,
+          artifact.sourceId,
+          artifact.profile,
+          artifact.manifestEntryOrdinal,
+          artifact.databasePath,
+          artifact.backend,
+          artifact.status,
+          artifact.reason,
+        );
+        const artifactResultId = insertion.lastInsertRowid as bigint;
+        for (const finding of artifact.findings) {
+          insertCacheFinding(
+            insertCacheFindingStatement,
+            artifactResultId,
+            runId,
+            finding,
+          );
+        }
+        for (const candidate of artifact.candidates) {
+          insertCacheCandidate(
+            insertCacheCandidateStatement,
+            artifactResultId,
+            runId,
+            candidate,
+          );
+        }
+        if (artifact.status === "complete") {
+          deactivatePreviousCache.run(artifact.sourceId, artifact.profile);
+          activateCurrentCache.run(artifactResultId);
+        }
+      }
+
       // The SQLite primary stores (History, Cookies, Login Data, Web Data, Top
       // Sites, Favicons) drive the Analysis Run exit state. The JSON-derived
       // artifacts —
@@ -1645,6 +1890,7 @@ export function storeHistoryAnalysis(
         ...(options.webDataArtifacts ?? []),
         ...(options.faviconArtifacts ?? []),
         ...(options.downloadsArtifacts ?? []),
+        ...(options.cacheArtifacts ?? []),
       ];
       const unavailableCount = combinedArtifacts.filter(
         (artifact) => artifact.status === "unavailable",

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -223,7 +223,6 @@ export interface CacheArtifactWrite {
   readonly reason: string | null;
   readonly findings: readonly PersistedCacheFinding[];
   readonly candidates: readonly PersistedCacheCandidate[];
-  readonly entryFindingCount: number;
   readonly candidateCount: number;
   readonly payloadFileCount: number;
 }

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -240,7 +240,6 @@ export interface CacheAnalysisSummary {
   readonly analysedProfileCount: number;
   readonly absentProfileCount: number;
   readonly unavailableProfileCount: number;
-  readonly entryFindingCount: number;
   readonly candidateCount: number;
   readonly payloadFileCount: number;
   readonly findingCount: number;
@@ -1737,10 +1736,6 @@ export async function analyseCase(
       analysedProfileCount: cacheAnalysed.length,
       absentProfileCount: cacheAbsent.length,
       unavailableProfileCount: cacheUnavailable.length,
-      entryFindingCount: cacheAnalysed.reduce(
-        (count, artifact) => count + artifact.entryFindingCount,
-        0,
-      ),
       candidateCount: cacheAnalysed.reduce(
         (count, artifact) => count + artifact.candidateCount,
         0,

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -4,6 +4,7 @@ import {
   storeHistoryAnalysis,
   type AnalysisRunExitState,
   type BookmarksArtifactWrite,
+  type CacheArtifactWrite,
   type CookieArtifactWrite,
   type DeclaredOriginOs,
   type DownloadsArtifactWrite,
@@ -16,6 +17,7 @@ import {
   type WebDataArtifactWrite,
 } from "./case-findings.js";
 import { analyseSourceBookmarks } from "./bookmarks.js";
+import { analyseSourceCache } from "./cache.js";
 import { analyseSourceCookies } from "./cookies.js";
 import { analyseDownloadsProfile } from "./downloads.js";
 import { analyseSourceFavicons } from "./favicons.js";
@@ -232,6 +234,18 @@ export interface BookmarksAnalysisSummary {
   readonly declaredTimezone: string;
 }
 
+export interface CacheAnalysisSummary {
+  readonly status: "complete" | "partial";
+  readonly profileCount: number;
+  readonly analysedProfileCount: number;
+  readonly absentProfileCount: number;
+  readonly unavailableProfileCount: number;
+  readonly entryFindingCount: number;
+  readonly candidateCount: number;
+  readonly payloadFileCount: number;
+  readonly findingCount: number;
+}
+
 export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly command: "analyse";
   readonly analysisStatus: "ready";
@@ -247,6 +261,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly downloads: DownloadsAnalysisSummary;
   readonly preferences: PreferencesAnalysisSummary;
   readonly bookmarks: BookmarksAnalysisSummary;
+  readonly cache: CacheAnalysisSummary;
   readonly decryption: DecryptionSummary;
 }
 
@@ -1280,6 +1295,7 @@ export async function analyseCase(
   const downloadsArtifacts: DownloadsArtifactWrite[] = [];
   const metadataArtifacts: MetadataArtifactWrite[] = [];
   const bookmarksArtifacts: BookmarksArtifactWrite[] = [];
+  const cacheArtifacts: CacheArtifactWrite[] = [];
   for (const source of sources) {
     const workingCopyPath = workingCopyAbsolutePath(caseDirectory, source);
     for (const profile of source.profiles) {
@@ -1351,6 +1367,14 @@ export async function analyseCase(
         declaredTimezone,
       })),
     );
+    cacheArtifacts.push(
+      ...(await analyseSourceCache({
+        source,
+        workingCopyPath,
+        caseDirectory,
+        declaredTimezone,
+      })),
+    );
   }
 
   await verifyWorkingCopy(caseDirectory);
@@ -1370,6 +1394,7 @@ export async function analyseCase(
     downloadsArtifacts,
     metadataArtifacts,
     bookmarksArtifacts,
+    cacheArtifacts,
   });
   const singletonLockPresent = sources.some((source) =>
     source.entries.some(
@@ -1458,6 +1483,15 @@ export async function analyseCase(
   const bookmarksUnavailable = bookmarksArtifacts.filter(
     (artifact) => artifact.status === "unavailable",
   );
+  const cacheAnalysed = cacheArtifacts.filter(
+    (artifact) => artifact.status === "complete",
+  );
+  const cacheAbsent = cacheArtifacts.filter(
+    (artifact) => artifact.status === "absent",
+  );
+  const cacheUnavailable = cacheArtifacts.filter(
+    (artifact) => artifact.status === "unavailable",
+  );
   return {
     ...verification,
     command: "analyse",
@@ -1469,7 +1503,8 @@ export async function analyseCase(
       topSitesAnalysed.length +
       webAnalysed.length +
       faviconsAnalysed.length +
-      downloadsAnalysed.length,
+      downloadsAnalysed.length +
+      cacheAnalysed.length,
     runId: stored.runId,
     exitState: stored.runStatus,
     cookies: {
@@ -1692,6 +1727,32 @@ export async function analyseCase(
         0,
       ),
       declaredTimezone,
+    },
+    cache: {
+      status: cacheUnavailable.length === 0 ? "complete" : "partial",
+      profileCount: sources.reduce(
+        (count, source) => count + source.profiles.length,
+        0,
+      ),
+      analysedProfileCount: cacheAnalysed.length,
+      absentProfileCount: cacheAbsent.length,
+      unavailableProfileCount: cacheUnavailable.length,
+      entryFindingCount: cacheAnalysed.reduce(
+        (count, artifact) => count + artifact.entryFindingCount,
+        0,
+      ),
+      candidateCount: cacheAnalysed.reduce(
+        (count, artifact) => count + artifact.candidateCount,
+        0,
+      ),
+      payloadFileCount: cacheAnalysed.reduce(
+        (count, artifact) => count + artifact.payloadFileCount,
+        0,
+      ),
+      findingCount: cacheAnalysed.reduce(
+        (count, artifact) => count + artifact.findings.length,
+        0,
+      ),
     },
     decryption: {
       enabled: decryption.enabled,

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -102,6 +102,7 @@ export {
   type LoginDataAnalysisSummary,
   type PreferencesAnalysisSummary,
   type BookmarksAnalysisSummary,
+  type CacheAnalysisSummary,
   type TopSitesAnalysisSummary,
   type WebDataAnalysisSummary,
 } from "./history.js";
@@ -225,9 +226,29 @@ export {
   type BookmarkSource,
 } from "./bookmarks-query.js";
 export {
+  queryCache,
+  type CacheDirection,
+  type CachePage,
+  type CacheQuery,
+  type CacheRecordType,
+  type CacheSort,
+} from "./cache-query.js";
+export {
+  CACHE_PAYLOAD_DIRECTORY,
+  analyseSourceCache,
+  type CacheAnalysisInput,
+} from "./cache.js";
+export {
+  detectCacheBackend,
+  parseSimpleEntryFile,
+  parseSimpleIndex,
+  type CacheBackend,
+} from "./cache-format.js";
+export {
   type AnalysisRunExitState,
   type BookmarksArtifactWrite,
   type BookmarkSourceFile,
+  type CacheArtifactWrite,
   type DeclaredOriginOs,
 } from "./case-findings.js";
 export { openDatabaseSync, type OpenDatabaseConfig } from "./sqlite-open.js";

--- a/core/test/cache-format.test.ts
+++ b/core/test/cache-format.test.ts
@@ -1,0 +1,251 @@
+import { createHash } from "node:crypto";
+import { crc32 } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  BLOCKFILE_INDEX_MAGIC,
+  detectCacheBackend,
+  entryHashHexFromKey,
+  parseBlockfileIndexHeader,
+  parseSimpleEntryFile,
+  parseSimpleIndex,
+  superFastHash,
+  type CacheDirEntry,
+} from "../src/cache-format.js";
+
+const SIMPLE_INITIAL_MAGIC = 0xfcfb6d1ba7725c30n;
+const SIMPLE_FINAL_MAGIC = 0xf4fa6f45970d41d8n;
+const SIMPLE_INDEX_MAGIC = 0x656e74657220796fn;
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+const FLAG_HAS_CRC32 = 1;
+const FLAG_HAS_KEY_SHA256 = 2;
+
+function u32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value >>> 0);
+  return buffer;
+}
+
+function u64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(BigInt.asUintN(64, value));
+  return buffer;
+}
+
+function i64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigInt64LE(value);
+  return buffer;
+}
+
+/**
+ * Build a Simple Cache stream-0/stream-1 entry file per simple_entry_format.h:
+ * header, key, stream 1 (body), stream-1 EOF, stream 0 (metadata), optional key
+ * SHA-256, stream-0 EOF.
+ */
+function buildSimpleEntry(options: {
+  readonly key: string;
+  readonly body: Uint8Array;
+  readonly stream0?: Uint8Array;
+  readonly version?: number;
+  readonly withKeySha256?: boolean;
+  readonly corruptKeyHash?: boolean;
+}): Buffer {
+  const key = Buffer.from(options.key, "utf8");
+  const headerHash = options.corruptKeyHash ? 0 : superFastHash(key);
+  const header = Buffer.concat([
+    u64(SIMPLE_INITIAL_MAGIC),
+    u32(options.version ?? 5),
+    u32(key.length),
+    u32(headerHash),
+    u32(0),
+  ]);
+  const stream1 = Buffer.from(options.body);
+  const eof1 = Buffer.concat([
+    u64(SIMPLE_FINAL_MAGIC),
+    u32(FLAG_HAS_CRC32),
+    u32(crc32(stream1) >>> 0),
+    u32(0),
+    u32(0),
+  ]);
+  const stream0 = Buffer.from(options.stream0 ?? Buffer.from("headers"));
+  const keySha = options.withKeySha256
+    ? createHash("sha256").update(key).digest()
+    : Buffer.alloc(0);
+  const eof0 = Buffer.concat([
+    u64(SIMPLE_FINAL_MAGIC),
+    u32(options.withKeySha256 ? FLAG_HAS_KEY_SHA256 : 0),
+    u32(0),
+    u32(stream0.length),
+    u32(0),
+  ]);
+  return Buffer.concat([header, key, stream1, eof1, stream0, keySha, eof0]);
+}
+
+function buildRealIndex(
+  records: readonly {
+    readonly hashHex: string;
+    readonly lastUsedInternalMicros: bigint;
+    readonly entrySizeBytes: number;
+  }[],
+): Buffer {
+  const body: Buffer[] = [
+    u64(SIMPLE_INDEX_MAGIC),
+    u32(9),
+    u64(BigInt(records.length)),
+    u64(65536n),
+    u32(0),
+  ];
+  for (const record of records) {
+    body.push(u64(BigInt(`0x${record.hashHex}`)));
+    body.push(i64(record.lastUsedInternalMicros));
+    body.push(u64((BigInt(record.entrySizeBytes >> 8) << 8n) | 0n));
+  }
+  body.push(i64(0n));
+  const payload = Buffer.concat(body);
+  return Buffer.concat([
+    u32(payload.length),
+    u32(crc32(payload) >>> 0),
+    payload,
+  ]);
+}
+
+describe("Cache backend detection", () => {
+  it("distinguishes blockfile, Simple Cache, SQL, and unknown from contents", () => {
+    // AC1: detection reads directory contents, never a Source platform.
+    expect(
+      detectCacheBackend([
+        { relativePath: "index", head: u32(BLOCKFILE_INDEX_MAGIC) },
+        { relativePath: "data_0", head: u32(0xc104cac3) },
+      ]).backend,
+    ).toBe("blockfile");
+    expect(
+      detectCacheBackend([
+        { relativePath: "index", head: Buffer.alloc(16) },
+        { relativePath: "index-dir/the-real-index", head: Buffer.alloc(16) },
+      ]).backend,
+    ).toBe("simple");
+    expect(
+      detectCacheBackend([
+        {
+          relativePath: "0011223344556677_0",
+          head: u64(SIMPLE_INITIAL_MAGIC),
+        },
+      ]).backend,
+    ).toBe("simple");
+    expect(
+      detectCacheBackend([
+        {
+          relativePath: "index",
+          head: Buffer.from("SQLite format 3\u0000"),
+        },
+      ]).backend,
+    ).toBe("sql");
+    expect(
+      detectCacheBackend([
+        { relativePath: "index", head: Buffer.from("garbage-bytes-xx") },
+      ]).backend,
+    ).toBe("unknown");
+    expect(detectCacheBackend([] as CacheDirEntry[]).backend).toBe("unknown");
+  });
+
+  it("reads a blockfile index header for entry count evidence", () => {
+    const header = Buffer.concat([
+      u32(BLOCKFILE_INDEX_MAGIC),
+      u32(0x30000),
+      u32(42),
+    ]);
+    const parsed = parseBlockfileIndexHeader(header);
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.numEntries).toBe(42);
+    }
+    expect(parseBlockfileIndexHeader(Buffer.from("no")).ok).toBe(false);
+  });
+});
+
+describe("Simple Cache entry parsing (exact against recorded format)", () => {
+  it("recovers key, key hash, streams, and body payload", () => {
+    const key = "1/0/https://example.com/style.css";
+    const body = Buffer.from("body-bytes-payload");
+    const parsed = parseSimpleEntryFile(
+      buildSimpleEntry({ key, body, withKeySha256: true }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+    expect(parsed.keyText).toBe(key);
+    expect(parsed.keyLength).toBe(Buffer.from(key).length);
+    // AC2: the header key hash validates against SuperFastHash of the key.
+    expect(parsed.keyHashValid).toBe(true);
+    // The 16-hex entry hash derives from the key exactly as Chromium names it.
+    expect(parsed.entryHashFromKey).toBe(entryHashHexFromKey(Buffer.from(key)));
+    expect(parsed.stream1.size).toBe(body.length);
+    expect(Buffer.from(parsed.stream1.data).equals(body)).toBe(true);
+    // AC2: the stream-1 CRC32 recorded in the EOF validates the body.
+    expect(parsed.stream1.crc32Valid).toBe(true);
+    expect(parsed.keySha256).toBe(
+      createHash("sha256").update(key).digest("hex"),
+    );
+  });
+
+  it("flags a corrupt key hash without discarding the entry", () => {
+    const parsed = parseSimpleEntryFile(
+      buildSimpleEntry({
+        key: "1/0/https://example.com/a",
+        body: Buffer.from("x"),
+        corruptKeyHash: true,
+      }),
+    );
+    expect(parsed.ok).toBe(true);
+    if (parsed.ok) {
+      expect(parsed.keyHashValid).toBe(false);
+    }
+  });
+
+  it("rejects a non-Simple entry and a truncated file with typed reasons", () => {
+    const bad = parseSimpleEntryFile(Buffer.from("not-a-simple-entry-file!!"));
+    expect(bad.ok).toBe(false);
+    if (!bad.ok) {
+      expect(bad.reason).toBe("not_simple_magic");
+    }
+    expect(parseSimpleEntryFile(Buffer.alloc(4)).ok).toBe(false);
+  });
+});
+
+describe("Simple Cache index parsing", () => {
+  it("decodes entry hashes, last-used time, and size with CRC validation", () => {
+    const hashHex = entryHashHexFromKey(Buffer.from("1/0/https://a.test/x"));
+    const lastUsed =
+      BigInt(Date.UTC(2024, 0, 2)) * 1000n + WINDOWS_EPOCH_OFFSET_MICROS;
+    const parsed = parseSimpleIndex(
+      buildRealIndex([
+        { hashHex, lastUsedInternalMicros: lastUsed, entrySizeBytes: 4096 },
+      ]),
+    );
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) {
+      return;
+    }
+    expect(parsed.declaredEntryCount).toBe(1n);
+    const record = parsed.records.get(hashHex);
+    expect(record?.lastUsedUtc).toBe("2024-01-02T00:00:00.000000Z");
+    expect(record?.entrySizeBytes).toBe(4096n);
+  });
+
+  it("rejects a corrupt index CRC rather than mining bogus timestamps", () => {
+    const hashHex = "0011223344556677";
+    const valid = buildRealIndex([
+      { hashHex, lastUsedInternalMicros: 0n, entrySizeBytes: 256 },
+    ]);
+    valid[valid.length - 1] = ((valid.at(-1) ?? 0) ^ 0xff) & 0xff;
+    const parsed = parseSimpleIndex(valid);
+    expect(parsed.ok).toBe(false);
+    if (!parsed.ok) {
+      expect(parsed.reason).toBe("crc_mismatch");
+    }
+  });
+});

--- a/e2e/cache-cli.test.ts
+++ b/e2e/cache-cli.test.ts
@@ -1,0 +1,598 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { crc32 } from "node:zlib";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+const SIMPLE_INITIAL_MAGIC = 0xfcfb6d1ba7725c30n;
+const SIMPLE_FINAL_MAGIC = 0xf4fa6f45970d41d8n;
+const SIMPLE_INDEX_MAGIC = 0x656e74657220796fn;
+const BLOCKFILE_INDEX_MAGIC = 0xc103cac3;
+const WINDOWS_EPOCH_OFFSET_MICROS = 11_644_473_600_000_000n;
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+type Field<T> =
+  | { readonly state: "value"; readonly value: T; readonly synthetic?: boolean }
+  | { readonly state: "absent" }
+  | { readonly state: "unavailable"; readonly reason: string };
+
+interface CacheRecord {
+  readonly recordType: "finding" | "candidate";
+  readonly findingKind?: string;
+  readonly candidateKind?: string;
+  readonly rank?: number;
+  readonly count?: number;
+  readonly profile: string;
+  readonly provenance: {
+    readonly database: string;
+    readonly table: string;
+    readonly rowId: string;
+    readonly supportingRows?: readonly {
+      readonly table: string;
+      readonly rowId: string;
+    }[];
+  };
+  readonly fields: Record<string, Field<unknown>>;
+}
+
+interface CachePage {
+  readonly status: "ok";
+  readonly command: "cache";
+  readonly recordType: "finding" | "candidate";
+  readonly items: readonly CacheRecord[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+function u32(value: number): Buffer {
+  const buffer = Buffer.alloc(4);
+  buffer.writeUInt32LE(value >>> 0);
+  return buffer;
+}
+
+function u64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigUInt64LE(BigInt.asUintN(64, value));
+  return buffer;
+}
+
+function i64(value: bigint): Buffer {
+  const buffer = Buffer.alloc(8);
+  buffer.writeBigInt64LE(value);
+  return buffer;
+}
+
+/** Paul Hsieh SuperFastHash — Chromium's persisted SimpleFileHeader key_hash. */
+function superFastHash(data: Uint8Array): number {
+  let length = data.length;
+  if (length <= 0) {
+    return 0;
+  }
+  let hash = length >>> 0;
+  const remainder = length & 3;
+  length >>= 2;
+  let offset = 0;
+  const get16 = (at: number): number =>
+    (data[at] ?? 0) | ((data[at + 1] ?? 0) << 8);
+  const signedByte = (at: number): number => ((data[at] ?? 0) << 24) >> 24;
+  for (; length > 0; length -= 1) {
+    hash = (hash + get16(offset)) >>> 0;
+    const tmp = (((get16(offset + 2) << 11) >>> 0) ^ hash) >>> 0;
+    hash = (((hash << 16) >>> 0) ^ tmp) >>> 0;
+    offset += 4;
+    hash = (hash + (hash >>> 11)) >>> 0;
+  }
+  switch (remainder) {
+    case 3:
+      hash = (hash + get16(offset)) >>> 0;
+      hash = (hash ^ ((hash << 16) >>> 0)) >>> 0;
+      hash = (hash ^ ((signedByte(offset + 2) << 18) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 11)) >>> 0;
+      break;
+    case 2:
+      hash = (hash + get16(offset)) >>> 0;
+      hash = (hash ^ ((hash << 11) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 17)) >>> 0;
+      break;
+    case 1:
+      hash = (hash + signedByte(offset)) >>> 0;
+      hash = (hash ^ ((hash << 10) >>> 0)) >>> 0;
+      hash = (hash + (hash >>> 1)) >>> 0;
+      break;
+    default:
+      break;
+  }
+  hash = (hash ^ ((hash << 3) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 5)) >>> 0;
+  hash = (hash ^ ((hash << 4) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 17)) >>> 0;
+  hash = (hash ^ ((hash << 10) >>> 0)) >>> 0;
+  hash = (hash + (hash >>> 6)) >>> 0;
+  return hash >>> 0;
+}
+
+/** The 16-hex entry hash: first 8 bytes of SHA-1(key) read little-endian. */
+function entryHash(key: string): string {
+  const digest = createHash("sha1").update(Buffer.from(key, "utf8")).digest();
+  return digest
+    .subarray(0, 8)
+    .readBigUInt64LE(0)
+    .toString(16)
+    .padStart(16, "0");
+}
+
+function buildSimpleEntry(key: string, body: Uint8Array): Buffer {
+  const keyBuffer = Buffer.from(key, "utf8");
+  const header = Buffer.concat([
+    u64(SIMPLE_INITIAL_MAGIC),
+    u32(5),
+    u32(keyBuffer.length),
+    u32(superFastHash(keyBuffer)),
+    u32(0),
+  ]);
+  const stream1 = Buffer.from(body);
+  const eof1 = Buffer.concat([
+    u64(SIMPLE_FINAL_MAGIC),
+    u32(1),
+    u32(crc32(stream1) >>> 0),
+    u32(0),
+    u32(0),
+  ]);
+  const stream0 = Buffer.from("HTTP/1.1 200 OK");
+  const eof0 = Buffer.concat([
+    u64(SIMPLE_FINAL_MAGIC),
+    u32(1),
+    u32(crc32(stream0) >>> 0),
+    u32(stream0.length),
+    u32(0),
+  ]);
+  return Buffer.concat([header, keyBuffer, stream1, eof1, stream0, eof0]);
+}
+
+function buildRealIndex(
+  records: readonly {
+    readonly key: string;
+    readonly lastUsedUtcMillis: number;
+    readonly entrySizeBytes: number;
+  }[],
+): Buffer {
+  const body: Buffer[] = [
+    u64(SIMPLE_INDEX_MAGIC),
+    u32(9),
+    u64(BigInt(records.length)),
+    u64(1_048_576n),
+    u32(0),
+  ];
+  for (const record of records) {
+    const internal =
+      BigInt(record.lastUsedUtcMillis) * 1000n + WINDOWS_EPOCH_OFFSET_MICROS;
+    body.push(u64(BigInt(`0x${entryHash(record.key)}`)));
+    body.push(i64(internal));
+    body.push(u64((BigInt(record.entrySizeBytes >> 8) << 8n) | 0n));
+  }
+  body.push(i64(0n));
+  const payload = Buffer.concat(body);
+  return Buffer.concat([
+    u32(payload.length),
+    u32(crc32(payload) >>> 0),
+    payload,
+  ]);
+}
+
+async function writeCacheFile(
+  cacheDataDir: string,
+  relativePath: string,
+  bytes: Uint8Array,
+): Promise<void> {
+  const full = join(cacheDataDir, ...relativePath.split("/"));
+  await mkdir(join(full, ".."), { recursive: true });
+  await writeFile(full, bytes);
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) => rm(root, { force: true, recursive: true })),
+  );
+});
+
+describe("compiled analyzer CLI Cache backends", () => {
+  it("extracts Simple Cache entries, payloads, and doomed/evicted Candidates", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cache-e2e-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const cacheData = join(source, "Default", "Cache", "Cache_Data");
+    await mkdir(cacheData, { recursive: true });
+
+    const alphaKey = "1/0/https://alpha.example/app.js";
+    const live = [
+      { key: alphaKey, body: "alpha-body-1" },
+      { key: "1/0/https://bravo.example/style.css", body: "bravo-body-22" },
+      { key: "1/0/https://delta.example/logo.png", body: "delta-body-333" },
+    ];
+    for (const entry of live) {
+      await writeCacheFile(
+        cacheData,
+        `${entryHash(entry.key)}_0`,
+        buildSimpleEntry(entry.key, Buffer.from(entry.body)),
+      );
+    }
+    // A doomed entry: on disk with a parseable `_0` file but absent from the
+    // real index. Its key and payload are preserved but it stays a Candidate.
+    const doomedKey = "1/0/https://doomed.example/orphan.js";
+    await writeCacheFile(
+      cacheData,
+      `${entryHash(doomedKey)}_0`,
+      buildSimpleEntry(doomedKey, Buffer.from("doomed-body")),
+    );
+    // An evicted reference: in the index but with no recoverable entry file.
+    const evictedKey = "1/0/https://evicted.example/gone.css";
+
+    await writeCacheFile(
+      cacheData,
+      "index-dir/the-real-index",
+      buildRealIndex([
+        ...live.map((entry) => ({
+          key: entry.key,
+          lastUsedUtcMillis: Date.UTC(2024, 0, 1),
+          entrySizeBytes: 4096,
+        })),
+        {
+          key: evictedKey,
+          lastUsedUtcMillis: Date.UTC(2024, 0, 2),
+          entrySizeBytes: 512,
+        },
+      ]),
+    );
+    // The Simple Cache fake index (not a blockfile index): zeroed head.
+    await writeCacheFile(cacheData, "index", Buffer.alloc(16));
+
+    const alphaSha = createHash("sha256")
+      .update(Buffer.from("alpha-body-1"))
+      .digest("hex");
+    const aEntry = await readFile(join(cacheData, `${entryHash(alphaKey)}_0`));
+
+    const caseDirectory = join(root, "CASE-CACHE");
+    expect(
+      runCli([
+        "ingest",
+        source,
+        "--case",
+        caseDirectory,
+        "--include-tier-2",
+        "--json",
+      ]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    // AC1/AC2/AC4: Simple Cache produces three entry Findings and two
+    // Candidates (one doomed, one evicted), with payloads as hashed files.
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      command: "analyse",
+      exitState: "complete",
+      cache: {
+        status: "complete",
+        analysedProfileCount: 1,
+        unavailableProfileCount: 0,
+        entryFindingCount: 3,
+        candidateCount: 2,
+        payloadFileCount: 4,
+      },
+    });
+
+    // AC3: the response body is a separately hashed file named by its SHA-256,
+    // referenced by digest and path — never base64-inlined into a row.
+    const payloadOnDisk = await readFile(
+      join(caseDirectory, "cache-payloads", alphaSha),
+    );
+    expect(payloadOnDisk.toString("utf8")).toBe("alpha-body-1");
+
+    // AC5: bounded keyset pagination over Findings, ordered by cache key.
+    const firstPage = parseJson<CachePage>(
+      runCli([
+        "cache",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "key",
+        "--limit",
+        "2",
+        "--json",
+      ]).stdout,
+    );
+    expect(firstPage.recordType).toBe("finding");
+    expect(firstPage.items).toHaveLength(2);
+    expect(firstPage.nextCursor).not.toBeNull();
+
+    const alpha = firstPage.items[0];
+    expect(alpha).toBeDefined();
+    // AC2: entry metadata, key, timestamp, size, and payload reference exact.
+    expect(alpha).toMatchObject({
+      recordType: "finding",
+      findingKind: "cache_entry",
+      profile: "Default",
+      provenance: {
+        database: "Default/Cache/Cache_Data",
+        table: "simple_entry",
+        rowId: entryHash(alphaKey),
+      },
+      fields: {
+        backend: { state: "value", value: "simple" },
+        key: { state: "value", value: alphaKey },
+        keyHashValid: { state: "value", value: "true" },
+        entryHashMatchesFilename: { state: "value", value: "true" },
+        entrySizeBytes: { state: "value", value: "4096" },
+        payloadSha256: { state: "value", value: alphaSha },
+        payloadPath: { state: "value", value: `cache-payloads/${alphaSha}` },
+        stream1Crc32Valid: { state: "value", value: "true" },
+      },
+    });
+    expect(alpha?.fields.lastUsed).toMatchObject({
+      state: "value",
+      value: { utc: "2024-01-01T00:00:00.000000Z" },
+    });
+    // AC2: the index record is cited as supporting Provenance for the entry.
+    expect(
+      (alpha?.provenance.supportingRows ?? []).map((row) => row.table),
+    ).toContain("the_real_index");
+
+    const secondPage = parseJson<CachePage>(
+      runCli([
+        "cache",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "key",
+        "--limit",
+        "2",
+        "--after",
+        firstPage.nextCursor as string,
+        "--json",
+      ]).stdout,
+    );
+    const keys = [...firstPage.items, ...secondPage.items].map(
+      (item) =>
+        item.fields.key.state === "value" && (item.fields.key.value as string),
+    );
+    expect(new Set(keys).size).toBe(3);
+
+    // AC4: doomed and evicted evidence are Candidates — ranked, with supporting
+    // count and resolvable Provenance — and are NEVER Findings.
+    const candidates = parseJson<CachePage>(
+      runCli([
+        "cache",
+        "--case",
+        caseDirectory,
+        "--record-type",
+        "candidate",
+        "--json",
+      ]).stdout,
+    );
+    expect(candidates.recordType).toBe("candidate");
+    expect(candidates.items).toHaveLength(2);
+    const kinds = candidates.items.map((item) => item.candidateKind).sort();
+    expect(kinds).toEqual(["doomed_entry", "evicted_reference"]);
+    for (const candidate of candidates.items) {
+      expect(candidate.recordType).toBe("candidate");
+      expect(candidate.findingKind).toBeUndefined();
+      expect(typeof candidate.rank).toBe("number");
+      expect(candidate.count).toBeGreaterThan(0);
+      expect(candidate.fields.state?.state).toBe("value");
+    }
+    const doomed = candidates.items.find(
+      (item) => item.candidateKind === "doomed_entry",
+    );
+    // The doomed entry still yields its key and a hashed payload as evidence.
+    expect(doomed?.fields.key).toMatchObject({
+      state: "value",
+      value: doomedKey,
+    });
+    expect(doomed?.fields.state).toMatchObject({
+      state: "value",
+      value: "allocated_deleted_or_doomed",
+    });
+
+    // AC2: search matches the cache key.
+    const searched = parseJson<CachePage>(
+      runCli(["cache", "--case", caseDirectory, "--search", "bravo", "--json"])
+        .stdout,
+    );
+    expect(searched.items).toHaveLength(1);
+
+    // The Analyzer never mutates the evidence it reads.
+    expect(await readFile(join(cacheData, `${entryHash(alphaKey)}_0`))).toEqual(
+      aEntry,
+    );
+  });
+
+  it("detects blockfile and SQL backends with explicit unavailable reasons", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cache-backend-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+
+    // Default: a blockfile cache (index magic + data files).
+    const blockData = join(source, "Default", "Cache", "Cache_Data");
+    await mkdir(blockData, { recursive: true });
+    await writeFile(
+      join(blockData, "index"),
+      Buffer.concat([u32(BLOCKFILE_INDEX_MAGIC), u32(0x30000), u32(7)]),
+    );
+    await writeFile(
+      join(blockData, "data_0"),
+      Buffer.concat([u32(0xc104cac3), Buffer.alloc(60)]),
+    );
+    // Profile 1: a SQL Cache backend (SQLite database).
+    const sqlData = join(source, "Profile 1", "Cache", "Cache_Data");
+    await mkdir(sqlData, { recursive: true });
+    await writeFile(
+      join(sqlData, "index"),
+      Buffer.concat([Buffer.from("SQLite format 3\u0000"), Buffer.alloc(80)]),
+    );
+    // Profile 2: a supported Simple Cache, so the run mixes complete with
+    // unavailable and the backends are routed per Profile from contents alone.
+    const simpleData = join(source, "Profile 2", "Cache", "Cache_Data");
+    await mkdir(simpleData, { recursive: true });
+    const simpleKey = "1/0/https://ok.example/main.js";
+    await writeCacheFile(
+      simpleData,
+      `${entryHash(simpleKey)}_0`,
+      buildSimpleEntry(simpleKey, Buffer.from("ok-body")),
+    );
+    await writeCacheFile(
+      simpleData,
+      "index-dir/the-real-index",
+      buildRealIndex([
+        {
+          key: simpleKey,
+          lastUsedUtcMillis: Date.UTC(2024, 2, 3),
+          entrySizeBytes: 256,
+        },
+      ]),
+    );
+
+    const caseDirectory = join(root, "CASE-CACHE-BACKENDS");
+    expect(
+      runCli([
+        "ingest",
+        source,
+        "--case",
+        caseDirectory,
+        "--include-tier-2",
+        "--json",
+      ]).status,
+    ).toBe(0);
+
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    // AC5: unsupported backends make the run partial and report explicit
+    // unavailable reasons rather than an empty result.
+    expect(analysis.status).toBe(2);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      exitState: "partial",
+      cache: {
+        status: "partial",
+        analysedProfileCount: 1,
+        unavailableProfileCount: 2,
+        entryFindingCount: 1,
+      },
+    });
+
+    // No Findings are produced for the unsupported backends; only the Simple
+    // Cache Profile contributes one entry.
+    const findings = parseJson<CachePage>(
+      runCli(["cache", "--case", caseDirectory, "--json"]).stdout,
+    );
+    expect(findings.items).toHaveLength(1);
+    expect(findings.items[0]?.profile).toBe("Profile 2");
+  });
+
+  it("scales to a large Simple Cache with bounded, streamed extraction", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-cache-scale-"));
+    temporaryRoots.push(root);
+    const source = join(root, "source");
+    await mkdir(source, { recursive: true });
+    await writeFile(join(source, "Local State"), "{}\n");
+    const cacheData = join(source, "Default", "Cache", "Cache_Data");
+    await mkdir(cacheData, { recursive: true });
+
+    const count = 250;
+    const indexRecords: {
+      key: string;
+      lastUsedUtcMillis: number;
+      entrySizeBytes: number;
+    }[] = [];
+    for (let index = 0; index < count; index += 1) {
+      const key = `1/0/https://scale.example/asset-${index}.bin`;
+      await writeCacheFile(
+        cacheData,
+        `${entryHash(key)}_0`,
+        buildSimpleEntry(key, Buffer.from(`payload-${index}`)),
+      );
+      indexRecords.push({
+        key,
+        lastUsedUtcMillis: Date.UTC(2024, 0, 1) + index * 1000,
+        entrySizeBytes: 256,
+      });
+    }
+    await writeCacheFile(
+      cacheData,
+      "index-dir/the-real-index",
+      buildRealIndex(indexRecords),
+    );
+
+    const caseDirectory = join(root, "CASE-CACHE-SCALE");
+    expect(
+      runCli([
+        "ingest",
+        source,
+        "--case",
+        caseDirectory,
+        "--include-tier-2",
+        "--json",
+      ]).status,
+    ).toBe(0);
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
+      cache: { entryFindingCount: count, payloadFileCount: count },
+    });
+
+    // AC6: the query is bounded; the whole result set is walked in fixed-size
+    // keyset pages rather than a single unbounded read.
+    let cursor: string | null = null;
+    let seen = 0;
+    let pages = 0;
+    do {
+      const page: CachePage = parseJson<CachePage>(
+        runCli([
+          "cache",
+          "--case",
+          caseDirectory,
+          "--sort",
+          "entry-hash",
+          "--limit",
+          "50",
+          ...(cursor === null ? [] : ["--after", cursor]),
+          "--json",
+        ]).stdout,
+      );
+      expect(page.items.length).toBeLessThanOrEqual(50);
+      seen += page.items.length;
+      cursor = page.nextCursor;
+      pages += 1;
+      expect(pages).toBeLessThanOrEqual(10);
+    } while (cursor !== null);
+    expect(seen).toBe(count);
+  });
+});

--- a/e2e/cache-cli.test.ts
+++ b/e2e/cache-cli.test.ts
@@ -304,7 +304,7 @@ describe("compiled analyzer CLI Cache backends", () => {
         status: "complete",
         analysedProfileCount: 1,
         unavailableProfileCount: 0,
-        entryFindingCount: 3,
+        findingCount: 3,
         candidateCount: 2,
         payloadFileCount: 4,
       },
@@ -504,7 +504,7 @@ describe("compiled analyzer CLI Cache backends", () => {
         status: "partial",
         analysedProfileCount: 1,
         unavailableProfileCount: 2,
-        entryFindingCount: 1,
+        findingCount: 1,
       },
     });
 
@@ -565,7 +565,7 @@ describe("compiled analyzer CLI Cache backends", () => {
     const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
     expect(analysis.status).toBe(0);
     expect(parseJson<Record<string, unknown>>(analysis.stdout)).toMatchObject({
-      cache: { entryFindingCount: count, payloadFileCount: count },
+      cache: { findingCount: count, payloadFileCount: count },
     });
 
     // AC6: the query is bounded; the whole result set is walked in fixed-size


### PR DESCRIPTION
Closes #182.

Adds a **Cache** artifact that classifies each Profile cache directory (`<Profile>/Cache/Cache_Data`) by its on-disk contents rather than the Source platform, extracts the supported **Simple Cache** backend to exact entry Findings, and preserves doomed/evicted evidence as Candidates. Mirrors the established parser/query/persistence contracts (TYPE-first column, search + keyset pagination, multi-Profile, distinct empty/absent/unavailable, binary payloads as separately hashed files).

### Acceptance criteria → where

- **AC1 — backend detection on every platform.** `core/src/cache-format.ts#detectCacheBackend` reads magic numbers and file names (blockfile `index` magic `0xC103CAC3`, Simple `the-real-index`/entry `0xfcfb6d1ba7725c30`, SQLite header, else `unknown`). Covered by `core/test/cache-format.test.ts` and the e2e blockfile/SQL routing test.
- **AC2 — exact entry metadata/keys/timestamps/states/payload refs.** `parseSimpleEntryFile` decodes the `SimpleFileHeader`/`SimpleFileEOF` layout (key, SuperFastHash `key_hash`, key SHA-256, stream sizes, stream-1 CRC32, body). `parseSimpleIndex` decodes the `the-real-index` `base::Pickle` (`EntryMetadata` last-used time + 256-byte-granular size) with CRC validation. Fields asserted byte-exact against constructed ground-truth fixtures faithful to the recorded Chromium format (`net/disk_cache/simple/*`).
- **AC3 — payloads as separate hashed files.** Response bodies (stream 1) are written to `cache-payloads/<sha256>` and referenced by digest + path; rows never inline base64. Asserted on disk in the e2e test.
- **AC4 — allocated-deleted/evicted/doomed as Candidates, never promoted.** On-disk entry files absent from the index → `doomed_entry` (`allocated_deleted_or_doomed`); index records with no recoverable file → `evicted_reference`; unreadable entry files → `unreadable_entry`. All are ranked `Candidate`s with supporting counts and resolvable Provenance; the query proves they carry no `findingKind`.
- **AC5 — unsupported backend/platform → explicit unavailable, not empty.** Blockfile (`cache_backend_unsupported:blockfile[:entries=N]`), SQL (`cache_backend_unsupported:sql`), unrecognized (`cache_backend_unrecognized`), and uncollected tier-2 (`cache_not_in_working_copy`) all return typed unavailable artifacts; absent caches stay `absent`.
- **AC6 — bounded queries + streamed extraction + scale gate.** `queryCache` uses fingerprinted keyset pagination (limit 1–100); payloads are extracted one entry at a time. A 250-entry scale test walks the whole set in fixed 50-row pages.

### Notes

- Analyzer stays read-only and offline; no coupling to the Collector, no network, no Python.
- Cache is a **tier-2** artifact, so extraction requires `ingest --include-tier-2`.
- Simple Cache is the fully-extracted backend; blockfile and SQL Cache are detected and reported as explicit unavailable per AC5.
- `pnpm verify` green (format, lint, typecheck, 130 tests across 25 files).

No research scaffolding (`CONTEXT.md` etc.) added; targets `v2` only.