### PR TITLE
feat(topics): classify browsing topics locally as ranked Candidates

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -18,6 +18,7 @@ import {
   queryFavicons,
   queryHistory,
   queryMetadata,
+  queryTopicCandidates,
   queryTopSites,
   renderReport,
   type AutofillDirection,
@@ -37,6 +38,8 @@ import {
   type DownloadSort,
   type FaviconDirection,
   type FaviconSort,
+  type TopicCandidateDirection,
+  type TopicCandidateSort,
   type TopSiteDirection,
   type TopSiteSort,
   type DeclaredOriginOs,
@@ -77,6 +80,7 @@ const USAGE = `Usage:
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix top-sites --case <case-directory>
+  forensix topic-candidates --case <case-directory> [--label <topic-id>] [--sort rank|supporting|label|profile]
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <rank|url|title|profile>]
@@ -153,6 +157,7 @@ const FLAG_OPTIONS = new Set([
   "--csv",
   "--include-secrets",
   "--decrypt",
+  "--no-topic-classification",
 ]);
 const VALUE_OPTIONS = new Set([
   "--case",
@@ -185,6 +190,7 @@ const VALUE_OPTIONS = new Set([
   "--extract",
   "--key-material",
   "--recipient-key",
+  "--label",
 ]);
 const REPEATABLE_OPTIONS = new Set(["--profile", "--collection"]);
 
@@ -408,6 +414,7 @@ async function run(arguments_: readonly string[]): Promise<number> {
         "--decrypt",
         "--key-material",
         "--recipient-key",
+        "--no-topic-classification",
       ]),
     );
     if (parsed.positionals.length !== 0) {
@@ -417,6 +424,10 @@ async function run(arguments_: readonly string[]): Promise<number> {
       );
     }
     const decryptionEnabled = hasOption(parsed, "--decrypt");
+    const topicClassificationEnabled = !hasOption(
+      parsed,
+      "--no-topic-classification",
+    );
     const keyMaterialPath = optionValue(parsed, "--key-material");
     const recipientKeyPath = optionValue(parsed, "--recipient-key");
     if (
@@ -439,6 +450,7 @@ async function run(arguments_: readonly string[]): Promise<number> {
       decryptionEnabled,
       ...(keyMaterialPath === undefined ? {} : { keyMaterialPath }),
       ...(recipientKeyPath === undefined ? {} : { recipientKeyPath }),
+      topicClassification: { enabled: topicClassificationEnabled },
       invocation: arguments_,
     });
     process.stdout.write(`${JSON.stringify(result)}\n`);
@@ -742,6 +754,54 @@ async function run(arguments_: readonly string[]): Promise<number> {
       ] as const) as TopSiteSort | undefined,
       direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
         | TopSiteDirection
+        | undefined,
+      limit: integerOption(parsed, "--limit"),
+      after: optionValue(parsed, "--after"),
+    });
+    process.stdout.write(`${JSON.stringify(result)}\n`);
+    return 0;
+  }
+
+  if (parsed.command === "topic-candidates") {
+    assertAllowedOptions(
+      parsed,
+      new Set([
+        "--case",
+        "--json",
+        "--profile",
+        "--search",
+        "--commit-state",
+        "--label",
+        "--sort",
+        "--direction",
+        "--limit",
+        "--after",
+      ]),
+    );
+    if (parsed.positionals.length !== 0) {
+      throw new ForensixError(
+        "INVALID_ARGUMENT",
+        "The topic-candidates command accepts no positional values.",
+      );
+    }
+    const result = queryTopicCandidates({
+      caseDirectory: requiredCasePath(parsed),
+      profiles: optionValues(parsed, "--profile"),
+      search: optionValue(parsed, "--search"),
+      commitState: enumOption(parsed, "--commit-state", [
+        "committed",
+        "wal_resident",
+        "journal_resident",
+      ] as const) as CommitState | undefined,
+      label: optionValue(parsed, "--label"),
+      sort: enumOption(parsed, "--sort", [
+        "rank",
+        "supporting",
+        "label",
+        "profile",
+      ] as const) as TopicCandidateSort | undefined,
+      direction: enumOption(parsed, "--direction", ["asc", "desc"] as const) as
+        | TopicCandidateDirection
         | undefined,
       limit: integerOption(parsed, "--limit"),
       after: optionValue(parsed, "--after"),

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -80,10 +80,16 @@ const USAGE = `Usage:
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix top-sites --case <case-directory>
-  forensix topic-candidates --case <case-directory> [--label <topic-id>] [--sort rank|supporting|label|profile]
                    [--profile <profile>]... [--search <text>]
                    [--commit-state <committed|wal_resident|journal_resident>]
                    [--sort <rank|url|title|profile>]
+                   [--direction <asc|desc>]
+                   [--limit <1-100>] [--after <cursor>] [--json]
+  forensix topic-candidates --case <case-directory>
+                   [--profile <profile>]... [--search <text>]
+                   [--commit-state <committed|wal_resident|journal_resident>]
+                   [--label <topic-id>]
+                   [--sort <rank|supporting|label|profile>]
                    [--direction <asc|desc>]
                    [--limit <1-100>] [--after <cursor>] [--json]
   forensix autofill --case <case-directory>

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -409,8 +409,9 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ),
       rank INTEGER NOT NULL CHECK (rank > 0),
       supporting_count INTEGER NOT NULL CHECK (supporting_count > 0),
+      -- topic-specific projection of fields.topicLabel, kept as a column so the
+      -- Candidate query can filter and sort by label without parsing JSON.
       topic_label TEXT,
-      special_category INTEGER NOT NULL DEFAULT 0 CHECK (special_category IN (0, 1)),
       provenance_json TEXT NOT NULL,
       fields_json TEXT NOT NULL,
       search_text TEXT NOT NULL
@@ -1017,19 +1018,14 @@ function insertCandidate(
   row: PersistedCandidate,
 ): void {
   const candidate = row.candidate;
-  // Denormalise the topic label and special-category flag into columns so the
-  // Candidate query can filter and sort on them without parsing JSON per row.
-  // They are a projection of `fields`, never a second source of truth.
+  // Denormalise the topic label into a column so the Candidate query can filter
+  // and sort by it without parsing JSON per row. It is a projection of
+  // `fields.topicLabel`, never a second source of truth.
   const labelField = candidate.fields.topicLabel;
   const topicLabel =
     labelField !== undefined && labelField.state === "value"
       ? String(labelField.value)
       : null;
-  const scField = candidate.fields.specialCategory;
-  const specialCategory =
-    scField !== undefined && scField.state === "value" && scField.value === true
-      ? 1
-      : 0;
   statement.run(
     artifactResultId,
     runId,
@@ -1040,7 +1036,6 @@ function insertCandidate(
     candidate.rank,
     candidate.count,
     topicLabel,
-    specialCategory,
     JSON.stringify(candidate.provenance),
     JSON.stringify(candidate.fields),
     row.searchText,
@@ -1368,9 +1363,8 @@ export function storeHistoryAnalysis(
         `INSERT INTO forensic_candidates
            (artifact_result_id, run_id, record_type, candidate_kind,
             profile_path, commit_state, rank, supporting_count,
-            topic_label, special_category, provenance_json, fields_json,
-            search_text)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            topic_label, provenance_json, fields_json, search_text)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       const deactivatePrevious = database.prepare(
         `UPDATE history_artifact_results

--- a/core/src/case-findings.ts
+++ b/core/src/case-findings.ts
@@ -409,10 +409,21 @@ export function initializeFindingSchema(database: DatabaseSync): void {
       ),
       rank INTEGER NOT NULL CHECK (rank > 0),
       supporting_count INTEGER NOT NULL CHECK (supporting_count > 0),
+      topic_label TEXT,
+      special_category INTEGER NOT NULL DEFAULT 0 CHECK (special_category IN (0, 1)),
       provenance_json TEXT NOT NULL,
       fields_json TEXT NOT NULL,
       search_text TEXT NOT NULL
     ) STRICT;
+
+    CREATE INDEX IF NOT EXISTS forensic_candidates_rank_query
+      ON forensic_candidates(candidate_kind, rank, candidate_id);
+    CREATE INDEX IF NOT EXISTS forensic_candidates_supporting_query
+      ON forensic_candidates(candidate_kind, supporting_count, candidate_id);
+    CREATE INDEX IF NOT EXISTS forensic_candidates_label_query
+      ON forensic_candidates(candidate_kind, COALESCE(topic_label, ''), candidate_id);
+    CREATE INDEX IF NOT EXISTS forensic_candidates_profile_query
+      ON forensic_candidates(candidate_kind, profile_path, commit_state, candidate_id);
 
     CREATE TABLE IF NOT EXISTS login_data_artifact_results (
       artifact_result_id INTEGER PRIMARY KEY,
@@ -1006,6 +1017,19 @@ function insertCandidate(
   row: PersistedCandidate,
 ): void {
   const candidate = row.candidate;
+  // Denormalise the topic label and special-category flag into columns so the
+  // Candidate query can filter and sort on them without parsing JSON per row.
+  // They are a projection of `fields`, never a second source of truth.
+  const labelField = candidate.fields.topicLabel;
+  const topicLabel =
+    labelField !== undefined && labelField.state === "value"
+      ? String(labelField.value)
+      : null;
+  const scField = candidate.fields.specialCategory;
+  const specialCategory =
+    scField !== undefined && scField.state === "value" && scField.value === true
+      ? 1
+      : 0;
   statement.run(
     artifactResultId,
     runId,
@@ -1015,6 +1039,8 @@ function insertCandidate(
     row.commitState,
     candidate.rank,
     candidate.count,
+    topicLabel,
+    specialCategory,
     JSON.stringify(candidate.provenance),
     JSON.stringify(candidate.fields),
     row.searchText,
@@ -1342,8 +1368,9 @@ export function storeHistoryAnalysis(
         `INSERT INTO forensic_candidates
            (artifact_result_id, run_id, record_type, candidate_kind,
             profile_path, commit_state, rank, supporting_count,
-            provenance_json, fields_json, search_text)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            topic_label, special_category, provenance_json, fields_json,
+            search_text)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       );
       const deactivatePrevious = database.prepare(
         `UPDATE history_artifact_results

--- a/core/src/history-topic-classification.ts
+++ b/core/src/history-topic-classification.ts
@@ -1,0 +1,177 @@
+import type { HistoryArtifactWrite } from "./case-findings.js";
+import {
+  createTopicClassifier,
+  type EmbeddingEngine,
+  type TopicCandidateInput,
+  type TopicClassifierUnavailableReason,
+} from "./topic-candidates.js";
+import { loadTopicEngine } from "./topic-candidates-onnx.js";
+
+/**
+ * The topic-classification pass for History analysis, kept out of the History
+ * orchestrator: it is a self-contained topic-domain concern that reads the
+ * already-built distinct-URL summary Findings and attaches ranked Candidates.
+ * It never writes a Finding, so disabling it leaves every source artifact row
+ * byte-for-byte unchanged.
+ */
+
+export interface TopicClassificationSetting {
+  readonly enabled?: boolean;
+  /** Inject an engine (tests, alternate deployments). Overrides the loader. */
+  readonly engine?: EmbeddingEngine;
+}
+
+/**
+ * Outcome of the local topic classifier. `disabled` and every `unavailable`
+ * reason are first-class recorded states: the History analysis is complete and
+ * queryable regardless, and no classifier output is ever a Finding.
+ */
+export interface TopicCandidateSummary {
+  readonly status: "complete" | "disabled" | "unavailable";
+  readonly reason: TopicClassifierUnavailableReason | null;
+  readonly classifiedUrlCount: number;
+  readonly candidateCount: number;
+  readonly modelId: string | null;
+  readonly modelRevision: string | null;
+}
+
+type EngineIdentity = {
+  readonly modelId: string;
+  readonly modelRevision: string;
+};
+
+function disabledSummary(): TopicCandidateSummary {
+  return {
+    status: "disabled",
+    reason: null,
+    classifiedUrlCount: 0,
+    candidateCount: 0,
+    modelId: null,
+    modelRevision: null,
+  };
+}
+
+function unavailableSummary(
+  reason: TopicClassifierUnavailableReason,
+  engine?: EngineIdentity,
+): TopicCandidateSummary {
+  return {
+    status: "unavailable",
+    reason,
+    classifiedUrlCount: 0,
+    candidateCount: 0,
+    modelId: engine?.modelId ?? null,
+    modelRevision: engine?.modelRevision ?? null,
+  };
+}
+
+function completeSummary(
+  engine: EngineIdentity,
+  classifiedUrlCount: number,
+  candidateCount: number,
+): TopicCandidateSummary {
+  return {
+    status: "complete",
+    reason: null,
+    classifiedUrlCount,
+    candidateCount,
+    modelId: engine.modelId,
+    modelRevision: engine.modelRevision,
+  };
+}
+
+function topicInputsFromArtifact(
+  artifact: HistoryArtifactWrite,
+): TopicCandidateInput[] {
+  const inputs: TopicCandidateInput[] = [];
+  // Classification consumes the already-built distinct-URL summaries. It reads
+  // Findings but never writes them: the summary Findings are identical whether
+  // or not the classifier runs, so disabling classification cannot perturb a
+  // single source artifact row.
+  for (const persisted of artifact.findings) {
+    const finding = persisted.finding;
+    if (finding.findingKind !== "history_most_visited_summary") {
+      continue;
+    }
+    const urlField = finding.fields.url;
+    const titleField = finding.fields.title;
+    const countField = finding.fields.supportingVisitCount;
+    const url =
+      urlField !== undefined && urlField.state === "value"
+        ? String(urlField.value)
+        : null;
+    const title =
+      titleField !== undefined && titleField.state === "value"
+        ? String(titleField.value)
+        : null;
+    const rawCount =
+      countField !== undefined && countField.state === "value"
+        ? Number(countField.value)
+        : 1;
+    inputs.push({
+      url,
+      title,
+      profile: finding.profile,
+      commitState: finding.commitState,
+      provenance: finding.provenance,
+      supportingCount:
+        Number.isSafeInteger(rawCount) && rawCount >= 1 ? rawCount : 1,
+    });
+  }
+  return inputs;
+}
+
+export async function classifyHistoryTopics(
+  artifacts: readonly HistoryArtifactWrite[],
+  setting: TopicClassificationSetting | undefined,
+): Promise<{
+  readonly artifacts: readonly HistoryArtifactWrite[];
+  readonly summary: TopicCandidateSummary;
+}> {
+  if ((setting?.enabled ?? true) === false) {
+    return { artifacts, summary: disabledSummary() };
+  }
+  const engineOrUnavailable = setting?.engine ?? (await loadTopicEngine());
+  if ("available" in engineOrUnavailable) {
+    return {
+      artifacts,
+      summary: unavailableSummary(engineOrUnavailable.reason),
+    };
+  }
+  // Prepare the classifier once: the label anchors depend only on the engine,
+  // so embedding them per artifact would be wasted work. Anchor-embedding
+  // failure surfaces here as a typed unavailability.
+  const prepared = await createTopicClassifier(engineOrUnavailable);
+  if ("available" in prepared) {
+    return {
+      artifacts,
+      summary: unavailableSummary(prepared.reason, engineOrUnavailable),
+    };
+  }
+  const withCandidates: HistoryArtifactWrite[] = [];
+  let classifiedUrlCount = 0;
+  let candidateCount = 0;
+  for (const artifact of artifacts) {
+    if (artifact.status !== "complete") {
+      withCandidates.push(artifact);
+      continue;
+    }
+    const inputs = topicInputsFromArtifact(artifact);
+    classifiedUrlCount += inputs.length;
+    const result = await prepared.classifyBatch(inputs);
+    if (!Array.isArray(result)) {
+      // An inference failure keeps every Finding intact: return the original
+      // artifacts with no Candidates attached and a typed reason.
+      return {
+        artifacts,
+        summary: unavailableSummary(result.reason, prepared),
+      };
+    }
+    candidateCount += result.length;
+    withCandidates.push({ ...artifact, candidates: result });
+  }
+  return {
+    artifacts: withCandidates,
+    summary: completeSummary(prepared, classifiedUrlCount, candidateCount),
+  };
+}

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -53,7 +53,7 @@ import {
   type SourceRowProvenance,
 } from "./forensic-model.js";
 import {
-  classifyTopicCandidates,
+  createTopicClassifier,
   type EmbeddingEngine,
   type TopicCandidateInput,
   type TopicClassifierUnavailableReason,
@@ -1366,7 +1366,23 @@ async function classifyHistoryTopics(
       },
     };
   }
-  const engine = engineOrUnavailable;
+  // Prepare the classifier once: the label anchors depend only on the engine,
+  // so embedding them per artifact would be wasted work. Anchor-embedding
+  // failure surfaces here as a typed unavailability.
+  const prepared = await createTopicClassifier(engineOrUnavailable);
+  if ("available" in prepared) {
+    return {
+      artifacts,
+      summary: {
+        status: "unavailable",
+        reason: prepared.reason,
+        classifiedUrlCount: 0,
+        candidateCount: 0,
+        modelId: engineOrUnavailable.modelId,
+        modelRevision: engineOrUnavailable.modelRevision,
+      },
+    };
+  }
   const withCandidates: HistoryArtifactWrite[] = [];
   let classifiedUrlCount = 0;
   let candidateCount = 0;
@@ -1377,7 +1393,7 @@ async function classifyHistoryTopics(
     }
     const inputs = topicInputsFromArtifact(artifact);
     classifiedUrlCount += inputs.length;
-    const result = await classifyTopicCandidates(engine, inputs);
+    const result = await prepared.classifyBatch(inputs);
     if (!Array.isArray(result)) {
       // An inference failure keeps every Finding intact: return the original
       // artifacts with no Candidates attached and a typed reason.
@@ -1388,8 +1404,8 @@ async function classifyHistoryTopics(
           reason: result.reason,
           classifiedUrlCount: 0,
           candidateCount: 0,
-          modelId: engine.modelId,
-          modelRevision: engine.modelRevision,
+          modelId: prepared.modelId,
+          modelRevision: prepared.modelRevision,
         },
       };
     }
@@ -1403,8 +1419,8 @@ async function classifyHistoryTopics(
       reason: null,
       classifiedUrlCount,
       candidateCount,
-      modelId: engine.modelId,
-      modelRevision: engine.modelRevision,
+      modelId: prepared.modelId,
+      modelRevision: prepared.modelRevision,
     },
   };
 }

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -52,13 +52,12 @@ import {
   type Provenance,
   type SourceRowProvenance,
 } from "./forensic-model.js";
+import { type EmbeddingEngine } from "./topic-candidates.js";
 import {
-  createTopicClassifier,
-  type EmbeddingEngine,
-  type TopicCandidateInput,
-  type TopicClassifierUnavailableReason,
-} from "./topic-candidates.js";
-import { loadTopicEngine } from "./topic-candidates-onnx.js";
+  classifyHistoryTopics,
+  type TopicCandidateSummary,
+} from "./history-topic-classification.js";
+export type { TopicCandidateSummary } from "./history-topic-classification.js";
 import {
   readHistoryPasses,
   type HistorySchema,
@@ -135,20 +134,6 @@ export interface HistoryAnalysisSummary {
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
   readonly declaredOriginOsConflict: boolean;
-}
-
-/**
- * Outcome of the local topic classifier. `disabled` and every `unavailable`
- * reason are first-class recorded states: the History analysis is complete and
- * queryable regardless, and no classifier output is ever a Finding.
- */
-export interface TopicCandidateSummary {
-  readonly status: "complete" | "disabled" | "unavailable";
-  readonly reason: TopicClassifierUnavailableReason | null;
-  readonly classifiedUrlCount: number;
-  readonly candidateCount: number;
-  readonly modelId: string | null;
-  readonly modelRevision: string | null;
 }
 
 export interface CookieAnalysisSummary {
@@ -1288,141 +1273,6 @@ async function analyseProfile(options: {
       reason,
     );
   }
-}
-
-function topicInputsFromArtifact(
-  artifact: HistoryArtifactWrite,
-): TopicCandidateInput[] {
-  const inputs: TopicCandidateInput[] = [];
-  // Classification consumes the already-built distinct-URL summaries. It reads
-  // Findings but never writes them: the summary Findings are identical whether
-  // or not the classifier runs, so disabling classification cannot perturb a
-  // single source artifact row.
-  for (const persisted of artifact.findings) {
-    const finding = persisted.finding;
-    if (finding.findingKind !== "history_most_visited_summary") {
-      continue;
-    }
-    const urlField = finding.fields.url;
-    const titleField = finding.fields.title;
-    const countField = finding.fields.supportingVisitCount;
-    const url =
-      urlField !== undefined && urlField.state === "value"
-        ? String(urlField.value)
-        : null;
-    const title =
-      titleField !== undefined && titleField.state === "value"
-        ? String(titleField.value)
-        : null;
-    const rawCount =
-      countField !== undefined && countField.state === "value"
-        ? Number(countField.value)
-        : 1;
-    inputs.push({
-      url,
-      title,
-      profile: finding.profile,
-      commitState: finding.commitState,
-      provenance: finding.provenance,
-      supportingCount:
-        Number.isSafeInteger(rawCount) && rawCount >= 1 ? rawCount : 1,
-    });
-  }
-  return inputs;
-}
-
-async function classifyHistoryTopics(
-  artifacts: readonly HistoryArtifactWrite[],
-  setting: AnalyseCaseOptions["topicClassification"],
-): Promise<{
-  readonly artifacts: readonly HistoryArtifactWrite[];
-  readonly summary: TopicCandidateSummary;
-}> {
-  const enabled = setting?.enabled ?? true;
-  if (!enabled) {
-    return {
-      artifacts,
-      summary: {
-        status: "disabled",
-        reason: null,
-        classifiedUrlCount: 0,
-        candidateCount: 0,
-        modelId: null,
-        modelRevision: null,
-      },
-    };
-  }
-  const engineOrUnavailable = setting?.engine ?? (await loadTopicEngine());
-  if ("available" in engineOrUnavailable) {
-    return {
-      artifacts,
-      summary: {
-        status: "unavailable",
-        reason: engineOrUnavailable.reason,
-        classifiedUrlCount: 0,
-        candidateCount: 0,
-        modelId: null,
-        modelRevision: null,
-      },
-    };
-  }
-  // Prepare the classifier once: the label anchors depend only on the engine,
-  // so embedding them per artifact would be wasted work. Anchor-embedding
-  // failure surfaces here as a typed unavailability.
-  const prepared = await createTopicClassifier(engineOrUnavailable);
-  if ("available" in prepared) {
-    return {
-      artifacts,
-      summary: {
-        status: "unavailable",
-        reason: prepared.reason,
-        classifiedUrlCount: 0,
-        candidateCount: 0,
-        modelId: engineOrUnavailable.modelId,
-        modelRevision: engineOrUnavailable.modelRevision,
-      },
-    };
-  }
-  const withCandidates: HistoryArtifactWrite[] = [];
-  let classifiedUrlCount = 0;
-  let candidateCount = 0;
-  for (const artifact of artifacts) {
-    if (artifact.status !== "complete") {
-      withCandidates.push(artifact);
-      continue;
-    }
-    const inputs = topicInputsFromArtifact(artifact);
-    classifiedUrlCount += inputs.length;
-    const result = await prepared.classifyBatch(inputs);
-    if (!Array.isArray(result)) {
-      // An inference failure keeps every Finding intact: return the original
-      // artifacts with no Candidates attached and a typed reason.
-      return {
-        artifacts,
-        summary: {
-          status: "unavailable",
-          reason: result.reason,
-          classifiedUrlCount: 0,
-          candidateCount: 0,
-          modelId: prepared.modelId,
-          modelRevision: prepared.modelRevision,
-        },
-      };
-    }
-    candidateCount += result.length;
-    withCandidates.push({ ...artifact, candidates: result });
-  }
-  return {
-    artifacts: withCandidates,
-    summary: {
-      status: "complete",
-      reason: null,
-      classifiedUrlCount,
-      candidateCount,
-      modelId: prepared.modelId,
-      modelRevision: prepared.modelRevision,
-    },
-  };
 }
 
 export async function analyseCase(

--- a/core/src/history.ts
+++ b/core/src/history.ts
@@ -53,6 +53,13 @@ import {
   type SourceRowProvenance,
 } from "./forensic-model.js";
 import {
+  classifyTopicCandidates,
+  type EmbeddingEngine,
+  type TopicCandidateInput,
+  type TopicClassifierUnavailableReason,
+} from "./topic-candidates.js";
+import { loadTopicEngine } from "./topic-candidates-onnx.js";
+import {
   readHistoryPasses,
   type HistorySchema,
   type HistorySourceTable,
@@ -94,6 +101,18 @@ export interface AnalyseCaseOptions {
   readonly keyMaterialPath?: string;
   /** Recipient X25519 private key (PEM) used to unseal captured key material. */
   readonly recipientKeyPath?: string;
+  /**
+   * Local topic classification (issue #184). Enabled by default; the settled
+   * ONNX model runs only when its optional runtime and model directory are
+   * present, and a typed unavailability is recorded otherwise. Disabling it, or
+   * removing the model, leaves every source artifact row byte-for-byte
+   * unchanged — Candidates are additive and live in a separate collection.
+   */
+  readonly topicClassification?: {
+    readonly enabled?: boolean;
+    /** Inject an engine (tests, alternate deployments). Overrides the loader. */
+    readonly engine?: EmbeddingEngine;
+  };
 }
 
 export interface DecryptionSummary {
@@ -112,10 +131,24 @@ export interface HistoryAnalysisSummary {
   readonly committedVisitCount: number;
   readonly recoveredVisitCount: number;
   readonly findingCount: number;
-  readonly candidateCount: 0;
+  readonly candidateCount: number;
   readonly declaredTimezone: string;
   readonly declaredOriginOs: DeclaredOriginOs | null;
   readonly declaredOriginOsConflict: boolean;
+}
+
+/**
+ * Outcome of the local topic classifier. `disabled` and every `unavailable`
+ * reason are first-class recorded states: the History analysis is complete and
+ * queryable regardless, and no classifier output is ever a Finding.
+ */
+export interface TopicCandidateSummary {
+  readonly status: "complete" | "disabled" | "unavailable";
+  readonly reason: TopicClassifierUnavailableReason | null;
+  readonly classifiedUrlCount: number;
+  readonly candidateCount: number;
+  readonly modelId: string | null;
+  readonly modelRevision: string | null;
 }
 
 export interface CookieAnalysisSummary {
@@ -262,6 +295,7 @@ export interface AnalyseCaseResult extends WorkingCopyVerification {
   readonly bookmarks: BookmarksAnalysisSummary;
   readonly cache: CacheAnalysisSummary;
   readonly decryption: DecryptionSummary;
+  readonly topicCandidates: TopicCandidateSummary;
 }
 
 interface ManifestIdentity {
@@ -1256,6 +1290,125 @@ async function analyseProfile(options: {
   }
 }
 
+function topicInputsFromArtifact(
+  artifact: HistoryArtifactWrite,
+): TopicCandidateInput[] {
+  const inputs: TopicCandidateInput[] = [];
+  // Classification consumes the already-built distinct-URL summaries. It reads
+  // Findings but never writes them: the summary Findings are identical whether
+  // or not the classifier runs, so disabling classification cannot perturb a
+  // single source artifact row.
+  for (const persisted of artifact.findings) {
+    const finding = persisted.finding;
+    if (finding.findingKind !== "history_most_visited_summary") {
+      continue;
+    }
+    const urlField = finding.fields.url;
+    const titleField = finding.fields.title;
+    const countField = finding.fields.supportingVisitCount;
+    const url =
+      urlField !== undefined && urlField.state === "value"
+        ? String(urlField.value)
+        : null;
+    const title =
+      titleField !== undefined && titleField.state === "value"
+        ? String(titleField.value)
+        : null;
+    const rawCount =
+      countField !== undefined && countField.state === "value"
+        ? Number(countField.value)
+        : 1;
+    inputs.push({
+      url,
+      title,
+      profile: finding.profile,
+      commitState: finding.commitState,
+      provenance: finding.provenance,
+      supportingCount:
+        Number.isSafeInteger(rawCount) && rawCount >= 1 ? rawCount : 1,
+    });
+  }
+  return inputs;
+}
+
+async function classifyHistoryTopics(
+  artifacts: readonly HistoryArtifactWrite[],
+  setting: AnalyseCaseOptions["topicClassification"],
+): Promise<{
+  readonly artifacts: readonly HistoryArtifactWrite[];
+  readonly summary: TopicCandidateSummary;
+}> {
+  const enabled = setting?.enabled ?? true;
+  if (!enabled) {
+    return {
+      artifacts,
+      summary: {
+        status: "disabled",
+        reason: null,
+        classifiedUrlCount: 0,
+        candidateCount: 0,
+        modelId: null,
+        modelRevision: null,
+      },
+    };
+  }
+  const engineOrUnavailable = setting?.engine ?? (await loadTopicEngine());
+  if ("available" in engineOrUnavailable) {
+    return {
+      artifacts,
+      summary: {
+        status: "unavailable",
+        reason: engineOrUnavailable.reason,
+        classifiedUrlCount: 0,
+        candidateCount: 0,
+        modelId: null,
+        modelRevision: null,
+      },
+    };
+  }
+  const engine = engineOrUnavailable;
+  const withCandidates: HistoryArtifactWrite[] = [];
+  let classifiedUrlCount = 0;
+  let candidateCount = 0;
+  for (const artifact of artifacts) {
+    if (artifact.status !== "complete") {
+      withCandidates.push(artifact);
+      continue;
+    }
+    const inputs = topicInputsFromArtifact(artifact);
+    classifiedUrlCount += inputs.length;
+    const result = await classifyTopicCandidates(engine, inputs);
+    if (!Array.isArray(result)) {
+      // An inference failure keeps every Finding intact: return the original
+      // artifacts with no Candidates attached and a typed reason.
+      return {
+        artifacts,
+        summary: {
+          status: "unavailable",
+          reason: result.reason,
+          classifiedUrlCount: 0,
+          candidateCount: 0,
+          modelId: engine.modelId,
+          modelRevision: engine.modelRevision,
+        },
+      };
+    }
+    candidateCount += result.length;
+    withCandidates.push({ ...artifact, candidates: result });
+  }
+  return {
+    artifacts: withCandidates,
+    summary: {
+      status: "complete",
+      reason: null,
+      classifiedUrlCount,
+      candidateCount,
+      modelId: engine.modelId,
+      modelRevision: engine.modelRevision,
+    },
+  };
+}
+
 export async function analyseCase(
   options: AnalyseCaseOptions,
 ): Promise<AnalyseCaseResult> {
@@ -1376,6 +1529,11 @@ export async function analyseCase(
     );
   }
 
+  const classification = await classifyHistoryTopics(
+    artifacts,
+    options.topicClassification,
+  );
+
   await verifyWorkingCopy(caseDirectory);
   const stored = storeHistoryAnalysis({
     caseDirectory,
@@ -1384,7 +1542,7 @@ export async function analyseCase(
     declaredOriginOs,
     invocation: options.invocation ?? ["analyse", "--case", caseDirectory],
     startedAt,
-    artifacts,
+    artifacts: classification.artifacts,
     cookieArtifacts,
     loginDataArtifacts,
     topSitesArtifacts,
@@ -1557,7 +1715,7 @@ export async function analyseCase(
         (count, artifact) => count + artifact.findings.length,
         0,
       ),
-      candidateCount: 0,
+      candidateCount: classification.summary.candidateCount,
       declaredTimezone,
       declaredOriginOs,
       declaredOriginOsConflict:
@@ -1754,5 +1912,6 @@ export async function analyseCase(
       keyMaterialCount: decryption.keyMaterial.length,
       keyMaterialIssueCount: keyMaterialIssues.length,
     },
+    topicCandidates: classification.summary,
   };
 }

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -69,6 +69,34 @@ export {
   type WorkingCopyVerification,
 } from "./verify.js";
 export {
+  classifyTopicCandidates,
+  topicInputText,
+  TOPIC_CANDIDATE_KIND,
+  TOPIC_TAXONOMY,
+  TOPIC_TAXONOMY_SOURCE,
+  UNCLASSIFIED_LABEL_ID,
+  type EmbeddingEngine,
+  type TopicCandidateInput,
+  type TopicClassifierOptions,
+  type TopicClassifierUnavailable,
+  type TopicClassifierUnavailableReason,
+  type TopicLabel,
+} from "./topic-candidates.js";
+export {
+  loadTopicEngine,
+  TOPIC_MODEL_DIR_ENV,
+  TOPIC_MODEL_ID,
+  TOPIC_MODEL_REVISION,
+  type LoadTopicEngineOptions,
+} from "./topic-candidates-onnx.js";
+export {
+  queryTopicCandidates,
+  type TopicCandidateDirection,
+  type TopicCandidatePage,
+  type TopicCandidateQuery,
+  type TopicCandidateSort,
+} from "./topic-candidates-query.js";
+export {
   absentField,
   createCandidate,
   createFinding,
@@ -103,6 +131,7 @@ export {
   type PreferencesAnalysisSummary,
   type BookmarksAnalysisSummary,
   type CacheAnalysisSummary,
+  type TopicCandidateSummary,
   type TopSitesAnalysisSummary,
   type WebDataAnalysisSummary,
 } from "./history.js";

--- a/core/src/index.ts
+++ b/core/src/index.ts
@@ -70,12 +70,14 @@ export {
 } from "./verify.js";
 export {
   classifyTopicCandidates,
+  createTopicClassifier,
   topicInputText,
   TOPIC_CANDIDATE_KIND,
   TOPIC_TAXONOMY,
   TOPIC_TAXONOMY_SOURCE,
   UNCLASSIFIED_LABEL_ID,
   type EmbeddingEngine,
+  type PreparedTopicClassifier,
   type TopicCandidateInput,
   type TopicClassifierOptions,
   type TopicClassifierUnavailable,

--- a/core/src/topic-candidates-onnx.ts
+++ b/core/src/topic-candidates-onnx.ts
@@ -1,0 +1,195 @@
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  EmbeddingEngine,
+  TopicClassifierUnavailable,
+} from "./topic-candidates.js";
+
+/**
+ * The settled local ONNX topic engine.
+ *
+ * The model is `minishlab/potion-base-8M` (Model2Vec / EmbeddingBag), pinned by
+ * revision, selected by the classifier bench (ChmaraX/forensix#137): a static
+ * embedding with a permissive MIT licence, a ~30 MB footprint, and — decisively
+ * for a forensic tool — cross-architecture decision parity. Inference is a single
+ * ONNX pass (`input_ids` + `offsets` -> one L2-normalised vector); topic scores
+ * are the cosine similarity of that vector to the frozen label anchors.
+ *
+ * INVARIANTS enforced here:
+ *   - No runtime network. The runtime and the model bytes are loaded from disk;
+ *     nothing is fetched. The tokeniser is created with `local_files_only`.
+ *   - No Python, no pickle, no second analysis process. `onnxruntime-node` runs
+ *     in-process; the `.sav` pickle path from ForensiX v1 is gone.
+ *   - Determinism. The session is single-threaded with basic graph optimisation,
+ *     the control the bench identified for bitwise cross-host divergence.
+ *
+ * The runtime (`onnxruntime-node`) and tokeniser (`@huggingface/transformers`)
+ * are OPTIONAL: they are loaded through a dynamic import guarded by try/catch, so
+ * a deployment without them — including this repository's default install — gets
+ * a typed {@link TopicClassifierUnavailable} rather than a crash, and History
+ * analysis stays fully usable. When they are present alongside the model
+ * directory, the same code path produces real classifications.
+ */
+
+export const TOPIC_MODEL_ID = "minishlab/potion-base-8M" as const;
+export const TOPIC_MODEL_REVISION =
+  "bf8b056651a2c21b8d2565580b8569da283cab23" as const;
+export const TOPIC_MODEL_DIR_ENV = "FORENSIX_TOPIC_MODEL_DIR" as const;
+const MODEL_FILE = join("onnx", "model.onnx");
+const MAX_LENGTH = 512;
+
+interface OrtTensorLike {
+  readonly data: ArrayLike<number>;
+}
+interface OrtSessionLike {
+  readonly inputNames: readonly string[];
+  readonly outputNames: readonly string[];
+  run(feeds: Record<string, unknown>): Promise<Record<string, OrtTensorLike>>;
+}
+interface OrtModuleLike {
+  readonly InferenceSession: {
+    create(path: string, options: unknown): Promise<OrtSessionLike>;
+  };
+  readonly Tensor: new (
+    type: string,
+    data: BigInt64Array,
+    dims: readonly number[],
+  ) => unknown;
+}
+type TokenizerFn = (
+  text: string,
+  options: Record<string, unknown>,
+) => { input_ids?: { data?: ArrayLike<number> } | ArrayLike<number> };
+
+// Loaded through non-literal specifiers so the type-checker does not try to
+// resolve the optional native modules at build time.
+async function optionalImport(specifier: string): Promise<unknown> {
+  return import(specifier);
+}
+
+function resolveModelDir(explicit?: string): string | null {
+  const dir = explicit ?? process.env[TOPIC_MODEL_DIR_ENV];
+  if (dir === undefined || dir.trim() === "") {
+    return null;
+  }
+  return dir;
+}
+
+function sha256File(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex");
+}
+
+function extractIds(encoded: ReturnType<TokenizerFn>): number[] {
+  const ids = encoded.input_ids;
+  if (ids === undefined) {
+    throw new Error("Tokenizer produced no input_ids.");
+  }
+  if (typeof ids === "object" && "data" in ids && ids.data !== undefined) {
+    return Array.from(ids.data, Number);
+  }
+  return Array.from(ids as ArrayLike<number>, Number);
+}
+
+export interface LoadTopicEngineOptions {
+  /** Model directory. Falls back to the FORENSIX_TOPIC_MODEL_DIR env var. */
+  readonly modelDir?: string;
+}
+
+/**
+ * Load the settled ONNX topic engine, or explain — with a typed reason — why it
+ * is unavailable. Never throws for an absent runtime or model; those are
+ * expected, recorded states, not failures.
+ */
+export async function loadTopicEngine(
+  options: LoadTopicEngineOptions = {},
+): Promise<EmbeddingEngine | TopicClassifierUnavailable> {
+  const modelDir = resolveModelDir(options.modelDir);
+  if (modelDir === null || !existsSync(join(modelDir, MODEL_FILE))) {
+    return { available: false, reason: "model_artifact_missing" };
+  }
+
+  let ort: OrtModuleLike;
+  let AutoTokenizer: {
+    from_pretrained(dir: string, options: unknown): Promise<TokenizerFn>;
+  };
+  try {
+    ort = (await optionalImport("onnxruntime-node")) as OrtModuleLike;
+    const transformers = (await optionalImport(
+      "@huggingface/transformers",
+    )) as {
+      AutoTokenizer: typeof AutoTokenizer;
+      env: { allowRemoteModels: boolean; allowLocalModels: boolean };
+    };
+    transformers.env.allowRemoteModels = false;
+    transformers.env.allowLocalModels = true;
+    AutoTokenizer = transformers.AutoTokenizer;
+  } catch (error) {
+    return {
+      available: false,
+      reason: "model_runtime_unavailable",
+      detail: String(error),
+    };
+  }
+
+  try {
+    const modelPath = join(modelDir, MODEL_FILE);
+    const tokenizer = await AutoTokenizer.from_pretrained(modelDir, {
+      local_files_only: true,
+    });
+    const session = await ort.InferenceSession.create(modelPath, {
+      executionProviders: ["cpu"],
+      graphOptimizationLevel: "basic",
+      intraOpNumThreads: 1,
+      interOpNumThreads: 1,
+      enableCpuMemArena: false,
+      enableMemPattern: false,
+    });
+    const modelSha256 = sha256File(modelPath);
+    void modelSha256;
+
+    const embed = async (text: string): Promise<Float32Array> => {
+      const encoded = tokenizer(text, {
+        padding: false,
+        truncation: true,
+        max_length: MAX_LENGTH,
+      });
+      const parsed = extractIds(encoded);
+      const ids = parsed.length > 0 ? parsed : [0];
+      const feeds: Record<string, unknown> = {};
+      for (const name of session.inputNames) {
+        if (name === "input_ids") {
+          feeds[name] = new ort.Tensor(
+            "int64",
+            BigInt64Array.from(ids, (value) => BigInt(value)),
+            [ids.length],
+          );
+        } else if (name === "offsets") {
+          feeds[name] = new ort.Tensor("int64", BigInt64Array.from([0n]), [1]);
+        } else {
+          throw new Error(`Unhandled ONNX input "${name}".`);
+        }
+      }
+      const output = await session.run(feeds);
+      const outputName = session.outputNames[0];
+      const first = outputName === undefined ? undefined : output[outputName];
+      if (first === undefined) {
+        throw new Error("ONNX session produced no output.");
+      }
+      return Float32Array.from(first.data, Number);
+    };
+
+    return {
+      modelId: TOPIC_MODEL_ID,
+      modelRevision: TOPIC_MODEL_REVISION,
+      embed,
+    };
+  } catch (error) {
+    return {
+      available: false,
+      reason: "model_load_failed",
+      detail: String(error),
+    };
+  }
+}

--- a/core/src/topic-candidates-onnx.ts
+++ b/core/src/topic-candidates-onnx.ts
@@ -1,5 +1,4 @@
-import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync } from "node:fs";
 import { join } from "node:path";
 
 import type {
@@ -77,10 +76,6 @@ function resolveModelDir(explicit?: string): string | null {
   return dir;
 }
 
-function sha256File(path: string): string {
-  return createHash("sha256").update(readFileSync(path)).digest("hex");
-}
-
 function extractIds(encoded: ReturnType<TokenizerFn>): number[] {
   const ids = encoded.input_ids;
   if (ids === undefined) {
@@ -146,8 +141,6 @@ export async function loadTopicEngine(
       enableCpuMemArena: false,
       enableMemPattern: false,
     });
-    const modelSha256 = sha256File(modelPath);
-    void modelSha256;
 
     const embed = async (text: string): Promise<Float32Array> => {
       const encoded = tokenizer(text, {

--- a/core/src/topic-candidates-query.ts
+++ b/core/src/topic-candidates-query.ts
@@ -1,0 +1,386 @@
+import { createHash } from "node:crypto";
+import { join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { pathToFileURL } from "node:url";
+
+import { CASE_FILENAME } from "./case.js";
+import { ForensixError } from "./errors.js";
+import {
+  createCandidate,
+  type Candidate,
+  type CommitState,
+  type ForensicFields,
+  type Provenance,
+} from "./forensic-model.js";
+import { TOPIC_CANDIDATE_KIND } from "./topic-candidates.js";
+
+/**
+ * Read-only query surface for topic Candidates.
+ *
+ * This is deliberately a separate surface from every Finding query. Candidates
+ * are ranked hypotheses, not facts: the page carries `Candidate` records
+ * (recordType `candidate`) and never `Finding` records, so no consumer of this
+ * API can mistake a classifier output for a Finding or a factual summary tile.
+ * The query mirrors the shared surface — TYPE-first (`candidateKind`), search,
+ * Profile and Commit-State filters, deterministic sort, and keyset pagination.
+ */
+
+export type TopicCandidateDirection = "asc" | "desc";
+export type TopicCandidateSort = "rank" | "supporting" | "label" | "profile";
+
+export interface TopicCandidateQuery {
+  readonly caseDirectory: string;
+  readonly profiles?: readonly string[];
+  readonly search?: string;
+  readonly commitState?: CommitState;
+  /** Filter to a single taxonomy label id (e.g. `finance_banking`). */
+  readonly label?: string;
+  readonly sort?: TopicCandidateSort;
+  readonly direction?: TopicCandidateDirection;
+  readonly limit?: number;
+  readonly after?: string;
+}
+
+export interface TopicCandidatePage {
+  readonly status: "ok";
+  readonly command: "topic-candidates";
+  readonly items: readonly Candidate[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+interface CursorPayload {
+  readonly version: 1;
+  readonly fingerprint: string;
+  readonly key: string;
+  readonly candidateId: string;
+}
+
+interface QueryRow {
+  readonly candidate_id: bigint;
+  readonly candidate_kind: string;
+  readonly profile_path: string;
+  readonly commit_state: string;
+  readonly rank: bigint;
+  readonly supporting_count: bigint;
+  readonly provenance_json: string;
+  readonly fields_json: string;
+  readonly cursor_key: string | bigint;
+}
+
+const DIRECTIONS = ["asc", "desc"] as const;
+const SORTS = ["rank", "supporting", "label", "profile"] as const;
+const COMMIT_STATES = [
+  "committed",
+  "wal_resident",
+  "journal_resident",
+] as const;
+
+interface SortDefinition {
+  readonly expression: string;
+  readonly kind: "text" | "integer";
+}
+
+const SORT_DEFINITIONS: Readonly<Record<TopicCandidateSort, SortDefinition>> = {
+  rank: { expression: "c.rank", kind: "integer" },
+  supporting: { expression: "c.supporting_count", kind: "integer" },
+  label: { expression: "COALESCE(c.topic_label, '')", kind: "text" },
+  profile: { expression: "c.profile_path", kind: "text" },
+};
+
+const SQLITE_MAX_INTEGER = 9_223_372_036_854_775_807n;
+const SQLITE_MIN_INTEGER = -9_223_372_036_854_775_808n;
+
+function queryFingerprint(input: {
+  readonly caseId: string;
+  readonly activeArtifactResultIds: readonly string[];
+  readonly profiles: readonly string[];
+  readonly search: string | null;
+  readonly commitState: CommitState | null;
+  readonly label: string | null;
+  readonly sort: TopicCandidateSort;
+  readonly direction: TopicCandidateDirection;
+}): string {
+  return createHash("sha256").update(JSON.stringify(input)).digest("hex");
+}
+
+function encodeCursor(payload: CursorPayload): string {
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  value: string,
+  expectedFingerprint: string,
+): CursorPayload {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(value, "base64url").toString("utf8"));
+  } catch (error) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Topic Candidate cursor is not valid.",
+      {},
+      { cause: error },
+    );
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !("version" in parsed) ||
+    parsed.version !== 1 ||
+    !("fingerprint" in parsed) ||
+    parsed.fingerprint !== expectedFingerprint ||
+    !("key" in parsed) ||
+    typeof parsed.key !== "string" ||
+    !("candidateId" in parsed) ||
+    typeof parsed.candidateId !== "string" ||
+    !/^[0-9]+$/.test(parsed.candidateId)
+  ) {
+    throw new ForensixError(
+      "INVALID_CURSOR",
+      "Topic Candidate cursor does not belong to this query.",
+    );
+  }
+  return parsed as CursorPayload;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  const limit = value ?? 50;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Topic Candidate --limit must be an integer from 1 through 100.",
+      { limit },
+    );
+  }
+  return limit;
+}
+
+function enumValue<const Values extends readonly string[]>(
+  value: string | undefined,
+  fallback: Values[number],
+  values: Values,
+  name: string,
+): Values[number] {
+  const result = value ?? fallback;
+  if (!values.includes(result)) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      `Topic Candidate ${name} has an unsupported value.`,
+      { value: result, allowed: values },
+    );
+  }
+  return result;
+}
+
+function activeAnalysisIdentity(database: DatabaseSync): {
+  readonly caseId: string;
+  readonly artifactResultIds: readonly string[];
+} {
+  const caseRow = database
+    .prepare("SELECT case_id FROM case_info LIMIT 1")
+    .get();
+  if (typeof caseRow?.case_id !== "string") {
+    throw new ForensixError("CASE_INVALID", "Case identity is missing.");
+  }
+  const resultRows = database
+    .prepare(
+      `SELECT artifact_result_id
+         FROM history_artifact_results
+        WHERE active = 1
+        ORDER BY artifact_result_id`,
+    )
+    .all();
+  return {
+    caseId: caseRow.case_id,
+    artifactResultIds: resultRows.map((row) => String(row.artifact_result_id)),
+  };
+}
+
+function openCase(caseDirectory: string): DatabaseSync {
+  const url = pathToFileURL(join(resolve(caseDirectory), CASE_FILENAME));
+  url.searchParams.set("immutable", "1");
+  return new DatabaseSync(url.href, { readOnly: true, readBigInts: true });
+}
+
+function candidateSchemaExists(database: DatabaseSync): boolean {
+  return (
+    database
+      .prepare(
+        "SELECT 1 AS present FROM sqlite_schema WHERE type = 'table' AND name = 'forensic_candidates'",
+      )
+      .get() !== undefined
+  );
+}
+
+function parseCandidate(row: QueryRow): Candidate {
+  let provenance: Provenance;
+  let fields: ForensicFields;
+  try {
+    provenance = JSON.parse(row.provenance_json) as Provenance;
+    fields = JSON.parse(row.fields_json) as ForensicFields;
+  } catch (error) {
+    throw new ForensixError(
+      "CASE_INVALID",
+      "Case contains invalid Candidate JSON.",
+      { candidate_id: row.candidate_id.toString() },
+      { cause: error },
+    );
+  }
+  return createCandidate({
+    candidateKind: row.candidate_kind,
+    rank: Number(row.rank),
+    count: Number(row.supporting_count),
+    provenance,
+    fields,
+  });
+}
+
+export function queryTopicCandidates(
+  input: TopicCandidateQuery,
+): TopicCandidatePage {
+  const direction = enumValue(
+    input.direction,
+    "asc",
+    DIRECTIONS,
+    "--direction",
+  );
+  const sort = enumValue(input.sort, "rank", SORTS, "--sort");
+  const commitState =
+    input.commitState === undefined
+      ? null
+      : enumValue(
+          input.commitState,
+          "committed",
+          COMMIT_STATES,
+          "--commit-state",
+        );
+  const sortDefinition = SORT_DEFINITIONS[sort];
+  const sortExpression = sortDefinition.expression;
+  const limit = normalizeLimit(input.limit);
+  const profiles = [...new Set(input.profiles ?? [])].sort();
+  if (profiles.length > 100) {
+    throw new ForensixError(
+      "INVALID_ARGUMENT",
+      "Topic Candidate queries accept at most 100 Profile filters.",
+      { profile_count: profiles.length },
+    );
+  }
+  const label = input.label ?? null;
+  const search = input.search?.toLocaleLowerCase("en-US") ?? null;
+
+  const database = openCase(input.caseDirectory);
+  try {
+    if (!candidateSchemaExists(database)) {
+      throw new ForensixError(
+        "ANALYSIS_NOT_FOUND",
+        "Case has no analysis. Run analyse first.",
+      );
+    }
+    const identity = activeAnalysisIdentity(database);
+    const fingerprint = queryFingerprint({
+      caseId: identity.caseId,
+      activeArtifactResultIds: identity.artifactResultIds,
+      profiles,
+      search,
+      commitState,
+      label,
+      sort,
+      direction,
+    });
+    const cursor =
+      input.after === undefined ? null : decodeCursor(input.after, fingerprint);
+
+    const conditions = [
+      "r.active = 1",
+      "c.candidate_kind = ?",
+      "c.record_type = 'candidate'",
+    ];
+    const parameters: (string | bigint)[] = [TOPIC_CANDIDATE_KIND];
+    if (profiles.length > 0) {
+      conditions.push(
+        `c.profile_path IN (${profiles.map(() => "?").join(", ")})`,
+      );
+      parameters.push(...profiles);
+    }
+    if (commitState !== null) {
+      conditions.push("c.commit_state = ?");
+      parameters.push(commitState);
+    }
+    if (label !== null) {
+      conditions.push("c.topic_label = ?");
+      parameters.push(label);
+    }
+    if (search !== null) {
+      conditions.push("instr(c.search_text, ?) > 0");
+      parameters.push(search);
+    }
+    if (cursor !== null) {
+      const operator = direction === "asc" ? ">" : "<";
+      conditions.push(
+        `(${sortExpression} ${operator} ? OR ` +
+          `(${sortExpression} = ? AND c.candidate_id ${operator} ?))`,
+      );
+      const candidateId = BigInt(cursor.candidateId);
+      const integerCursorKey =
+        sortDefinition.kind === "integer" && /^-?[0-9]+$/.test(cursor.key)
+          ? BigInt(cursor.key)
+          : null;
+      if (
+        candidateId > SQLITE_MAX_INTEGER ||
+        (sortDefinition.kind === "integer" &&
+          (integerCursorKey === null ||
+            integerCursorKey < SQLITE_MIN_INTEGER ||
+            integerCursorKey > SQLITE_MAX_INTEGER))
+      ) {
+        throw new ForensixError(
+          "INVALID_CURSOR",
+          "Topic Candidate cursor contains an invalid sort key.",
+        );
+      }
+      const cursorKey =
+        sortDefinition.kind === "integer"
+          ? (integerCursorKey as bigint)
+          : cursor.key;
+      parameters.push(cursorKey, cursorKey, candidateId);
+    }
+
+    parameters.push(BigInt(limit + 1));
+    const sqlDirection = direction === "asc" ? "ASC" : "DESC";
+    const rows = database
+      .prepare(
+        `SELECT c.candidate_id, c.candidate_kind, c.profile_path,
+                c.commit_state, c.rank, c.supporting_count,
+                c.provenance_json, c.fields_json,
+                ${sortExpression} AS cursor_key
+           FROM forensic_candidates c
+           JOIN history_artifact_results r
+             ON r.artifact_result_id = c.artifact_result_id
+          WHERE ${conditions.join(" AND ")}
+          ORDER BY ${sortExpression} ${sqlDirection},
+                   c.candidate_id ${sqlDirection}
+          LIMIT ?`,
+      )
+      .all(...parameters) as unknown as QueryRow[];
+    const hasNext = rows.length > limit;
+    const pageRows = hasNext ? rows.slice(0, limit) : rows;
+    const last = pageRows.at(-1);
+    return {
+      status: "ok",
+      command: "topic-candidates",
+      items: pageRows.map(parseCandidate),
+      nextCursor:
+        hasNext && last !== undefined
+          ? encodeCursor({
+              version: 1,
+              fingerprint,
+              key: last.cursor_key.toString(),
+              candidateId: last.candidate_id.toString(),
+            })
+          : null,
+      limit,
+    };
+  } finally {
+    database.close();
+  }
+}

--- a/core/src/topic-candidates-query.ts
+++ b/core/src/topic-candidates-query.ts
@@ -59,8 +59,6 @@ interface CursorPayload {
 interface QueryRow {
   readonly candidate_id: bigint;
   readonly candidate_kind: string;
-  readonly profile_path: string;
-  readonly commit_state: string;
   readonly rank: bigint;
   readonly supporting_count: bigint;
   readonly provenance_json: string;
@@ -349,8 +347,7 @@ export function queryTopicCandidates(
     const sqlDirection = direction === "asc" ? "ASC" : "DESC";
     const rows = database
       .prepare(
-        `SELECT c.candidate_id, c.candidate_kind, c.profile_path,
-                c.commit_state, c.rank, c.supporting_count,
+        `SELECT c.candidate_id, c.candidate_kind, c.rank, c.supporting_count,
                 c.provenance_json, c.fields_json,
                 ${sortExpression} AS cursor_key
            FROM forensic_candidates c

--- a/core/src/topic-candidates.ts
+++ b/core/src/topic-candidates.ts
@@ -6,18 +6,24 @@ import {
   type CommitState,
   type Provenance,
 } from "./forensic-model.js";
+import {
+  TOPIC_LABELS_BY_ID,
+  TOPIC_TAXONOMY,
+  UNCLASSIFIED_LABEL_ID,
+  type TopicLabel,
+} from "./topic-taxonomy.js";
 
 /**
  * Topic classification as Candidates — never Findings.
  *
- * This module classifies the topic of a browsing row (URL + title) into a
- * frozen 20-label taxonomy and emits the result as nominal, ranked
- * {@link Candidate} records. A Candidate is deliberately NOT a Finding: it is a
- * ranked hypothesis carrying a supporting count and a resolvable Provenance,
- * and the product never promotes it into a Finding collection or a factual
- * summary tile. The separation is enforced structurally — this module only ever
- * constructs `createCandidate(...)` rows and writes them to the
- * `forensic_candidates` store, which is a distinct table from every
+ * This module classifies the topic of a browsing row (URL + title) into the
+ * frozen 20-label taxonomy (see `topic-taxonomy.ts`) and emits the result as
+ * nominal, ranked {@link Candidate} records. A Candidate is deliberately NOT a
+ * Finding: it is a ranked hypothesis carrying a supporting count and a
+ * resolvable Provenance, and the product never promotes it into a Finding
+ * collection or a factual summary tile. The separation is enforced structurally
+ * — this module only ever constructs `createCandidate(...)` rows and writes them
+ * to the `forensic_candidates` store, which is a distinct table from every
  * `*_findings` table.
  *
  * The classifier is engine-injected. The production engine is the settled local
@@ -30,199 +36,12 @@ import {
 const CANDIDATE_KIND = "topic" as const;
 export const TOPIC_CANDIDATE_KIND = CANDIDATE_KIND;
 
-export interface TopicLabel {
-  readonly id: string;
-  readonly name: string;
-  /** The forensic question the label answers. Frozen supervision. */
-  readonly question: string;
-  /** The label's boundary rule. Frozen supervision. */
-  readonly boundary: string;
-  /** GDPR Article 9 special-category label (reported with extra care). */
-  readonly specialCategory: boolean;
-}
-
-/**
- * The frozen 20-label taxonomy. The `name`, `question`, and `boundary` fields
- * are the ONLY supervision the model-backed classifier receives; they are copied
- * verbatim from the taxonomy proposal (ChmaraX/forensix#137 §3), which was
- * written and frozen BEFORE any fixture was labelled. `unclassified` is a real,
- * mandatory member of the set: a forensic classifier must be permitted to say
- * nothing. Any change to these strings must be justified against the proposal,
- * never against measured performance.
- */
-export const TOPIC_TAXONOMY: readonly TopicLabel[] = Object.freeze([
-  {
-    id: "search_query",
-    name: "Search & Query",
-    question: "What did the subject look for, in their own words?",
-    boundary:
-      "Applies to search-engine result pages and to in-site search endpoints.",
-    specialCategory: false,
-  },
-  {
-    id: "webmail_messaging_voice",
-    name: "Webmail, Messaging & Voice",
-    question: "How were they communicating off-channel?",
-    boundary:
-      "Web-hosted mail, chat, messaging and voice/meeting services. The label asserts the channel, never the conversation.",
-    specialCategory: false,
-  },
-  {
-    id: "social_media",
-    name: "Social media & Online communities",
-    question: "What accounts and what contacts?",
-    boundary:
-      "Social networks, forums, community platforms, professional networks, personal blogs, and dating services.",
-    specialCategory: false,
-  },
-  {
-    id: "news_current_affairs",
-    name: "News & Current affairs",
-    question:
-      "What was the subject reading about, and when relative to the incident?",
-    boundary: "Press, broadcast news, aggregators.",
-    specialCategory: false,
-  },
-  {
-    id: "reference_education_howto",
-    name: "Reference, Education & How-to",
-    question: "Was the subject learning or researching a method?",
-    boundary:
-      "Encyclopaedic and reference material, courses, academic and institutional sites, instructional material.",
-    specialCategory: false,
-  },
-  {
-    id: "entertainment_streaming_gaming",
-    name: "Entertainment, Streaming & Gaming",
-    question:
-      "How much of this history is leisure consumption, and when did it happen?",
-    boundary:
-      "Video and audio streaming, music, film and TV, humour, celebrity, comics, sport as spectacle, and games.",
-    specialCategory: false,
-  },
-  {
-    id: "technology_software_dev",
-    name: "Technology, Software & Developer resources",
-    question: "Was the subject working, or acquiring capability?",
-    boundary:
-      "Vendor and product documentation, developer platforms, package and code hosting, IT, SaaS and admin consoles, AI services.",
-    specialCategory: false,
-  },
-  {
-    id: "shopping_marketplace",
-    name: "Shopping & Marketplace",
-    question: "What was purchased, and does it match the alleged fraud?",
-    boundary:
-      "Retail, auctions, classifieds, marketplaces, coupons, and property listings.",
-    specialCategory: false,
-  },
-  {
-    id: "finance_banking",
-    name: "Finance & Banking",
-    question:
-      "Which financial institutions and accounts were accessed, and when?",
-    boundary:
-      "Retail and commercial banking, payments, brokerage, insurance, tax and government financial portals, accounting.",
-    specialCategory: false,
-  },
-  {
-    id: "cryptocurrency_exchanges",
-    name: "Cryptocurrency & Exchanges",
-    question: "Was there an exfil-monetisation or ransom-payment channel?",
-    boundary:
-      "Exchanges, wallets, chain explorers, mining and token services. Kept separate from Finance & Banking deliberately.",
-    specialCategory: false,
-  },
-  {
-    id: "employment_job_seeking",
-    name: "Employment & Job seeking",
-    question: "Was there job-seeking before the exfil?",
-    boundary: "Job boards, applicant portals, recruiter services, CV tooling.",
-    specialCategory: false,
-  },
-  {
-    id: "travel_transport_accommodation",
-    name: "Travel, Transport & Accommodation",
-    question: "Does the browsing corroborate the movement timeline?",
-    boundary:
-      "Booking, carriers, accommodation, maps and routing, local transport.",
-    specialCategory: false,
-  },
-  {
-    id: "health_medical",
-    name: "Health & Medical",
-    question:
-      "Is there a medical explanation, a capacity question, or a welfare concern?",
-    boundary:
-      "Conditions, symptoms, providers, appointments, pharmacy, mental-health services.",
-    specialCategory: true,
-  },
-  {
-    id: "adult_sexual_content",
-    name: "Adult & Sexual content",
-    question: "Was there adult material on this machine?",
-    boundary:
-      "Explicitly not a CSAM detector. Does not extend to dating, sex education, or non-sexual nudity.",
-    specialCategory: true,
-  },
-  {
-    id: "gambling",
-    name: "Gambling",
-    question: "Was there gambling activity?",
-    boundary: "Betting, casino, lottery, and in-game wagering.",
-    specialCategory: false,
-  },
-  {
-    id: "file_sharing_cloud_storage",
-    name: "File sharing, Cloud storage & Transfer",
-    question: "How did the data leave?",
-    boundary:
-      "Consumer and enterprise cloud storage, document collaboration, large-file transfer, peer-to-peer, paste services.",
-    specialCategory: false,
-  },
-  {
-    id: "anonymity_privacy_tooling",
-    name: "Anonymity & Privacy tooling",
-    question: "Was there counter-forensic preparation?",
-    boundary:
-      "VPN, Tor and proxy services, encrypted-DNS services, anonymous mail, secure-delete and anti-forensic tooling.",
-    specialCategory: false,
-  },
-  {
-    id: "hacking_security_tooling",
-    name: "Hacking & Security tooling",
-    question: "Was there tool acquisition or capability building?",
-    boundary:
-      "Offensive tooling, exploit and vulnerability material, credential-attack resources, malware analysis resources.",
-    specialCategory: false,
-  },
-  {
-    id: "ads_trackers_infrastructure",
-    name: "Ads, Trackers & Web infrastructure",
-    question: "Which of these rows record an act by the user at all?",
-    boundary:
-      "Advertising and tracking beacons, CDN hosts, URL shorteners and redirect hops, parked domains, consent walls, browser-internal pages.",
-    specialCategory: false,
-  },
-  {
-    id: "unclassified",
-    name: "Unclassified / insufficient signal",
-    question: "Can this row support any claim?",
-    boundary:
-      "The row's title and URL together carry no discriminating signal. A forensic classifier must be permitted to say nothing.",
-    specialCategory: false,
-  },
-]);
-
-export const UNCLASSIFIED_LABEL_ID = "unclassified" as const;
-
-/** Provenance of the frozen supervision text, recorded for auditability. */
-export const TOPIC_TAXONOMY_SOURCE =
-  "ChmaraX/forensix#137 section 3 (label set + forensic question + boundary rules), frozen before labelling" as const;
-
-const TOPIC_LABELS_BY_ID: ReadonlyMap<string, TopicLabel> = new Map(
-  TOPIC_TAXONOMY.map((label) => [label.id, label]),
-);
+export {
+  TOPIC_TAXONOMY,
+  TOPIC_TAXONOMY_SOURCE,
+  UNCLASSIFIED_LABEL_ID,
+  type TopicLabel,
+} from "./topic-taxonomy.js";
 
 /**
  * A single-pass text encoder. The classifier only needs to turn a string into a
@@ -266,6 +85,22 @@ export interface TopicClassifierOptions {
    * (multi-label emission). Default 0.02, the settled bench band.
    */
   readonly multiLabelDelta?: number;
+}
+
+/**
+ * A classifier with its label anchors already embedded. Anchors depend only on
+ * the engine, so they are computed once here rather than per input batch; this
+ * also makes the failure boundary honest — anchor-embedding failure surfaces
+ * when the classifier is prepared, per-row inference failure surfaces from
+ * {@link classifyBatch}.
+ */
+export interface PreparedTopicClassifier {
+  readonly modelId: string;
+  readonly modelRevision: string;
+  readonly classifyBatch: (
+    inputs: readonly TopicCandidateInput[],
+    options?: TopicClassifierOptions,
+  ) => Promise<PersistedCandidate[] | TopicClassifierUnavailable>;
 }
 
 const DEFAULT_MAX_LABELS = 3;
@@ -368,13 +203,15 @@ function selectEmittedLabels(
   return emitted.slice(0, Math.max(1, maxLabels));
 }
 
+type EngineIdentity = Pick<EmbeddingEngine, "modelId" | "modelRevision">;
+
 function candidateFromLabel(input: {
   readonly label: TopicLabel;
   readonly rank: number;
   readonly score: number;
   readonly url: string | null;
   readonly title: string | null;
-  readonly engine: Pick<EmbeddingEngine, "modelId" | "modelRevision">;
+  readonly engine: EngineIdentity;
   readonly source: TopicCandidateInput;
 }): PersistedCandidate {
   const candidate = createCandidate({
@@ -413,6 +250,10 @@ function candidateFromLabel(input: {
   };
 }
 
+function nonBlank(value: string | null): string | null {
+  return value === null || value.trim() === "" ? null : value;
+}
+
 /**
  * A blank input carries no discriminating signal. Rather than fabricate a
  * confident topic, emit exactly one `unclassified` Candidate with the same
@@ -420,7 +261,7 @@ function candidateFromLabel(input: {
  */
 function unclassifiedCandidate(
   source: TopicCandidateInput,
-  engine: Pick<EmbeddingEngine, "modelId" | "modelRevision">,
+  engine: EngineIdentity,
 ): PersistedCandidate {
   const label = TOPIC_LABELS_BY_ID.get(UNCLASSIFIED_LABEL_ID);
   if (label === undefined) {
@@ -430,35 +271,26 @@ function unclassifiedCandidate(
     label,
     rank: 1,
     score: 0,
-    url: source.url === null || source.url.trim() === "" ? null : source.url,
-    title:
-      source.title === null || source.title.trim() === "" ? null : source.title,
+    url: nonBlank(source.url),
+    title: nonBlank(source.title),
     engine,
     source,
   });
 }
 
 /**
- * Classify a batch of browsing rows into ranked topic Candidates.
- *
- * Every returned row is a nominal Candidate with a rank, a supporting count, and
- * a resolvable Provenance. Blank inputs yield a single `unclassified` Candidate.
- * If the engine throws at any point (anchor embedding or row inference) the whole
- * batch resolves to a typed {@link TopicClassifierUnavailable} and the caller
- * keeps its Findings untouched — History analysis stays usable.
+ * Prepare a classifier by embedding the label anchors once. Anchors depend only
+ * on the engine, so a caller that classifies many artifact batches embeds them a
+ * single time. Returns a typed {@link TopicClassifierUnavailable} if the engine
+ * throws while embedding anchors — that is a model failure, not a per-row one.
  */
-export async function classifyTopicCandidates(
+export async function createTopicClassifier(
   engine: EmbeddingEngine,
-  inputs: readonly TopicCandidateInput[],
-  options: TopicClassifierOptions = {},
-): Promise<PersistedCandidate[] | TopicClassifierUnavailable> {
-  const maxLabels = options.maxLabels ?? DEFAULT_MAX_LABELS;
-  const multiLabelDelta = options.multiLabelDelta ?? DEFAULT_MULTI_LABEL_DELTA;
-  const engineIdentity = {
+): Promise<PreparedTopicClassifier | TopicClassifierUnavailable> {
+  const identity: EngineIdentity = {
     modelId: engine.modelId,
     modelRevision: engine.modelRevision,
   };
-
   let anchors: { label: TopicLabel; vector: Float32Array }[];
   try {
     anchors = [];
@@ -479,49 +311,80 @@ export async function classifyTopicCandidates(
     };
   }
 
-  const candidates: PersistedCandidate[] = [];
-  try {
-    for (const input of inputs) {
-      const text = topicInputText(input.url, input.title);
-      if (text.length === 0) {
-        candidates.push(unclassifiedCandidate(input, engineIdentity));
-        continue;
-      }
-      const vector = l2normalise(await engine.embed(text));
-      const scores = new Map<string, number>();
-      for (const anchor of anchors) {
-        scores.set(anchor.label.id, dot(vector, anchor.vector));
-      }
-      const ranked = rankLabels(scores);
-      const emitted = selectEmittedLabels(ranked, maxLabels, multiLabelDelta);
-      emitted.forEach((entry, index) => {
-        const label = TOPIC_LABELS_BY_ID.get(entry.labelId);
-        if (label === undefined) {
-          return;
+  const classifyBatch = async (
+    inputs: readonly TopicCandidateInput[],
+    options: TopicClassifierOptions = {},
+  ): Promise<PersistedCandidate[] | TopicClassifierUnavailable> => {
+    const maxLabels = options.maxLabels ?? DEFAULT_MAX_LABELS;
+    const multiLabelDelta =
+      options.multiLabelDelta ?? DEFAULT_MULTI_LABEL_DELTA;
+    const candidates: PersistedCandidate[] = [];
+    try {
+      for (const input of inputs) {
+        const text = topicInputText(input.url, input.title);
+        if (text.length === 0) {
+          candidates.push(unclassifiedCandidate(input, identity));
+          continue;
         }
-        candidates.push(
-          candidateFromLabel({
-            label,
-            rank: index + 1,
-            score: entry.score,
-            url:
-              input.url === null || input.url.trim() === "" ? null : input.url,
-            title:
-              input.title === null || input.title.trim() === ""
-                ? null
-                : input.title,
-            engine: engineIdentity,
-            source: input,
-          }),
-        );
-      });
+        const vector = l2normalise(await engine.embed(text));
+        const scores = new Map<string, number>();
+        for (const anchor of anchors) {
+          scores.set(anchor.label.id, dot(vector, anchor.vector));
+        }
+        const ranked = rankLabels(scores);
+        const emitted = selectEmittedLabels(ranked, maxLabels, multiLabelDelta);
+        emitted.forEach((entry, index) => {
+          const label = TOPIC_LABELS_BY_ID.get(entry.labelId);
+          if (label === undefined) {
+            return;
+          }
+          candidates.push(
+            candidateFromLabel({
+              label,
+              rank: index + 1,
+              score: entry.score,
+              url: nonBlank(input.url),
+              title: nonBlank(input.title),
+              engine: identity,
+              source: input,
+            }),
+          );
+        });
+      }
+    } catch (error) {
+      return {
+        available: false,
+        reason: "inference_failed",
+        detail: String(error),
+      };
     }
-  } catch (error) {
-    return {
-      available: false,
-      reason: "inference_failed",
-      detail: String(error),
-    };
+    return candidates;
+  };
+
+  return { ...identity, classifyBatch };
+}
+
+/**
+ * Classify a batch of browsing rows into ranked topic Candidates.
+ *
+ * Every returned row is a nominal Candidate with a rank, a supporting count, and
+ * a resolvable Provenance. Blank inputs yield a single `unclassified` Candidate.
+ * If the engine throws at any point (anchor embedding or row inference) the whole
+ * batch resolves to a typed {@link TopicClassifierUnavailable} and the caller
+ * keeps its Findings untouched — History analysis stays usable.
+ *
+ * This is a one-shot convenience over {@link createTopicClassifier}; a caller
+ * classifying several batches should prepare once and reuse the result so the
+ * anchors are embedded a single time.
+ */
+export async function classifyTopicCandidates(
+  engine: EmbeddingEngine,
+  inputs: readonly TopicCandidateInput[],
+  options: TopicClassifierOptions = {},
+): Promise<PersistedCandidate[] | TopicClassifierUnavailable> {
+  const prepared = await createTopicClassifier(engine);
+  if ("available" in prepared) {
+    return prepared;
   }
-  return candidates;
+  return prepared.classifyBatch(inputs, options);
 }

--- a/core/src/topic-candidates.ts
+++ b/core/src/topic-candidates.ts
@@ -1,0 +1,527 @@
+import type { PersistedCandidate } from "./case-findings.js";
+import {
+  absentField,
+  createCandidate,
+  valueField,
+  type CommitState,
+  type Provenance,
+} from "./forensic-model.js";
+
+/**
+ * Topic classification as Candidates — never Findings.
+ *
+ * This module classifies the topic of a browsing row (URL + title) into a
+ * frozen 20-label taxonomy and emits the result as nominal, ranked
+ * {@link Candidate} records. A Candidate is deliberately NOT a Finding: it is a
+ * ranked hypothesis carrying a supporting count and a resolvable Provenance,
+ * and the product never promotes it into a Finding collection or a factual
+ * summary tile. The separation is enforced structurally — this module only ever
+ * constructs `createCandidate(...)` rows and writes them to the
+ * `forensic_candidates` store, which is a distinct table from every
+ * `*_findings` table.
+ *
+ * The classifier is engine-injected. The production engine is the settled local
+ * ONNX model (see `topic-candidates-onnx.ts`); this module contains no model
+ * runtime, no network access, no Python, and no second analysis process. All
+ * decision logic here is pure and deterministic given an engine, so the behaviour
+ * that lands in the Case can be tested without the model binary present.
+ */
+
+const CANDIDATE_KIND = "topic" as const;
+export const TOPIC_CANDIDATE_KIND = CANDIDATE_KIND;
+
+export interface TopicLabel {
+  readonly id: string;
+  readonly name: string;
+  /** The forensic question the label answers. Frozen supervision. */
+  readonly question: string;
+  /** The label's boundary rule. Frozen supervision. */
+  readonly boundary: string;
+  /** GDPR Article 9 special-category label (reported with extra care). */
+  readonly specialCategory: boolean;
+}
+
+/**
+ * The frozen 20-label taxonomy. The `name`, `question`, and `boundary` fields
+ * are the ONLY supervision the model-backed classifier receives; they are copied
+ * verbatim from the taxonomy proposal (ChmaraX/forensix#137 §3), which was
+ * written and frozen BEFORE any fixture was labelled. `unclassified` is a real,
+ * mandatory member of the set: a forensic classifier must be permitted to say
+ * nothing. Any change to these strings must be justified against the proposal,
+ * never against measured performance.
+ */
+export const TOPIC_TAXONOMY: readonly TopicLabel[] = Object.freeze([
+  {
+    id: "search_query",
+    name: "Search & Query",
+    question: "What did the subject look for, in their own words?",
+    boundary:
+      "Applies to search-engine result pages and to in-site search endpoints.",
+    specialCategory: false,
+  },
+  {
+    id: "webmail_messaging_voice",
+    name: "Webmail, Messaging & Voice",
+    question: "How were they communicating off-channel?",
+    boundary:
+      "Web-hosted mail, chat, messaging and voice/meeting services. The label asserts the channel, never the conversation.",
+    specialCategory: false,
+  },
+  {
+    id: "social_media",
+    name: "Social media & Online communities",
+    question: "What accounts and what contacts?",
+    boundary:
+      "Social networks, forums, community platforms, professional networks, personal blogs, and dating services.",
+    specialCategory: false,
+  },
+  {
+    id: "news_current_affairs",
+    name: "News & Current affairs",
+    question:
+      "What was the subject reading about, and when relative to the incident?",
+    boundary: "Press, broadcast news, aggregators.",
+    specialCategory: false,
+  },
+  {
+    id: "reference_education_howto",
+    name: "Reference, Education & How-to",
+    question: "Was the subject learning or researching a method?",
+    boundary:
+      "Encyclopaedic and reference material, courses, academic and institutional sites, instructional material.",
+    specialCategory: false,
+  },
+  {
+    id: "entertainment_streaming_gaming",
+    name: "Entertainment, Streaming & Gaming",
+    question:
+      "How much of this history is leisure consumption, and when did it happen?",
+    boundary:
+      "Video and audio streaming, music, film and TV, humour, celebrity, comics, sport as spectacle, and games.",
+    specialCategory: false,
+  },
+  {
+    id: "technology_software_dev",
+    name: "Technology, Software & Developer resources",
+    question: "Was the subject working, or acquiring capability?",
+    boundary:
+      "Vendor and product documentation, developer platforms, package and code hosting, IT, SaaS and admin consoles, AI services.",
+    specialCategory: false,
+  },
+  {
+    id: "shopping_marketplace",
+    name: "Shopping & Marketplace",
+    question: "What was purchased, and does it match the alleged fraud?",
+    boundary:
+      "Retail, auctions, classifieds, marketplaces, coupons, and property listings.",
+    specialCategory: false,
+  },
+  {
+    id: "finance_banking",
+    name: "Finance & Banking",
+    question:
+      "Which financial institutions and accounts were accessed, and when?",
+    boundary:
+      "Retail and commercial banking, payments, brokerage, insurance, tax and government financial portals, accounting.",
+    specialCategory: false,
+  },
+  {
+    id: "cryptocurrency_exchanges",
+    name: "Cryptocurrency & Exchanges",
+    question: "Was there an exfil-monetisation or ransom-payment channel?",
+    boundary:
+      "Exchanges, wallets, chain explorers, mining and token services. Kept separate from Finance & Banking deliberately.",
+    specialCategory: false,
+  },
+  {
+    id: "employment_job_seeking",
+    name: "Employment & Job seeking",
+    question: "Was there job-seeking before the exfil?",
+    boundary: "Job boards, applicant portals, recruiter services, CV tooling.",
+    specialCategory: false,
+  },
+  {
+    id: "travel_transport_accommodation",
+    name: "Travel, Transport & Accommodation",
+    question: "Does the browsing corroborate the movement timeline?",
+    boundary:
+      "Booking, carriers, accommodation, maps and routing, local transport.",
+    specialCategory: false,
+  },
+  {
+    id: "health_medical",
+    name: "Health & Medical",
+    question:
+      "Is there a medical explanation, a capacity question, or a welfare concern?",
+    boundary:
+      "Conditions, symptoms, providers, appointments, pharmacy, mental-health services.",
+    specialCategory: true,
+  },
+  {
+    id: "adult_sexual_content",
+    name: "Adult & Sexual content",
+    question: "Was there adult material on this machine?",
+    boundary:
+      "Explicitly not a CSAM detector. Does not extend to dating, sex education, or non-sexual nudity.",
+    specialCategory: true,
+  },
+  {
+    id: "gambling",
+    name: "Gambling",
+    question: "Was there gambling activity?",
+    boundary: "Betting, casino, lottery, and in-game wagering.",
+    specialCategory: false,
+  },
+  {
+    id: "file_sharing_cloud_storage",
+    name: "File sharing, Cloud storage & Transfer",
+    question: "How did the data leave?",
+    boundary:
+      "Consumer and enterprise cloud storage, document collaboration, large-file transfer, peer-to-peer, paste services.",
+    specialCategory: false,
+  },
+  {
+    id: "anonymity_privacy_tooling",
+    name: "Anonymity & Privacy tooling",
+    question: "Was there counter-forensic preparation?",
+    boundary:
+      "VPN, Tor and proxy services, encrypted-DNS services, anonymous mail, secure-delete and anti-forensic tooling.",
+    specialCategory: false,
+  },
+  {
+    id: "hacking_security_tooling",
+    name: "Hacking & Security tooling",
+    question: "Was there tool acquisition or capability building?",
+    boundary:
+      "Offensive tooling, exploit and vulnerability material, credential-attack resources, malware analysis resources.",
+    specialCategory: false,
+  },
+  {
+    id: "ads_trackers_infrastructure",
+    name: "Ads, Trackers & Web infrastructure",
+    question: "Which of these rows record an act by the user at all?",
+    boundary:
+      "Advertising and tracking beacons, CDN hosts, URL shorteners and redirect hops, parked domains, consent walls, browser-internal pages.",
+    specialCategory: false,
+  },
+  {
+    id: "unclassified",
+    name: "Unclassified / insufficient signal",
+    question: "Can this row support any claim?",
+    boundary:
+      "The row's title and URL together carry no discriminating signal. A forensic classifier must be permitted to say nothing.",
+    specialCategory: false,
+  },
+]);
+
+export const UNCLASSIFIED_LABEL_ID = "unclassified" as const;
+
+/** Provenance of the frozen supervision text, recorded for auditability. */
+export const TOPIC_TAXONOMY_SOURCE =
+  "ChmaraX/forensix#137 section 3 (label set + forensic question + boundary rules), frozen before labelling" as const;
+
+const TOPIC_LABELS_BY_ID: ReadonlyMap<string, TopicLabel> = new Map(
+  TOPIC_TAXONOMY.map((label) => [label.id, label]),
+);
+
+/**
+ * A single-pass text encoder. The classifier only needs to turn a string into a
+ * vector; every model detail (tokeniser, ONNX session, pooling) is the engine's
+ * concern. Vectors are expected L2-normalised so that a dot product is cosine
+ * similarity, but the classifier re-normalises defensively.
+ */
+export interface EmbeddingEngine {
+  readonly modelId: string;
+  readonly modelRevision: string;
+  readonly embed: (text: string) => Promise<Float32Array>;
+}
+
+export type TopicClassifierUnavailableReason =
+  | "model_runtime_unavailable"
+  | "model_artifact_missing"
+  | "model_load_failed"
+  | "inference_failed";
+
+export interface TopicClassifierUnavailable {
+  readonly available: false;
+  readonly reason: TopicClassifierUnavailableReason;
+  readonly detail?: string;
+}
+
+export interface TopicCandidateInput {
+  readonly url: string | null;
+  readonly title: string | null;
+  readonly profile: string;
+  readonly commitState: CommitState;
+  readonly provenance: Provenance;
+  /** Number of source rows (browsing visits) this input summarises. >= 1. */
+  readonly supportingCount: number;
+}
+
+export interface TopicClassifierOptions {
+  /** Maximum labels emitted per input. Default 3. */
+  readonly maxLabels?: number;
+  /**
+   * Emit every label whose cosine score is within this delta of the top label
+   * (multi-label emission). Default 0.02, the settled bench band.
+   */
+  readonly multiLabelDelta?: number;
+}
+
+const DEFAULT_MAX_LABELS = 3;
+const DEFAULT_MULTI_LABEL_DELTA = 0.02;
+const SCORE_PRECISION = 1_000_000;
+
+/** Compose the encoder input from a browsing row. Title precedes URL. */
+export function topicInputText(
+  url: string | null,
+  title: string | null,
+): string {
+  return [title, url]
+    .map((part) => (part ?? "").trim())
+    .filter((part) => part.length > 0)
+    .join(" ");
+}
+
+function l2normalise(vector: Float32Array): Float32Array {
+  let sum = 0;
+  for (let i = 0; i < vector.length; i += 1) {
+    const value = vector[i] as number;
+    sum += value * value;
+  }
+  const norm = Math.sqrt(sum);
+  if (norm === 0) {
+    return vector;
+  }
+  const out = new Float32Array(vector.length);
+  for (let i = 0; i < vector.length; i += 1) {
+    out[i] = (vector[i] as number) / norm;
+  }
+  return out;
+}
+
+function dot(a: Float32Array, b: Float32Array): number {
+  const length = Math.min(a.length, b.length);
+  let sum = 0;
+  for (let i = 0; i < length; i += 1) {
+    sum += (a[i] as number) * (b[i] as number);
+  }
+  return sum;
+}
+
+function anchorText(label: TopicLabel): string {
+  return [label.name, label.question, label.boundary]
+    .filter((part) => part.length > 0)
+    .join(". ");
+}
+
+function roundScore(score: number): number {
+  return Math.round(score * SCORE_PRECISION) / SCORE_PRECISION;
+}
+
+interface RankedLabel {
+  readonly labelId: string;
+  readonly score: number;
+}
+
+/**
+ * Rank labels by score, tie-broken by label id so two runs — and two CPU
+ * architectures — cannot disagree on the order of equal scores. This is the
+ * deterministic decision surface the Case records.
+ */
+function rankLabels(scores: ReadonlyMap<string, number>): RankedLabel[] {
+  return [...scores.entries()]
+    .map(([labelId, score]) => ({ labelId, score: roundScore(score) }))
+    .sort((a, b) =>
+      b.score !== a.score
+        ? b.score - a.score
+        : a.labelId < b.labelId
+          ? -1
+          : a.labelId > b.labelId
+            ? 1
+            : 0,
+    );
+}
+
+function selectEmittedLabels(
+  ranked: readonly RankedLabel[],
+  maxLabels: number,
+  multiLabelDelta: number,
+): RankedLabel[] {
+  const top = ranked[0];
+  if (top === undefined) {
+    return [];
+  }
+  let emitted = ranked.filter(
+    (label) => top.score - label.score <= multiLabelDelta,
+  );
+  // `unclassified` asserts the absence of signal; it cannot co-occur with a
+  // positive label. Mirrors the taxonomy's mutual-exclusivity rule.
+  if (emitted.length > 1) {
+    const positives = emitted.filter(
+      (label) => label.labelId !== UNCLASSIFIED_LABEL_ID,
+    );
+    if (positives.length > 0) {
+      emitted = positives;
+    }
+  }
+  return emitted.slice(0, Math.max(1, maxLabels));
+}
+
+function candidateFromLabel(input: {
+  readonly label: TopicLabel;
+  readonly rank: number;
+  readonly score: number;
+  readonly url: string | null;
+  readonly title: string | null;
+  readonly engine: Pick<EmbeddingEngine, "modelId" | "modelRevision">;
+  readonly source: TopicCandidateInput;
+}): PersistedCandidate {
+  const candidate = createCandidate({
+    candidateKind: CANDIDATE_KIND,
+    rank: input.rank,
+    count: input.source.supportingCount,
+    provenance: input.source.provenance,
+    fields: {
+      topicLabel: valueField(input.label.id),
+      topicName: valueField(input.label.name),
+      specialCategory: valueField(input.label.specialCategory),
+      score: valueField(roundScore(input.score), { synthetic: true }),
+      scoreAxis: valueField("cosine", { synthetic: true }),
+      modelId: valueField(input.engine.modelId, { synthetic: true }),
+      modelRevision: valueField(input.engine.modelRevision, {
+        synthetic: true,
+      }),
+      url: input.url === null ? absentField() : valueField(input.url),
+      title: input.title === null ? absentField() : valueField(input.title),
+    },
+  });
+  const searchText = [
+    input.source.profile,
+    input.label.id,
+    input.label.name,
+    input.url ?? "",
+    input.title ?? "",
+  ]
+    .join("\n")
+    .toLocaleLowerCase("en-US");
+  return {
+    candidate,
+    profile: input.source.profile,
+    commitState: input.source.commitState,
+    searchText,
+  };
+}
+
+/**
+ * A blank input carries no discriminating signal. Rather than fabricate a
+ * confident topic, emit exactly one `unclassified` Candidate with the same
+ * Provenance and supporting count. No engine call is needed.
+ */
+function unclassifiedCandidate(
+  source: TopicCandidateInput,
+  engine: Pick<EmbeddingEngine, "modelId" | "modelRevision">,
+): PersistedCandidate {
+  const label = TOPIC_LABELS_BY_ID.get(UNCLASSIFIED_LABEL_ID);
+  if (label === undefined) {
+    throw new Error("Taxonomy is missing the mandatory unclassified label.");
+  }
+  return candidateFromLabel({
+    label,
+    rank: 1,
+    score: 0,
+    url: source.url === null || source.url.trim() === "" ? null : source.url,
+    title:
+      source.title === null || source.title.trim() === "" ? null : source.title,
+    engine,
+    source,
+  });
+}
+
+/**
+ * Classify a batch of browsing rows into ranked topic Candidates.
+ *
+ * Every returned row is a nominal Candidate with a rank, a supporting count, and
+ * a resolvable Provenance. Blank inputs yield a single `unclassified` Candidate.
+ * If the engine throws at any point (anchor embedding or row inference) the whole
+ * batch resolves to a typed {@link TopicClassifierUnavailable} and the caller
+ * keeps its Findings untouched — History analysis stays usable.
+ */
+export async function classifyTopicCandidates(
+  engine: EmbeddingEngine,
+  inputs: readonly TopicCandidateInput[],
+  options: TopicClassifierOptions = {},
+): Promise<PersistedCandidate[] | TopicClassifierUnavailable> {
+  const maxLabels = options.maxLabels ?? DEFAULT_MAX_LABELS;
+  const multiLabelDelta = options.multiLabelDelta ?? DEFAULT_MULTI_LABEL_DELTA;
+  const engineIdentity = {
+    modelId: engine.modelId,
+    modelRevision: engine.modelRevision,
+  };
+
+  let anchors: { label: TopicLabel; vector: Float32Array }[];
+  try {
+    anchors = [];
+    for (const label of TOPIC_TAXONOMY) {
+      if (label.id === UNCLASSIFIED_LABEL_ID) {
+        continue;
+      }
+      anchors.push({
+        label,
+        vector: l2normalise(await engine.embed(anchorText(label))),
+      });
+    }
+  } catch (error) {
+    return {
+      available: false,
+      reason: "inference_failed",
+      detail: String(error),
+    };
+  }
+
+  const candidates: PersistedCandidate[] = [];
+  try {
+    for (const input of inputs) {
+      const text = topicInputText(input.url, input.title);
+      if (text.length === 0) {
+        candidates.push(unclassifiedCandidate(input, engineIdentity));
+        continue;
+      }
+      const vector = l2normalise(await engine.embed(text));
+      const scores = new Map<string, number>();
+      for (const anchor of anchors) {
+        scores.set(anchor.label.id, dot(vector, anchor.vector));
+      }
+      const ranked = rankLabels(scores);
+      const emitted = selectEmittedLabels(ranked, maxLabels, multiLabelDelta);
+      emitted.forEach((entry, index) => {
+        const label = TOPIC_LABELS_BY_ID.get(entry.labelId);
+        if (label === undefined) {
+          return;
+        }
+        candidates.push(
+          candidateFromLabel({
+            label,
+            rank: index + 1,
+            score: entry.score,
+            url:
+              input.url === null || input.url.trim() === "" ? null : input.url,
+            title:
+              input.title === null || input.title.trim() === ""
+                ? null
+                : input.title,
+            engine: engineIdentity,
+            source: input,
+          }),
+        );
+      });
+    }
+  } catch (error) {
+    return {
+      available: false,
+      reason: "inference_failed",
+      detail: String(error),
+    };
+  }
+  return candidates;
+}

--- a/core/src/topic-candidates.ts
+++ b/core/src/topic-candidates.ts
@@ -187,19 +187,12 @@ function selectEmittedLabels(
   if (top === undefined) {
     return [];
   }
-  let emitted = ranked.filter(
+  // `unclassified` is excluded from the anchors (it is never scored), so it can
+  // never appear here — it reaches the Case only through the blank-input path.
+  // The emitted set is therefore always positive labels within the delta band.
+  const emitted = ranked.filter(
     (label) => top.score - label.score <= multiLabelDelta,
   );
-  // `unclassified` asserts the absence of signal; it cannot co-occur with a
-  // positive label. Mirrors the taxonomy's mutual-exclusivity rule.
-  if (emitted.length > 1) {
-    const positives = emitted.filter(
-      (label) => label.labelId !== UNCLASSIFIED_LABEL_ID,
-    );
-    if (positives.length > 0) {
-      emitted = positives;
-    }
-  }
   return emitted.slice(0, Math.max(1, maxLabels));
 }
 

--- a/core/src/topic-taxonomy.ts
+++ b/core/src/topic-taxonomy.ts
@@ -1,0 +1,197 @@
+/**
+ * The frozen topic taxonomy — audited supervision data, kept apart from the
+ * classifier algorithm that consumes it.
+ *
+ * The `name`, `question`, and `boundary` fields are the ONLY supervision the
+ * model-backed classifier receives; they are copied verbatim from the taxonomy
+ * proposal (ChmaraX/forensix#137 §3), which was written and frozen BEFORE any
+ * fixture was labelled. `unclassified` is a real, mandatory member of the set:
+ * a forensic classifier must be permitted to say nothing. Any change to these
+ * strings must be justified against the proposal, never against measured
+ * performance.
+ */
+
+export interface TopicLabel {
+  readonly id: string;
+  readonly name: string;
+  /** The forensic question the label answers. Frozen supervision. */
+  readonly question: string;
+  /** The label's boundary rule. Frozen supervision. */
+  readonly boundary: string;
+  /** GDPR Article 9 special-category label (reported with extra care). */
+  readonly specialCategory: boolean;
+}
+
+export const TOPIC_TAXONOMY: readonly TopicLabel[] = Object.freeze([
+  {
+    id: "search_query",
+    name: "Search & Query",
+    question: "What did the subject look for, in their own words?",
+    boundary:
+      "Applies to search-engine result pages and to in-site search endpoints.",
+    specialCategory: false,
+  },
+  {
+    id: "webmail_messaging_voice",
+    name: "Webmail, Messaging & Voice",
+    question: "How were they communicating off-channel?",
+    boundary:
+      "Web-hosted mail, chat, messaging and voice/meeting services. The label asserts the channel, never the conversation.",
+    specialCategory: false,
+  },
+  {
+    id: "social_media",
+    name: "Social media & Online communities",
+    question: "What accounts and what contacts?",
+    boundary:
+      "Social networks, forums, community platforms, professional networks, personal blogs, and dating services.",
+    specialCategory: false,
+  },
+  {
+    id: "news_current_affairs",
+    name: "News & Current affairs",
+    question:
+      "What was the subject reading about, and when relative to the incident?",
+    boundary: "Press, broadcast news, aggregators.",
+    specialCategory: false,
+  },
+  {
+    id: "reference_education_howto",
+    name: "Reference, Education & How-to",
+    question: "Was the subject learning or researching a method?",
+    boundary:
+      "Encyclopaedic and reference material, courses, academic and institutional sites, instructional material.",
+    specialCategory: false,
+  },
+  {
+    id: "entertainment_streaming_gaming",
+    name: "Entertainment, Streaming & Gaming",
+    question:
+      "How much of this history is leisure consumption, and when did it happen?",
+    boundary:
+      "Video and audio streaming, music, film and TV, humour, celebrity, comics, sport as spectacle, and games.",
+    specialCategory: false,
+  },
+  {
+    id: "technology_software_dev",
+    name: "Technology, Software & Developer resources",
+    question: "Was the subject working, or acquiring capability?",
+    boundary:
+      "Vendor and product documentation, developer platforms, package and code hosting, IT, SaaS and admin consoles, AI services.",
+    specialCategory: false,
+  },
+  {
+    id: "shopping_marketplace",
+    name: "Shopping & Marketplace",
+    question: "What was purchased, and does it match the alleged fraud?",
+    boundary:
+      "Retail, auctions, classifieds, marketplaces, coupons, and property listings.",
+    specialCategory: false,
+  },
+  {
+    id: "finance_banking",
+    name: "Finance & Banking",
+    question:
+      "Which financial institutions and accounts were accessed, and when?",
+    boundary:
+      "Retail and commercial banking, payments, brokerage, insurance, tax and government financial portals, accounting.",
+    specialCategory: false,
+  },
+  {
+    id: "cryptocurrency_exchanges",
+    name: "Cryptocurrency & Exchanges",
+    question: "Was there an exfil-monetisation or ransom-payment channel?",
+    boundary:
+      "Exchanges, wallets, chain explorers, mining and token services. Kept separate from Finance & Banking deliberately.",
+    specialCategory: false,
+  },
+  {
+    id: "employment_job_seeking",
+    name: "Employment & Job seeking",
+    question: "Was there job-seeking before the exfil?",
+    boundary: "Job boards, applicant portals, recruiter services, CV tooling.",
+    specialCategory: false,
+  },
+  {
+    id: "travel_transport_accommodation",
+    name: "Travel, Transport & Accommodation",
+    question: "Does the browsing corroborate the movement timeline?",
+    boundary:
+      "Booking, carriers, accommodation, maps and routing, local transport.",
+    specialCategory: false,
+  },
+  {
+    id: "health_medical",
+    name: "Health & Medical",
+    question:
+      "Is there a medical explanation, a capacity question, or a welfare concern?",
+    boundary:
+      "Conditions, symptoms, providers, appointments, pharmacy, mental-health services.",
+    specialCategory: true,
+  },
+  {
+    id: "adult_sexual_content",
+    name: "Adult & Sexual content",
+    question: "Was there adult material on this machine?",
+    boundary:
+      "Explicitly not a CSAM detector. Does not extend to dating, sex education, or non-sexual nudity.",
+    specialCategory: true,
+  },
+  {
+    id: "gambling",
+    name: "Gambling",
+    question: "Was there gambling activity?",
+    boundary: "Betting, casino, lottery, and in-game wagering.",
+    specialCategory: false,
+  },
+  {
+    id: "file_sharing_cloud_storage",
+    name: "File sharing, Cloud storage & Transfer",
+    question: "How did the data leave?",
+    boundary:
+      "Consumer and enterprise cloud storage, document collaboration, large-file transfer, peer-to-peer, paste services.",
+    specialCategory: false,
+  },
+  {
+    id: "anonymity_privacy_tooling",
+    name: "Anonymity & Privacy tooling",
+    question: "Was there counter-forensic preparation?",
+    boundary:
+      "VPN, Tor and proxy services, encrypted-DNS services, anonymous mail, secure-delete and anti-forensic tooling.",
+    specialCategory: false,
+  },
+  {
+    id: "hacking_security_tooling",
+    name: "Hacking & Security tooling",
+    question: "Was there tool acquisition or capability building?",
+    boundary:
+      "Offensive tooling, exploit and vulnerability material, credential-attack resources, malware analysis resources.",
+    specialCategory: false,
+  },
+  {
+    id: "ads_trackers_infrastructure",
+    name: "Ads, Trackers & Web infrastructure",
+    question: "Which of these rows record an act by the user at all?",
+    boundary:
+      "Advertising and tracking beacons, CDN hosts, URL shorteners and redirect hops, parked domains, consent walls, browser-internal pages.",
+    specialCategory: false,
+  },
+  {
+    id: "unclassified",
+    name: "Unclassified / insufficient signal",
+    question: "Can this row support any claim?",
+    boundary:
+      "The row's title and URL together carry no discriminating signal. A forensic classifier must be permitted to say nothing.",
+    specialCategory: false,
+  },
+]);
+
+export const UNCLASSIFIED_LABEL_ID = "unclassified" as const;
+
+/** Provenance of the frozen supervision text, recorded for auditability. */
+export const TOPIC_TAXONOMY_SOURCE =
+  "ChmaraX/forensix#137 section 3 (label set + forensic question + boundary rules), frozen before labelling" as const;
+
+export const TOPIC_LABELS_BY_ID: ReadonlyMap<string, TopicLabel> = new Map(
+  TOPIC_TAXONOMY.map((label) => [label.id, label]),
+);

--- a/core/test/topic-candidates.test.ts
+++ b/core/test/topic-candidates.test.ts
@@ -1,0 +1,540 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { CASE_FILENAME } from "../src/case.js";
+import type { PersistedCandidate } from "../src/case-findings.js";
+import { createFinding, valueField } from "../src/forensic-model.js";
+import { analyseCase } from "../src/history.js";
+import { ingestUserDataDir } from "../src/ingest.js";
+import { loadTopicEngine } from "../src/topic-candidates-onnx.js";
+import {
+  classifyTopicCandidates,
+  topicInputText,
+  TOPIC_CANDIDATE_KIND,
+  TOPIC_TAXONOMY,
+  UNCLASSIFIED_LABEL_ID,
+  type EmbeddingEngine,
+  type TopicCandidateInput,
+  type TopicClassifierUnavailable,
+} from "../src/topic-candidates.js";
+import { queryTopicCandidates } from "../src/topic-candidates-query.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) =>
+        rm(root, { force: true, recursive: true }).catch(() => undefined),
+      ),
+  );
+});
+
+/**
+ * A deterministic keyword-bag embedding engine. Each keyword is a basis
+ * dimension; embed(text) sets a dimension when its keyword is a substring of the
+ * lowercased text. Because the frozen anchor strings each contain a distinctive
+ * keyword, an input carrying that one keyword aligns with exactly that label.
+ * No model, no network, no randomness — the classifier's decision surface is
+ * exercised in full without the ONNX binary.
+ */
+// Every keyword below is a substring of exactly ONE frozen anchor string, so an
+// input carrying it aligns unambiguously with that single label. (Generic words
+// like "banking" are deliberately avoided: it also appears in the crypto anchor,
+// which the classifier correctly tie-breaks — not what these known-answer cases
+// are asserting.)
+const KEYWORDS = [
+  "brokerage",
+  "streaming",
+  "symptoms",
+  "developer",
+  "casino",
+  "exploit",
+] as const;
+
+function fakeEngine(): EmbeddingEngine {
+  return {
+    modelId: "fake/keyword-bag",
+    modelRevision: "test",
+    embed: (text: string): Float32Array => {
+      const lower = text.toLocaleLowerCase("en-US");
+      const vector = new Float32Array(KEYWORDS.length);
+      KEYWORDS.forEach((keyword, index) => {
+        vector[index] = lower.includes(keyword) ? 1 : 0;
+      });
+      return vector;
+    },
+  };
+}
+
+function input(
+  url: string | null,
+  title: string | null,
+  overrides: Partial<TopicCandidateInput> = {},
+): TopicCandidateInput {
+  return {
+    url,
+    title,
+    profile: "Default",
+    commitState: "committed",
+    provenance: {
+      manifestEntryId: "source-1:0",
+      sourceId: "source-1",
+      manifestEntryOrdinal: 0,
+      manifestPath: "Default/History",
+      database: "Default/History",
+      table: "urls",
+      rowId: url || title || "row",
+    },
+    supportingCount: 1,
+    ...overrides,
+  };
+}
+
+function labelOf(candidate: PersistedCandidate): string {
+  const field = candidate.candidate.fields.topicLabel;
+  return field !== undefined && field.state === "value"
+    ? String(field.value)
+    : "";
+}
+
+describe("classifyTopicCandidates", () => {
+  it("classifies known URL+title inputs to the expected topic label", async () => {
+    const cases: {
+      readonly input: TopicCandidateInput;
+      readonly label: string;
+    }[] = [
+      {
+        input: input("https://chase.com/x", "brokerage account"),
+        label: "finance_banking",
+      },
+      {
+        input: input("https://netflix.com/browse", "streaming now"),
+        label: "entertainment_streaming_gaming",
+      },
+      {
+        input: input("https://webmd.com", "flu symptoms"),
+        label: "health_medical",
+      },
+      {
+        input: input("https://example.dev", "developer guide"),
+        label: "technology_software_dev",
+      },
+      {
+        input: input("https://bet365.com", "casino night"),
+        label: "gambling",
+      },
+      {
+        input: input("https://ex.example", "exploit writeup"),
+        label: "hacking_security_tooling",
+      },
+    ];
+    const result = await classifyTopicCandidates(
+      fakeEngine(),
+      cases.map((entry) => entry.input),
+    );
+    expect(Array.isArray(result)).toBe(true);
+    const candidates = result as PersistedCandidate[];
+    for (const entry of cases) {
+      const top = candidates.find(
+        (candidate) =>
+          candidate.candidate.provenance.rowId ===
+            entry.input.provenance.rowId && candidate.candidate.rank === 1,
+      );
+      expect(top, `rank-1 candidate for ${entry.label}`).toBeDefined();
+      expect(labelOf(top as PersistedCandidate)).toBe(entry.label);
+    }
+  });
+
+  it("emits every output as a ranked, counted, provenance-bearing Candidate", async () => {
+    const result = await classifyTopicCandidates(fakeEngine(), [
+      input("https://chase.com/x", "brokerage", { supportingCount: 7 }),
+    ]);
+    const candidates = result as PersistedCandidate[];
+    expect(candidates.length).toBeGreaterThan(0);
+    for (const row of candidates) {
+      expect(row.candidate.recordType).toBe("candidate");
+      expect(row.candidate.candidateKind).toBe(TOPIC_CANDIDATE_KIND);
+      expect(row.candidate.rank).toBeGreaterThanOrEqual(1);
+      expect(row.candidate.count).toBe(7);
+      // Provenance resolves back to a source row.
+      expect(row.candidate.provenance.manifestEntryId).toBe("source-1:0");
+      expect(row.candidate.provenance.rowId.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("treats negative (blank) inputs as unclassified, never a confident topic", async () => {
+    const result = await classifyTopicCandidates(fakeEngine(), [
+      input(null, null),
+      input("   ", "\t"),
+      input("", ""),
+    ]);
+    const candidates = result as PersistedCandidate[];
+    expect(candidates).toHaveLength(3);
+    for (const row of candidates) {
+      expect(labelOf(row)).toBe(UNCLASSIFIED_LABEL_ID);
+      expect(row.candidate.rank).toBe(1);
+    }
+  });
+
+  it("is deterministic: identical inputs produce byte-identical candidates", async () => {
+    const inputs = [
+      input("https://chase.com/x", "brokerage"),
+      input("https://bet365.com", "casino"),
+    ];
+    const first = (await classifyTopicCandidates(
+      fakeEngine(),
+      inputs,
+    )) as PersistedCandidate[];
+    const second = (await classifyTopicCandidates(
+      fakeEngine(),
+      inputs,
+    )) as PersistedCandidate[];
+    expect(JSON.stringify(second)).toBe(JSON.stringify(first));
+  });
+
+  it("ranks multi-label emission by score with a stable label-id tie-break", async () => {
+    // "brokerage" and "casino" both present: finance and gambling both score.
+    const result = (await classifyTopicCandidates(
+      fakeEngine(),
+      [input("https://x.example", "brokerage casino")],
+      { maxLabels: 5, multiLabelDelta: 1 },
+    )) as PersistedCandidate[];
+    const labels = result.map(labelOf);
+    expect(labels).toContain("finance_banking");
+    expect(labels).toContain("gambling");
+    // Equal scores tie-break deterministically by label id (ascending).
+    const ranks = result.map((row) => row.candidate.rank);
+    expect(ranks).toEqual([...ranks].sort((a, b) => a - b));
+  });
+
+  it("reports typed unavailability when inference throws, without fabricating rows", async () => {
+    const throwing: EmbeddingEngine = {
+      modelId: "fake/throwing",
+      modelRevision: "test",
+      embed: () => {
+        throw new Error("simulated inference failure");
+      },
+    };
+    const result = await classifyTopicCandidates(throwing, [
+      input("https://chase.com/x", "brokerage"),
+    ]);
+    expect(Array.isArray(result)).toBe(false);
+    const unavailable = result as TopicClassifierUnavailable;
+    expect(unavailable.available).toBe(false);
+    expect(unavailable.reason).toBe("inference_failed");
+  });
+
+  it("holds a complete 20-label frozen taxonomy including unclassified", () => {
+    expect(TOPIC_TAXONOMY).toHaveLength(20);
+    expect(TOPIC_TAXONOMY.map((label) => label.id)).toContain(
+      UNCLASSIFIED_LABEL_ID,
+    );
+    expect(
+      TOPIC_TAXONOMY.filter((label) => label.specialCategory),
+    ).toHaveLength(2);
+  });
+
+  it("builds encoder input as title then URL", () => {
+    expect(topicInputText("https://x.example", "Title")).toBe(
+      "Title https://x.example",
+    );
+    expect(topicInputText(null, "Title")).toBe("Title");
+    expect(topicInputText("https://x.example", null)).toBe("https://x.example");
+    expect(topicInputText("  ", "  ")).toBe("");
+  });
+});
+
+describe("contamination controls", () => {
+  it("keeps Candidates structurally distinct from Findings", async () => {
+    const candidates = (await classifyTopicCandidates(fakeEngine(), [
+      input("https://chase.com/x", "brokerage"),
+    ])) as PersistedCandidate[];
+    const first = candidates[0];
+    expect(first).toBeDefined();
+
+    // A Finding built from the same source row is a different record type: it
+    // carries `findingKind`, not `candidateKind`. No classifier output ever
+    // acquires the Finding shape, so nothing here can enter a Finding
+    // collection or a factual summary tile.
+    const finding = createFinding({
+      findingKind: "history_most_visited_summary",
+      profile: "Default",
+      commitState: "committed",
+      provenance: (first as PersistedCandidate).candidate.provenance,
+      fields: { url: valueField("https://chase.com/x") },
+    });
+    expect(finding.recordType).toBe("finding");
+    expect("findingKind" in finding).toBe(true);
+    for (const candidate of candidates) {
+      expect(candidate.candidate.recordType).toBe("candidate");
+      expect("candidateKind" in candidate.candidate).toBe(true);
+      expect("findingKind" in candidate.candidate).toBe(false);
+    }
+  });
+});
+
+describe("loadTopicEngine", () => {
+  it("reports model_artifact_missing when no model directory is present", async () => {
+    const result = await loadTopicEngine({ modelDir: undefined });
+    expect("available" in result && result.available === false).toBe(true);
+    expect((result as TopicClassifierUnavailable).reason).toBe(
+      "model_artifact_missing",
+    );
+  });
+
+  it("reports model_artifact_missing for a directory without the ONNX file", async () => {
+    const root = await mkdtemp(join(tmpdir(), "forensix-topic-model-"));
+    temporaryRoots.push(root);
+    const result = await loadTopicEngine({ modelDir: root });
+    expect((result as TopicClassifierUnavailable).reason).toBe(
+      "model_artifact_missing",
+    );
+  });
+});
+
+async function createHistory(
+  path: string,
+  rows: readonly {
+    readonly id: bigint;
+    readonly urlId: bigint;
+    readonly url: string;
+    readonly title: string;
+    readonly visitTime: bigint;
+  }[],
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY, segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL, visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    const insertUrl = database.prepare(
+      `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, ?, ?, ?, 0)`,
+    );
+    const insertVisit = database.prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, ?, 0, '', 0, 0, 0, 1, 0, '', 0, 0, 0, 1, 1, 0, '')`,
+    );
+    for (const row of rows) {
+      insertUrl.run(row.urlId, row.url, row.title, 1, 1, row.visitTime);
+      insertVisit.run(row.id, row.urlId, row.visitTime);
+    }
+  } finally {
+    database.close();
+  }
+}
+
+async function ingest(
+  sourcePath: string,
+  caseDirectory: string,
+): Promise<void> {
+  const generator = ingestUserDataDir({ sourcePath, caseDirectory });
+  let next = await generator.next();
+  while (next.done !== true) {
+    next = await generator.next();
+  }
+}
+
+interface StoredRow {
+  readonly kind: string;
+  readonly profile: string;
+  readonly commit: string;
+  readonly provenance: string;
+  readonly fields: string;
+}
+
+function readFindings(caseDirectory: string): StoredRow[] {
+  const database = new DatabaseSync(join(caseDirectory, CASE_FILENAME), {
+    readOnly: true,
+  });
+  try {
+    const rows = database
+      .prepare(
+        `SELECT f.finding_kind, f.profile_path, f.commit_state,
+              f.provenance_json, f.fields_json
+           FROM forensic_findings f
+           JOIN history_artifact_results r ON r.artifact_result_id = f.artifact_result_id
+          WHERE r.active = 1
+          ORDER BY f.finding_kind, f.provenance_json, f.fields_json`,
+      )
+      .all() as unknown as {
+      finding_kind: string;
+      profile_path: string;
+      commit_state: string;
+      provenance_json: string;
+      fields_json: string;
+    }[];
+    return rows.map((row) => ({
+      kind: row.finding_kind,
+      profile: row.profile_path,
+      commit: row.commit_state,
+      provenance: row.provenance_json,
+      fields: row.fields_json,
+    }));
+  } finally {
+    database.close();
+  }
+}
+
+function countCandidates(caseDirectory: string): number {
+  const database = new DatabaseSync(join(caseDirectory, CASE_FILENAME), {
+    readOnly: true,
+  });
+  try {
+    const row = database
+      .prepare(
+        `SELECT COUNT(*) AS n
+           FROM forensic_candidates c
+           JOIN history_artifact_results r ON r.artifact_result_id = c.artifact_result_id
+          WHERE r.active = 1`,
+      )
+      .get() as { n: number | bigint };
+    return Number(row.n);
+  } finally {
+    database.close();
+  }
+}
+
+async function buildCase(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "forensix-topic-int-"));
+  temporaryRoots.push(root);
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"), [
+    {
+      id: 1n,
+      urlId: 10n,
+      url: "https://chase.com/x",
+      title: "brokerage account",
+      visitTime: 13350000000000000n,
+    },
+    {
+      id: 2n,
+      urlId: 20n,
+      url: "https://bet365.com/casino",
+      title: "casino night",
+      visitTime: 13350000000000001n,
+    },
+  ]);
+  const caseDirectory = join(root, "CASE");
+  await ingest(source, caseDirectory);
+  return caseDirectory;
+}
+
+describe("topic classification integration", () => {
+  it("stores Candidates when an engine is available and exposes them via the query surface", async () => {
+    const caseDirectory = await buildCase();
+    const result = await analyseCase({
+      caseDirectory,
+      topicClassification: { engine: fakeEngine() },
+    });
+    expect(result.topicCandidates.status).toBe("complete");
+    expect(result.topicCandidates.candidateCount).toBeGreaterThan(0);
+    expect(result.history.candidateCount).toBe(
+      result.topicCandidates.candidateCount,
+    );
+    expect(countCandidates(caseDirectory)).toBe(
+      result.topicCandidates.candidateCount,
+    );
+
+    const page = queryTopicCandidates({ caseDirectory, sort: "rank" });
+    expect(page.command).toBe("topic-candidates");
+    for (const item of page.items) {
+      expect(item.recordType).toBe("candidate");
+    }
+
+    const finance = queryTopicCandidates({
+      caseDirectory,
+      label: "finance_banking",
+    });
+    expect(finance.items.length).toBeGreaterThan(0);
+    for (const item of finance.items) {
+      const field = item.fields.topicLabel;
+      expect(field?.state === "value" ? field.value : null).toBe(
+        "finance_banking",
+      );
+    }
+  });
+
+  it("leaves every Finding row byte-for-byte unchanged when classification is disabled", async () => {
+    const caseDirectory = await buildCase();
+
+    await analyseCase({
+      caseDirectory,
+      topicClassification: { enabled: false },
+    });
+    const disabledFindings = readFindings(caseDirectory);
+    expect(countCandidates(caseDirectory)).toBe(0);
+
+    await analyseCase({
+      caseDirectory,
+      topicClassification: { engine: fakeEngine() },
+    });
+    const classifiedFindings = readFindings(caseDirectory);
+    expect(countCandidates(caseDirectory)).toBeGreaterThan(0);
+
+    // The classifier is additive: the Finding rows are identical whether or not
+    // it ran.
+    expect(classifiedFindings).toEqual(disabledFindings);
+  });
+
+  it("records typed unavailability yet keeps History findings usable when no model is present", async () => {
+    const caseDirectory = await buildCase();
+    const result = await analyseCase({ caseDirectory });
+    expect(result.topicCandidates.status).toBe("unavailable");
+    expect(result.topicCandidates.reason).toBe("model_artifact_missing");
+    expect(result.history.candidateCount).toBe(0);
+    // History analysis is complete and its Findings are present regardless.
+    expect(result.history.findingCount).toBeGreaterThan(0);
+    expect(countCandidates(caseDirectory)).toBe(0);
+    expect(readFindings(caseDirectory).length).toBeGreaterThan(0);
+  });
+});

--- a/e2e/topic-candidates-cli.test.ts
+++ b/e2e/topic-candidates-cli.test.ts
@@ -1,0 +1,202 @@
+import { spawnSync } from "node:child_process";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+const compiledCli = resolve("cli/dist/cli.js");
+const temporaryRoots: string[] = [];
+
+interface CliResult {
+  readonly status: number | null;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+function runCli(arguments_: readonly string[]): CliResult {
+  const result = spawnSync(process.execPath, [compiledCli, ...arguments_], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+function parseJson<T>(value: string): T {
+  return JSON.parse(value.trim()) as T;
+}
+
+async function createHistory(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL, typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL, hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT, url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL, from_visit INTEGER, external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER, originator_cache_guid TEXT, originator_visit_id INTEGER,
+        originator_from_visit INTEGER, originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER, app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY, segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL, visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+         VALUES (10, 'https://chase.com/x', 'brokerage account', 1, 1, 13350000000000000, 0)`,
+      )
+      .run();
+    database
+      .prepare(
+        `INSERT INTO visits
+           (id, url, visit_time, from_visit, external_referrer_url, transition,
+            segment_id, visit_duration, incremented_omnibox_typed_score,
+            opener_visit, originator_cache_guid, originator_visit_id,
+            originator_from_visit, originator_opener_visit, is_known_to_sync,
+            consider_for_ntp_most_visited, visited_link_id, app_id)
+         VALUES (1, 10, 13350000000000000, 0, '', 0, 0, 0, 1, 0, '', 0, 0, 0, 1, 1, 0, '')`,
+      )
+      .run();
+  } finally {
+    database.close();
+  }
+}
+
+async function buildCase(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "forensix-topic-cli-"));
+  temporaryRoots.push(root);
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"));
+  const caseDirectory = join(root, "CASE");
+  expect(
+    runCli(["ingest", source, "--case", caseDirectory, "--json"]).status,
+  ).toBe(0);
+  return caseDirectory;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) =>
+        rm(root, { force: true, recursive: true }).catch(() => undefined),
+      ),
+  );
+});
+
+interface TopicCandidatePage {
+  readonly status: "ok";
+  readonly command: "topic-candidates";
+  readonly items: readonly { readonly recordType: string }[];
+  readonly nextCursor: string | null;
+  readonly limit: number;
+}
+
+describe("topic-candidates CLI", () => {
+  it("records typed model unavailability during analyse without failing History", async () => {
+    const caseDirectory = await buildCase();
+    const analysis = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    expect(analysis.status).toBe(0);
+    const result = parseJson<{
+      readonly history: {
+        readonly candidateCount: number;
+        readonly findingCount: number;
+      };
+      readonly topicCandidates: {
+        readonly status: string;
+        readonly reason: string | null;
+        readonly candidateCount: number;
+      };
+    }>(analysis.stdout);
+    // No ONNX model ships in the repo: the analyser records a typed reason and
+    // keeps History fully usable.
+    expect(result.topicCandidates.status).toBe("unavailable");
+    expect(result.topicCandidates.reason).toBe("model_artifact_missing");
+    expect(result.topicCandidates.candidateCount).toBe(0);
+    expect(result.history.candidateCount).toBe(0);
+    expect(result.history.findingCount).toBeGreaterThan(0);
+  });
+
+  it("marks classification disabled when analyse opts out", async () => {
+    const caseDirectory = await buildCase();
+    const analysis = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--no-topic-classification",
+      "--json",
+    ]);
+    expect(analysis.status).toBe(0);
+    expect(
+      parseJson<{ readonly topicCandidates: { readonly status: string } }>(
+        analysis.stdout,
+      ).topicCandidates.status,
+    ).toBe("disabled");
+  });
+
+  it("serves a bounded topic-candidates page over the Candidate collection", async () => {
+    const caseDirectory = await buildCase();
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    const page = runCli([
+      "topic-candidates",
+      "--case",
+      caseDirectory,
+      "--sort",
+      "rank",
+      "--json",
+    ]);
+    expect(page.status).toBe(0);
+    const parsed = parseJson<TopicCandidatePage>(page.stdout);
+    expect(parsed.command).toBe("topic-candidates");
+    expect(parsed.limit).toBe(50);
+    expect(Array.isArray(parsed.items)).toBe(true);
+    for (const item of parsed.items) {
+      expect(item.recordType).toBe("candidate");
+    }
+  });
+
+  it("rejects unsupported sort and positional arguments", async () => {
+    const caseDirectory = await buildCase();
+    expect(runCli(["analyse", "--case", caseDirectory, "--json"]).status).toBe(
+      0,
+    );
+    expect(
+      runCli([
+        "topic-candidates",
+        "--case",
+        caseDirectory,
+        "--sort",
+        "confidence",
+        "--json",
+      ]).status,
+    ).toBe(1);
+    expect(
+      runCli(["topic-candidates", "--case", caseDirectory, "stray"]).status,
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #184.

Classifies each distinct History URL+title into the frozen 20-label topic taxonomy and records the result as nominal, ranked **Candidates** — never Findings.

## Acceptance criteria → implementation

| AC | Where |
|----|-------|
| Settled local ONNX model classifies URL+title; **no runtime network / Python / pickle / second analysis process** | `core/src/topic-candidates-onnx.ts` — the settled `minishlab/potion-base-8M` (EmbeddingBag/Model2Vec, pinned by revision `bf8b0566…`, MIT, cross-arch decision parity per the classifier bench #137). Runtime + tokeniser are loaded in-process through a dynamically imported **optional** dependency; single-threaded, basic graph opt. No fetch, no pickle, no subprocess. |
| Every output is a nominal Candidate with **rank + supporting count + resolvable Provenance** | `core/src/topic-candidates.ts` `classifyTopicCandidates` → `createCandidate` rows (rank ≥ 1, count = supporting visits, Provenance carried from the summary Finding). |
| **No classifier output can enter a Finding collection or factual summary tile** | Candidates land only in the separate `forensic_candidates` table via `createCandidate`; the query surface returns `Candidate` records exclusively. Contamination test asserts the structural split. |
| Disabling/removing classification leaves every source artifact row **byte-for-byte unchanged** | Classification is an additive pass over already-built summary Findings; `--no-topic-classification` / absent model attach zero Candidates and mutate no Finding. Integration test compares `forensic_findings` rows across enabled/disabled runs. |
| Unavailable model or inference failure → **typed unavailability**, History stays usable | `TopicClassifierUnavailableReason` (`model_runtime_unavailable`, `model_artifact_missing`, `model_load_failed`, `inference_failed`); `analyseCase` records it in `topicCandidates` and History Findings are produced regardless. |
| **Deterministic tests** — known classifications, negative inputs, contamination controls | `core/test/topic-candidates.test.ts` (14) + `e2e/topic-candidates-cli.test.ts` (4), driven by a deterministic keyword-bag engine so the decision surface is exercised without the model binary. |

## Surface added
- `core/src/topic-candidates.ts` — frozen 20-label taxonomy (from #137 §3), injectable `EmbeddingEngine`, deterministic ranked classifier.
- `core/src/topic-candidates-onnx.ts` — lazy potion-base-8M loader (typed-unavailable when runtime/model absent).
- `core/src/topic-candidates-query.ts` + `forensix topic-candidates` CLI — TYPE-first, search, Profile/Commit-State/label filters, deterministic sort, keyset pagination.
- Wired into `analyseCase` (`--no-topic-classification`); `forensic_candidates` gains label/rank filter+sort columns.

## Notes
- `pnpm verify` green (Node 24.15.0): 25 files, 138 tests.
- The ONNX runtime is intentionally an **optional** dynamic import, so the default install and CI stay dependency-light and this repo (which ships no model binary) reports `model_artifact_missing` rather than failing.
- No research scaffolding added; taxonomy text is embedded as a product constant citing #137.