### PR TITLE
feat(verify): ship offline verification, CI gates, and reproducible releases

### DIFF
--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -10,8 +10,11 @@ permissions:
   contents: read
 
 jobs:
-  verify:
-    name: analyzer / ${{ matrix.os }}
+  # Required gate 1: three-platform full offline verification. `verify:full`
+  # runs format:check, lint, typecheck, the vitest suite, and then the offline
+  # verification harness (compiled CLI: ingest -> analyse -> export) on each OS.
+  verify-full:
+    name: verify:full / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -26,5 +29,62 @@ jobs:
         run: corepack enable
       - name: Install locked dependencies
         run: corepack pnpm install --frozen-lockfile
-      - name: Verify Analyzer
-        run: corepack pnpm verify
+      - name: Verify Analyzer (full, offline)
+        run: corepack pnpm verify:full
+
+  # Required gate 2: static analysis. Redundant with verify-full by design, so
+  # a static regression is reported as its own required check.
+  static:
+    name: static
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+      - name: Format, lint, and type-check
+        run: |
+          corepack pnpm format:check
+          corepack pnpm lint
+          corepack pnpm typecheck
+
+  # Required gate 3: supply chain. The lockfile must be frozen and free of
+  # high-severity advisories in production dependencies.
+  supply-chain:
+    name: supply-chain
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install with a frozen lockfile
+        run: corepack pnpm install --frozen-lockfile
+      - name: Fail on lockfile drift
+        run: git diff --exit-code pnpm-lock.yaml
+      - name: Audit production dependencies
+        run: corepack pnpm audit --prod --audit-level high
+
+  # Required gate 4: bounded scale. The pipeline must process a mid-size History
+  # within a settled wall-clock budget. The million-row case stays a manual
+  # pre-release job (.github/workflows/scale-million.yml).
+  scale:
+    name: scale (bounded)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+      - name: Bounded scale gate (25k visits, 180s budget)
+        run: corepack pnpm verify:scale 25000 180000

--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -88,3 +88,44 @@ jobs:
         run: corepack pnpm install --frozen-lockfile
       - name: Bounded scale gate (25k visits, 180s budget)
         run: corepack pnpm verify:scale 25000 180000
+
+  # Release packaging DRY RUN. Exercises the exact packaging path used by the
+  # analyzer-v* release (version + git SHA injection, npm pack, checksums) so a
+  # broken release is caught on every PR, but publishes NOTHING: no provenance
+  # attestation, no GitHub Release, no npm publish. Those run only from the
+  # tag-triggered release-analyzer.yml workflow.
+  package-dry-run:
+    name: package (dry run)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+      - name: Build
+        run: corepack pnpm build
+      - name: Inject a placeholder version + git SHA
+        run: |
+          set -euo pipefail
+          printf '{\n  "version": "0.0.0-dryrun",\n  "gitSha": "%s"\n}\n' "$GITHUB_SHA" \
+            > cli/dist/build-info.json
+          node cli/dist/cli.js --version
+      - name: Pack and checksum
+        run: |
+          set -euo pipefail
+          mkdir -p dist/analyzer
+          corepack pnpm --filter @forensix/cli pack --pack-destination "$PWD/dist/analyzer"
+          cd dist/analyzer
+          sha256sum ./*.tgz > SHA256SUMS
+          cat SHA256SUMS
+      - name: Assert the tarball ships the compiled CLI
+        run: |
+          set -euo pipefail
+          tarball=$(ls dist/analyzer/*.tgz)
+          tar tzf "$tarball" | grep -qx 'package/dist/cli.js'
+          tar tzf "$tarball" | grep -qx 'package/dist/build-info.json'
+          echo "tarball contains the compiled CLI and injected build info"

--- a/.github/workflows/analyzer.yml
+++ b/.github/workflows/analyzer.yml
@@ -126,6 +126,10 @@ jobs:
         run: |
           set -euo pipefail
           tarball=$(ls dist/analyzer/*.tgz)
-          tar tzf "$tarball" | grep -qx 'package/dist/cli.js'
-          tar tzf "$tarball" | grep -qx 'package/dist/build-info.json'
+          # Materialize the listing once; piping tar into `grep -q` makes grep
+          # close the pipe on first match, killing tar with SIGPIPE and failing
+          # the step under pipefail even though the files are present.
+          listing=$(tar tzf "$tarball")
+          grep -qx 'package/dist/cli.js' <<<"$listing"
+          grep -qx 'package/dist/build-info.json' <<<"$listing"
           echo "tarball contains the compiled CLI and injected build info"

--- a/.github/workflows/collector.yml
+++ b/.github/workflows/collector.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "collector/**"
       - "contracts/manifest/**"
+      - "contracts/acquisition-bundle/**"
       - "contracts/selection-policy.chrome-userdata-1.json"
       - ".github/workflows/collector.yml"
   push:
@@ -13,6 +14,7 @@ on:
     paths:
       - "collector/**"
       - "contracts/manifest/**"
+      - "contracts/acquisition-bundle/**"
       - "contracts/selection-policy.chrome-userdata-1.json"
       - ".github/workflows/collector.yml"
 

--- a/.github/workflows/release-analyzer.yml
+++ b/.github/workflows/release-analyzer.yml
@@ -5,6 +5,10 @@ name: release-analyzer
 # full offline verification, injects the version plus git SHA into the compiled
 # CLI, and ships an npm package tarball with checksums and a build-provenance
 # attestation (AC6). npm publish runs only when an NPM_TOKEN secret is present.
+#
+# This workflow triggers ONLY on a matching tag push. Opening or merging a PR
+# never runs it, so merging this PR publishes nothing. The packaging path is
+# still validated on every PR by the `package-dry-run` job in analyzer.yml.
 on:
   push:
     tags:
@@ -69,7 +73,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: "dist/analyzer/*.tgz"
 

--- a/.github/workflows/release-analyzer.yml
+++ b/.github/workflows/release-analyzer.yml
@@ -19,6 +19,9 @@ jobs:
   release:
     name: release analyzer (npm)
     runs-on: ubuntu-latest
+    env:
+      # Job-level so the publish step's `if` (evaluated in job context) can see it.
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
@@ -83,6 +86,5 @@ jobs:
       - name: Publish to npm
         if: ${{ env.NPM_TOKEN != '' }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: corepack pnpm --filter @forensix/cli publish --no-git-checks --access public

--- a/.github/workflows/release-analyzer.yml
+++ b/.github/workflows/release-analyzer.yml
@@ -1,0 +1,88 @@
+name: release-analyzer
+
+# The analyzer publishes on its own SemVer line and tag prefix `analyzer-v*`,
+# independently of the Collector (issue #188, AC5). Each release is gated by the
+# full offline verification, injects the version plus git SHA into the compiled
+# CLI, and ships an npm package tarball with checksums and a build-provenance
+# attestation (AC6). npm publish runs only when an NPM_TOKEN secret is present.
+on:
+  push:
+    tags:
+      - "analyzer-v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: release analyzer (npm)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+          registry-url: https://registry.npmjs.org
+
+      - name: Resolve version and SHA
+        id: meta
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#analyzer-v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+
+      - name: Full offline verification gate
+        run: corepack pnpm verify:full
+
+      - name: Inject version + git SHA into the compiled CLI
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          COMMIT: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          printf '{\n  "version": "%s",\n  "gitSha": "%s"\n}\n' "$VERSION" "$COMMIT" \
+            > cli/dist/build-info.json
+          node cli/dist/cli.js --version
+
+      - name: Pack the CLI package
+        run: |
+          set -euo pipefail
+          mkdir -p dist/analyzer
+          corepack pnpm --filter @forensix/cli pack --pack-destination "$PWD/dist/analyzer"
+
+      - name: Generate checksums
+        working-directory: dist/analyzer
+        run: |
+          set -euo pipefail
+          sha256sum *.tgz > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "dist/analyzer/*.tgz"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Analyzer ${{ steps.meta.outputs.version }}" \
+            --notes "Analyzer ${{ steps.meta.outputs.version }} (${{ steps.meta.outputs.sha }}). npm package tarball with checksums and a provenance attestation." \
+            dist/analyzer/*.tgz dist/analyzer/SHA256SUMS
+
+      - name: Publish to npm
+        if: ${{ env.NPM_TOKEN != '' }}
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: corepack pnpm --filter @forensix/cli publish --no-git-checks --access public

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -1,0 +1,82 @@
+name: release-collector
+
+# The Collector publishes on its own SemVer line and tag prefix `collector-v*`,
+# independently of the analyzer (issue #188, AC5). Each release ships six raw
+# static Go binaries with checksums and build-provenance attestations, and the
+# version plus git SHA injected at build time (AC6).
+on:
+  push:
+    tags:
+      - "collector-v*"
+
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  release:
+    name: release collector binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: collector/go.mod
+          cache-dependency-path: collector/go.mod
+
+      - name: Resolve version and SHA
+        id: meta
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME#collector-v}"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Test and vet before release
+        working-directory: collector
+        run: |
+          go test ./...
+          go vet ./...
+
+      - name: Cross-build six static binaries with injected version + SHA
+        working-directory: collector
+        shell: bash
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+          COMMIT: ${{ steps.meta.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p ../dist/collector
+          ldflags="-s -w -X main.version=${VERSION} -X main.commit=${COMMIT}"
+          for target in windows/amd64 windows/arm64 darwin/amd64 darwin/arm64 linux/amd64 linux/arm64; do
+            os=${target%/*}
+            arch=${target#*/}
+            suffix=""
+            if [[ "$os" == windows ]]; then suffix=".exe"; fi
+            out="../dist/collector/forensix-collect-${VERSION}-${os}-${arch}${suffix}"
+            CGO_ENABLED=0 GOOS="$os" GOARCH="$arch" \
+              go build -trimpath -ldflags "$ldflags" -o "$out" ./cmd/forensix-collect
+          done
+
+      - name: Generate checksums
+        working-directory: dist/collector
+        run: |
+          set -euo pipefail
+          sha256sum forensix-collect-* > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "dist/collector/forensix-collect-*"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh release create "$GITHUB_REF_NAME" \
+            --title "Collector ${{ steps.meta.outputs.version }}" \
+            --notes "Collector ${{ steps.meta.outputs.version }} (${{ steps.meta.outputs.sha }}). Six static binaries with checksums and provenance attestations." \
+            dist/collector/forensix-collect-* dist/collector/SHA256SUMS

--- a/.github/workflows/release-collector.yml
+++ b/.github/workflows/release-collector.yml
@@ -4,6 +4,10 @@ name: release-collector
 # independently of the analyzer (issue #188, AC5). Each release ships six raw
 # static Go binaries with checksums and build-provenance attestations, and the
 # version plus git SHA injected at build time (AC6).
+#
+# This workflow triggers ONLY on a matching tag push. Opening or merging a PR
+# never runs it, so merging this PR publishes nothing. The six-target build is
+# still validated on every PR by the `race-and-cross-build` job in collector.yml.
 on:
   push:
     tags:
@@ -67,7 +71,7 @@ jobs:
           cat SHA256SUMS
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-path: "dist/collector/forensix-collect-*"
 

--- a/.github/workflows/scale-million.yml
+++ b/.github/workflows/scale-million.yml
@@ -1,0 +1,35 @@
+name: scale-million (manual)
+
+# The million-row scale case is manual pre-release validation, not a required
+# per-PR check (issue #188, AC4). Trigger it before cutting an analyzer release.
+on:
+  workflow_dispatch:
+    inputs:
+      row_count:
+        description: Number of History visits to seed
+        default: "1000000"
+        required: false
+      budget_ms:
+        description: Wall-clock budget for the pipeline in milliseconds
+        default: "1800000"
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  scale-million:
+    name: scale (${{ github.event.inputs.row_count }} visits)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        with:
+          node-version: 24.15.0
+      - name: Enable Corepack
+        run: corepack enable
+      - name: Install locked dependencies
+        run: corepack pnpm install --frozen-lockfile
+      - name: Million-row scale validation
+        run: corepack pnpm verify:scale "${{ github.event.inputs.row_count }}" "${{ github.event.inputs.budget_ms }}"

--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -58,6 +58,35 @@ import {
   type SourceKind,
 } from "@forensix/core";
 import { startDashboardServer } from "@forensix/server";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Release-injected build identity (issue #188, AC6). The release workflow
+ * writes `build-info.json` next to the compiled CLI with the published version
+ * and the exact git SHA it was built from. When present it is appended to the
+ * reported version as `<version>+<gitSha>`. Reading it is a local file read
+ * only — no network, no git invocation — so the offline invariant holds.
+ */
+function resolveToolVersion(): string {
+  try {
+    const buildInfoPath = join(
+      dirname(fileURLToPath(import.meta.url)),
+      "build-info.json",
+    );
+    const info = JSON.parse(readFileSync(buildInfoPath, "utf8")) as {
+      readonly version?: unknown;
+      readonly gitSha?: unknown;
+    };
+    if (typeof info.version === "string" && typeof info.gitSha === "string") {
+      return `${info.version}+${info.gitSha}`;
+    }
+  } catch {
+    // No build stamp (dev tree): fall back to the compiled tool version.
+  }
+  return TOOL_VERSION;
+}
 
 const USAGE = `Usage:
   forensix ingest <source> --case <case-directory> [--source-kind <kind>] [--include-tier-2] [--json]
@@ -375,7 +404,7 @@ async function run(arguments_: readonly string[]): Promise<number> {
     return 0;
   }
   if (arguments_.length === 1 && arguments_[0] === "--version") {
-    process.stdout.write(`${TOOL_VERSION}\n`);
+    process.stdout.write(`${resolveToolVersion()}\n`);
     return 0;
   }
 

--- a/collector/internal/collector/bundle_conformance_test.go
+++ b/collector/internal/collector/bundle_conformance_test.go
@@ -1,0 +1,61 @@
+package collector
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// The Acquisition Bundle Digest is a single cross-implementation contract: the
+// Collector emits `bundle_digest` and the analyzer recomputes it. Both must
+// serialize the sorted Bundle file list identically. This test pins the
+// Collector's digest of the shared golden file set (issue #188, AC6). The
+// analyzer pins the same golden to the same expected value in
+// core/test/acquisition-bundle-conformance.test.ts.
+func TestBundleDigestMatchesSharedGolden(t *testing.T) {
+	directory := filepath.Join(acquisitionBundleFixtureRoot(t), "canonical-v1")
+
+	var files []BundleFile
+	readStrictJSON(t, filepath.Join(directory, "bundle-files.json"), &files)
+
+	var expected struct {
+		BundleDigest string `json:"bundle_digest"`
+	}
+	readStrictJSON(t, filepath.Join(directory, "expected-bundle-digest.json"), &expected)
+
+	got, err := bundleFileDigest(files)
+	if err != nil {
+		t.Fatalf("bundleFileDigest: %v", err)
+	}
+	if got != expected.BundleDigest {
+		t.Fatalf(
+			"Collector Bundle Digest diverged from shared golden:\n got  %s\n want %s",
+			got, expected.BundleDigest,
+		)
+	}
+}
+
+func acquisitionBundleFixtureRoot(t *testing.T) string {
+	t.Helper()
+	_, current, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot locate bundle conformance test")
+	}
+	return filepath.Clean(filepath.Join(
+		filepath.Dir(current), "..", "..", "..",
+		"contracts", "acquisition-bundle", "fixtures",
+	))
+}
+
+func readStrictJSON(t *testing.T, path string, target any) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(content, target); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+}

--- a/contracts/acquisition-bundle/README.md
+++ b/contracts/acquisition-bundle/README.md
@@ -1,0 +1,34 @@
+# Acquisition Bundle Digest contract
+
+The Acquisition Bundle Digest is the single cross-implementation digest for a
+whole Acquisition Bundle. The Collector writes it as `bundle_digest` in
+`bundle_manifest.json`; the analyzer recomputes it independently while
+inspecting a Bundle and refuses a Bundle whose recomputed digest differs.
+
+## Construction
+
+1. List every regular file in the Bundle as `{ path, size, sha256 }`, where
+   `path` is the slash-separated path relative to the Bundle root.
+2. Sort the list by `path`.
+3. Serialize the list as JSON with fields in the order `path`, `size`,
+   `sha256`.
+4. The digest is SHA-256 over those JSON bytes followed by one trailing LF.
+
+Both implementations must serialize identically, so the field order is fixed
+and shared. There is no private copy of this construction:
+
+- Collector: `collector/internal/collector/bundle.go` (`bundleFileDigest`).
+- Analyzer: `core/src/acquisition-bundle.ts`
+  (`acquisitionBundleFilesDigest`).
+
+## Shared golden
+
+`fixtures/canonical-v1/bundle-files.json` is the canonical sorted file list.
+`fixtures/canonical-v1/expected-bundle-digest.json` pins its digest.
+
+Both implementations pin this golden to the same value as a required check:
+
+- Collector: `collector/internal/collector/bundle_conformance_test.go`.
+- Analyzer: `core/test/acquisition-bundle-conformance.test.ts`.
+
+A divergence in either serialization fails these tests before release.

--- a/contracts/acquisition-bundle/fixtures/canonical-v1/bundle-files.json
+++ b/contracts/acquisition-bundle/fixtures/canonical-v1/bundle-files.json
@@ -1,0 +1,22 @@
+[
+  {
+    "path": "sources/00000000-0000-4000-8000-000000000001/bundle_manifest_source.json",
+    "size": 512,
+    "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  },
+  {
+    "path": "sources/00000000-0000-4000-8000-000000000001/manifest.jsonl",
+    "size": 2048,
+    "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  },
+  {
+    "path": "sources/00000000-0000-4000-8000-000000000001/working_copy/Default/History",
+    "size": 40960,
+    "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  },
+  {
+    "path": "sources/00000000-0000-4000-8000-000000000001/working_copy/Local State",
+    "size": 3,
+    "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  }
+]

--- a/contracts/acquisition-bundle/fixtures/canonical-v1/expected-bundle-digest.json
+++ b/contracts/acquisition-bundle/fixtures/canonical-v1/expected-bundle-digest.json
@@ -1,0 +1,3 @@
+{
+  "bundle_digest": "cfee06eb5975d945e326ea8d71cfe85a0e4cf2e612eb0bf7d4bd36c6227c244f"
+}

--- a/core/src/acquisition-bundle.ts
+++ b/core/src/acquisition-bundle.ts
@@ -83,10 +83,25 @@ interface ActualNode {
   readonly stats: BigIntStats;
 }
 
-interface BundleFile {
+export interface BundleFile {
   readonly path: string;
   readonly size: number;
   readonly sha256: string;
+}
+
+/**
+ * The Acquisition Bundle Digest is SHA-256 over the JSON encoding of the sorted
+ * Bundle file list followed by one trailing LF. The Collector emits this as
+ * `bundle_digest`; the analyzer recomputes it independently and refuses a
+ * Bundle whose recomputed digest differs. Both implementations must serialize
+ * the file list identically (field order `path`, `size`, `sha256`), so this is
+ * the single cross-implementation digest construction. See
+ * `contracts/acquisition-bundle/` for the shared golden.
+ */
+export function acquisitionBundleFilesDigest(
+  files: readonly BundleFile[],
+): string {
+  return sha256(`${JSON.stringify(files)}\n`);
 }
 
 interface BundleUserDataDir {
@@ -473,7 +488,7 @@ export async function inspectAcquisitionBundle(
     }
   }
 
-  const actualBundleDigest = sha256(`${JSON.stringify(actualBundleFiles)}\n`);
+  const actualBundleDigest = acquisitionBundleFilesDigest(actualBundleFiles);
   return {
     bundleRoot,
     expectedBundleDigest: manifest.bundleDigest,

--- a/core/src/history-sqlite.ts
+++ b/core/src/history-sqlite.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdtemp, open, rm } from "node:fs/promises";
+import { lstat, mkdir, mkdtemp, open, rm } from "node:fs/promises";
 import type { FileHandle } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, join } from "node:path";
@@ -507,6 +507,19 @@ export async function snapshotVerifiedFile(
   }
 }
 
+/**
+ * Windows CI can transiently refuse the read-write recovery open of a freshly
+ * copied snapshot that still carries a hot rollback journal or WAL. This
+ * budget is finite and comfortably under the History E2E ceiling (60s), so a
+ * genuine deadlock still fails instead of hanging, while a slow-but-transient
+ * Windows lock/scanner window is absorbed. Successful opens are unaffected.
+ */
+const RECOVERY_OPEN_CONFIG = {
+  maxAttempts: 12,
+  maxTotalMs: 15_000,
+  busyTimeoutMs: 10_000,
+} as const;
+
 export async function readHistoryPasses(options: {
   readonly database: VerifiedHistoryFile;
   readonly sidecars: readonly VerifiedHistoryFile[];
@@ -514,20 +527,30 @@ export async function readHistoryPasses(options: {
   const temporaryDirectory = await mkdtemp(
     join(tmpdir(), "forensix-history-snapshot-"),
   );
-  const temporaryDatabasePath = join(
-    temporaryDirectory,
+  // The committed pass reads an immutable (lock-free) snapshot. The recovery
+  // pass must open read-write to roll back a hot journal / checkpoint a WAL,
+  // which acquires exclusive locks and mutates the file. Give recovery its own
+  // pristine copy in a separate directory so its read-write open never contends
+  // with the just-closed committed handle. On Windows a handle close does not
+  // synchronously release the OS lock, and reusing one file for both opens is
+  // the observed source of intermittent "unable to open database file".
+  const committedDirectory = join(temporaryDirectory, "committed");
+  const recoveryDirectory = join(temporaryDirectory, "recovery");
+  await mkdir(committedDirectory, { recursive: true });
+  const committedDatabasePath = join(
+    committedDirectory,
     basename(options.database.path),
   );
   try {
-    await snapshotVerifiedFile(options.database, temporaryDatabasePath);
+    await snapshotVerifiedFile(options.database, committedDatabasePath);
     for (const sidecar of options.sidecars) {
       await snapshotVerifiedFile(
         sidecar,
-        join(temporaryDirectory, basename(sidecar.path)),
+        join(committedDirectory, basename(sidecar.path)),
       );
     }
 
-    const committedDatabase = immutableDatabase(temporaryDatabasePath);
+    const committedDatabase = immutableDatabase(committedDatabasePath);
     let committed: HistoryPass;
     try {
       committed = readPass(committedDatabase);
@@ -555,11 +578,27 @@ export async function readHistoryPasses(options: {
       };
     }
 
+    // Fresh, isolated copy for the read-write rollback/checkpoint open.
+    await mkdir(recoveryDirectory, { recursive: true });
+    const recoveryDatabasePath = join(
+      recoveryDirectory,
+      basename(options.database.path),
+    );
+    await snapshotVerifiedFile(options.database, recoveryDatabasePath);
+    for (const sidecar of options.sidecars) {
+      await snapshotVerifiedFile(
+        sidecar,
+        join(recoveryDirectory, basename(sidecar.path)),
+      );
+    }
+
     let recoveryDatabase: DatabaseSync;
     try {
-      recoveryDatabase = openDatabaseSync(temporaryDatabasePath, {
-        readBigInts: true,
-      });
+      recoveryDatabase = openDatabaseSync(
+        recoveryDatabasePath,
+        { readBigInts: true },
+        RECOVERY_OPEN_CONFIG,
+      );
     } catch (error) {
       return {
         committed,

--- a/core/src/history-sqlite.ts
+++ b/core/src/history-sqlite.ts
@@ -534,22 +534,26 @@ export async function readHistoryPasses(options: {
   // with the just-closed committed handle. On Windows a handle close does not
   // synchronously release the OS lock, and reusing one file for both opens is
   // the observed source of intermittent "unable to open database file".
-  const committedDirectory = join(temporaryDirectory, "committed");
-  const recoveryDirectory = join(temporaryDirectory, "recovery");
-  await mkdir(committedDirectory, { recursive: true });
-  const committedDatabasePath = join(
-    committedDirectory,
-    basename(options.database.path),
-  );
-  try {
-    await snapshotVerifiedFile(options.database, committedDatabasePath);
+  // Copy the verified database and every sidecar into `directory`, preserving
+  // basenames so a hot journal/WAL still sits next to its database. Returns the
+  // snapshot database path.
+  const snapshotInto = async (directory: string): Promise<string> => {
+    await mkdir(directory, { recursive: true });
+    const databasePath = join(directory, basename(options.database.path));
+    await snapshotVerifiedFile(options.database, databasePath);
     for (const sidecar of options.sidecars) {
       await snapshotVerifiedFile(
         sidecar,
-        join(committedDirectory, basename(sidecar.path)),
+        join(directory, basename(sidecar.path)),
       );
     }
+    return databasePath;
+  };
 
+  const committedDirectory = join(temporaryDirectory, "committed");
+  const recoveryDirectory = join(temporaryDirectory, "recovery");
+  try {
+    const committedDatabasePath = await snapshotInto(committedDirectory);
     const committedDatabase = immutableDatabase(committedDatabasePath);
     let committed: HistoryPass;
     try {
@@ -578,18 +582,18 @@ export async function readHistoryPasses(options: {
       };
     }
 
-    // Fresh, isolated copy for the read-write rollback/checkpoint open.
-    await mkdir(recoveryDirectory, { recursive: true });
-    const recoveryDatabasePath = join(
-      recoveryDirectory,
-      basename(options.database.path),
-    );
-    await snapshotVerifiedFile(options.database, recoveryDatabasePath);
-    for (const sidecar of options.sidecars) {
-      await snapshotVerifiedFile(
-        sidecar,
-        join(recoveryDirectory, basename(sidecar.path)),
-      );
+    // Fresh, isolated copy for the read-write rollback/checkpoint open. A copy
+    // failure degrades to committed-only for symmetry with a recovery-open
+    // failure, rather than throwing and killing the whole read.
+    let recoveryDatabasePath: string;
+    try {
+      recoveryDatabasePath = await snapshotInto(recoveryDirectory);
+    } catch (error) {
+      return {
+        committed,
+        recovered: null,
+        recoveryUnavailableReason: `recovery_snapshot_failed:${String(error)}`,
+      };
     }
 
     let recoveryDatabase: DatabaseSync;

--- a/core/test/acquisition-bundle-conformance.test.ts
+++ b/core/test/acquisition-bundle-conformance.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  acquisitionBundleFilesDigest,
+  type BundleFile,
+} from "../src/acquisition-bundle.js";
+
+// Issue #188 (AC6): the Acquisition Bundle Digest is a single cross-
+// implementation contract. The analyzer recomputes it with
+// `acquisitionBundleFilesDigest`; the Collector computes it in
+// `collector/internal/collector/bundle.go`. Both pin the same shared golden
+// file set to the same expected digest, so a divergence in either
+// implementation's serialization fails a required check.
+const fixtureRoot = resolve(
+  "contracts/acquisition-bundle/fixtures/canonical-v1",
+);
+
+describe("Acquisition Bundle Digest cross-implementation conformance", () => {
+  it("matches the shared golden digest the Collector also pins", () => {
+    const files = JSON.parse(
+      readFileSync(`${fixtureRoot}/bundle-files.json`, "utf8"),
+    ) as BundleFile[];
+    const expected = JSON.parse(
+      readFileSync(`${fixtureRoot}/expected-bundle-digest.json`, "utf8"),
+    ) as { readonly bundle_digest: string };
+
+    expect(acquisitionBundleFilesDigest(files)).toBe(expected.bundle_digest);
+  });
+
+  it("depends on file order and content, exposing any serialization drift", () => {
+    const files = JSON.parse(
+      readFileSync(`${fixtureRoot}/bundle-files.json`, "utf8"),
+    ) as BundleFile[];
+    const reordered = [...files].reverse();
+    expect(acquisitionBundleFilesDigest(reordered)).not.toBe(
+      acquisitionBundleFilesDigest(files),
+    );
+  });
+});

--- a/e2e/fixtures/offline-verification/golden/chrome-ground-truth.json
+++ b/e2e/fixtures/offline-verification/golden/chrome-ground-truth.json
@@ -1,0 +1,4 @@
+{
+  "fixture": "chrome-ground-truth",
+  "derivedDigest": "ed323cd47cb5927445a796a0a79819046b5046606234831bcf9e6fdde2bec372"
+}

--- a/e2e/fixtures/offline-verification/golden/chrome-ground-truth.json
+++ b/e2e/fixtures/offline-verification/golden/chrome-ground-truth.json
@@ -1,4 +1,4 @@
 {
   "fixture": "chrome-ground-truth",
-  "derivedDigest": "ed323cd47cb5927445a796a0a79819046b5046606234831bcf9e6fdde2bec372"
+  "derivedDigest": "ce94e229b363df4def9f632f002b7977acb2ff6a2ff4c960f00956a529b90ef3"
 }

--- a/e2e/history-cli.test.ts
+++ b/e2e/history-cli.test.ts
@@ -1133,7 +1133,11 @@ describe("compiled analyzer CLI History Finding pipeline", () => {
         }),
       ]),
     );
-  });
+    // Same headroom as the rollback-journal test: the read-write recovery pass
+    // checkpoints a hot WAL on a freshly-copied snapshot, which Windows CI can
+    // transiently refuse and retry (see openDatabaseSync). Finite, not
+    // disabled: a genuine hang still fails within this ceiling.
+  }, 60_000);
 
   it("recovers rollback-journal rows without merging their Commit State", async () => {
     const root = await mkdtemp(join(tmpdir(), "forensix-history-journal-"));

--- a/e2e/offline-verification.test.ts
+++ b/e2e/offline-verification.test.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// Issue #188 (AC1–AC3): the single offline verification command drives the
+// compiled analyzer CLI from a recorded Source through ingest -> analyse ->
+// export and returns a structured capability, invariant, fixture, and failure
+// report. This test asserts the report contract and that it passes in-repo.
+
+const harness = resolve("scripts/offline-verification.mjs");
+
+interface Capability {
+  readonly name: string;
+  readonly status: "PASS" | "UNCOVERED";
+  readonly refusal?: { readonly code: string } | null;
+}
+
+interface OfflineReport {
+  readonly schema: string;
+  readonly tool: { readonly version: string; readonly gitSha: string };
+  readonly capabilities: readonly Capability[];
+  readonly invariants: readonly {
+    readonly name: string;
+    readonly status: "pass" | "fail";
+  }[];
+  readonly fixtures: readonly {
+    readonly name: string;
+    readonly status: "pass" | "fail";
+  }[];
+  readonly failures: readonly unknown[];
+  readonly ok: boolean;
+}
+
+describe("offline verification harness", () => {
+  it("runs the compiled CLI pipeline and reports PASS/UNCOVERED with no failures", () => {
+    const result = spawnSync(process.execPath, [harness], { encoding: "utf8" });
+    expect(result.status, result.stderr).toBe(0);
+
+    const report = JSON.parse(result.stdout) as OfflineReport;
+    expect(report.schema).toBe("forensix/offline-verification/1");
+    expect(report.ok).toBe(true);
+    expect(report.failures).toHaveLength(0);
+
+    // AC3: the capability table has only PASS and UNCOVERED, and every
+    // UNCOVERED capability is backed by a tested typed refusal (a code).
+    expect(report.capabilities.length).toBeGreaterThan(0);
+    for (const capability of report.capabilities) {
+      expect(["PASS", "UNCOVERED"]).toContain(capability.status);
+      if (capability.status === "UNCOVERED") {
+        expect(capability.refusal?.code).toEqual(expect.any(String));
+      }
+    }
+    // The uncovered refusals we assert on: unsupported collection, timezone-
+    // less range, and an unknown command all refuse with a typed code.
+    const uncovered = report.capabilities.filter(
+      (capability) => capability.status === "UNCOVERED",
+    );
+    expect(uncovered.length).toBeGreaterThanOrEqual(3);
+
+    // AC2: the fixture matrix (ground truth, broken input, negative control)
+    // and every invariant (immutable Source, deterministic rerun, supersede,
+    // golden Extract, exact row counts/seeded fields) pass.
+    for (const invariant of report.invariants) {
+      expect(invariant.status, invariant.name).toBe("pass");
+    }
+    for (const fixture of report.fixtures) {
+      expect(fixture.status, fixture.name).toBe("pass");
+    }
+    const invariantNames = report.invariants.map((entry) => entry.name);
+    expect(invariantNames).toEqual(
+      expect.arrayContaining([
+        "immutable-source.bytes",
+        "deterministic-rerun.extract-digest",
+        "supersede.single-active-artifact",
+        "golden-extract.byte-stable",
+        "row-counts.ground-truth",
+        "seeded-fields.ground-truth",
+      ]),
+    );
+    const fixtureNames = report.fixtures.map((entry) => entry.name);
+    expect(fixtureNames).toEqual(
+      expect.arrayContaining([
+        "chrome-ground-truth",
+        "broken-input",
+        "negative-control",
+      ]),
+    );
+  }, 60_000);
+});

--- a/package.json
+++ b/package.json
@@ -11,11 +11,14 @@
     "build": "pnpm -r --if-present build",
     "typecheck": "pnpm build && pnpm -r --if-present typecheck && tsc -p tsconfig.contracts.json",
     "lint": "eslint core/src core/test cli/src server/src client/src e2e eslint.config.mjs vitest.config.ts && depcruise core/src cli/src server/src client/src --config .dependency-cruiser.cjs",
-    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e",
-    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e",
+    "format": "prettier --write --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e scripts",
+    "format:check": "prettier --check --ignore-unknown package.json pnpm-workspace.yaml tsconfig.base.json tsconfig.contracts.json eslint.config.mjs vitest.config.ts .dependency-cruiser.cjs commitlint.config.cjs core cli server client contracts e2e scripts",
     "prepare": "husky",
     "test": "pnpm build && vitest run",
-    "verify": "pnpm format:check && pnpm lint && pnpm typecheck && vitest run"
+    "verify": "pnpm format:check && pnpm lint && pnpm typecheck && vitest run",
+    "verify:offline": "pnpm build && node scripts/offline-verification.mjs",
+    "verify:scale": "pnpm build && node scripts/scale-gate.mjs",
+    "verify:full": "pnpm verify && pnpm verify:offline"
   },
   "devDependencies": {
     "@commitlint/cli": "^21.2.2",

--- a/scripts/lib/chrome-history-schema.mjs
+++ b/scripts/lib/chrome-history-schema.mjs
@@ -3,9 +3,31 @@
 // exact same ground-truth schema; keeping the DDL here prevents silent drift
 // between the golden Extract and the scale gate.
 
+import { spawnSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { DatabaseSync } from "node:sqlite";
+
+const COMPILED_CLI = resolve("cli/dist/cli.js");
+
+/**
+ * Run the compiled analyzer CLI once and return its normalized result. Shared
+ * by the offline verification harness and the scale gate so both spawn the
+ * exact same binary the same way (large buffer for big JSON pages).
+ * @param {readonly string[]} argv
+ * @returns {{ status: number | null, stdout: string, stderr: string }}
+ */
+export function runCompiledCli(argv) {
+  const result = spawnSync(process.execPath, [COMPILED_CLI, ...argv], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
 
 /** Chrome History schema (version 70) shared by every fixture seeder. */
 export const CHROME_HISTORY_DDL = `

--- a/scripts/lib/chrome-history-schema.mjs
+++ b/scripts/lib/chrome-history-schema.mjs
@@ -1,0 +1,63 @@
+// Single-source Chrome History schema for the offline verification harness and
+// the scale gate. Both drive the compiled analyzer CLI, so they must seed the
+// exact same ground-truth schema; keeping the DDL here prevents silent drift
+// between the golden Extract and the scale gate.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+/** Chrome History schema (version 70) shared by every fixture seeder. */
+export const CHROME_HISTORY_DDL = `
+  CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+  INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+  CREATE TABLE urls (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url LONGVARCHAR, title LONGVARCHAR,
+    visit_count INTEGER DEFAULT 0 NOT NULL,
+    typed_count INTEGER DEFAULT 0 NOT NULL,
+    last_visit_time INTEGER NOT NULL,
+    hidden INTEGER DEFAULT 0 NOT NULL
+  );
+  CREATE TABLE visits (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
+    from_visit INTEGER, external_referrer_url TEXT,
+    transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
+    visit_duration INTEGER DEFAULT 0 NOT NULL,
+    incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+    opener_visit INTEGER, originator_cache_guid TEXT,
+    originator_visit_id INTEGER, originator_from_visit INTEGER,
+    originator_opener_visit INTEGER,
+    is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+    consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+    visited_link_id INTEGER, app_id TEXT
+  );
+  CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+`;
+
+/**
+ * Create a Chrome History database at `path`, run the shared schema DDL, then
+ * invoke `seed(database)` to insert fixture rows.
+ * @param {string} path
+ * @param {(database: DatabaseSync) => void} seed
+ */
+export function createHistoryDatabase(path, seed) {
+  mkdirSync(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(CHROME_HISTORY_DDL);
+    seed(database);
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * Write the minimal Chrome User Data Dir scaffold (a `Local State` file) into
+ * `sourceDirectory`, which must already exist.
+ * @param {string} sourceDirectory
+ */
+export function writeLocalState(sourceDirectory) {
+  writeFileSync(`${sourceDirectory}/Local State`, "{}\n");
+}

--- a/scripts/offline-verification.mjs
+++ b/scripts/offline-verification.mjs
@@ -1,0 +1,718 @@
+#!/usr/bin/env node
+// ForensiX offline verification harness (issue #188, AC1–AC3).
+//
+// One offline command drives the *compiled* analyzer CLI from a recorded
+// Source through ingest -> analyse -> export and returns a structured report of
+// capability, invariant, fixture, and failure details. It runs entirely
+// offline: no network, only the local compiled CLI and local git metadata.
+//
+// The report is a single JSON document on stdout. A short human summary goes to
+// stderr. Exit code is 0 only when every capability, invariant, and fixture
+// check passed.
+//
+// Capability table rule (AC3): a capability is either PASS (supported and
+// exercised) or UNCOVERED. Every UNCOVERED capability must be backed by a
+// tested typed refusal from the CLI — a structured ForensixError with a code
+// and exit status 1 — never a crash or a silently wrong answer.
+//
+// Golden Extract rule (AC2): each fixture pins the reproducible Extract digest
+// to a golden file. `FORENSIX_UPDATE_GOLDEN=1` rewrites goldens locally, but is
+// refused when `CI` is set so goldens can never be rewritten inside CI.
+
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { DatabaseSync } from "node:sqlite";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, "..");
+const COMPILED_CLI = resolve(REPO_ROOT, "cli/dist/cli.js");
+const GOLDEN_DIR = resolve(
+  REPO_ROOT,
+  "e2e/fixtures/offline-verification/golden",
+);
+const REPORT_SCHEMA = "forensix/offline-verification/1";
+
+const updateGolden = process.env.FORENSIX_UPDATE_GOLDEN === "1";
+const inCi = process.env.CI !== undefined && process.env.CI !== "";
+
+/** @typedef {{ status: number | null, stdout: string, stderr: string }} CliResult */
+
+/** @param {readonly string[]} argv @returns {CliResult} */
+function runCli(argv) {
+  const result = spawnSync(process.execPath, [COMPILED_CLI, ...argv], {
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+/** @param {string} value */
+function parseJson(value) {
+  return JSON.parse(value.trim());
+}
+
+/** @param {Buffer} data */
+function sha256(data) {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+function gitSha() {
+  const result = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  if (result.status === 0) {
+    return result.stdout.trim();
+  }
+  return "unknown";
+}
+
+// --- Deterministic Chrome ground-truth fixture -----------------------------
+//
+// A minimal but real Chrome History schema (version 70) with exactly two
+// committed visits over two URLs, plus a visit_source row. The row values are
+// seeded and fixed, so downstream row counts and field values are ground truth.
+
+/** @param {string} path */
+function seedGroundTruthHistory(path) {
+  mkdirSync(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
+        from_visit INTEGER, external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER, originator_cache_guid TEXT,
+        originator_visit_id INTEGER, originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER, app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+      VALUES
+        (10, 'https://alpha.example/start', 'Alpha start', 1, 1, 13348638245123456, 0),
+        (11, 'https://alpha.example/redirected', 'Alpha redirected', 1, 0, 13348638305456000, 0);
+      INSERT INTO visits
+        (id, url, visit_time, from_visit, external_referrer_url, transition,
+         segment_id, visit_duration, incremented_omnibox_typed_score,
+         opener_visit, originator_cache_guid, originator_visit_id,
+         originator_from_visit, originator_opener_visit, is_known_to_sync,
+         consider_for_ntp_most_visited, visited_link_id, app_id)
+      VALUES
+        (1, 10, 13348638245123456, 0, '', 268435457, 0, 2500000, 1, 0, 'origin-cache-guid', 1001, 0, 0, 1, 1, 2001, 'com.example.browser'),
+        (2, 11, 13348638305456000, 1, '', 1610612736, 0, 5000000, 1, 0, 'origin-cache-guid', 1002, 0, 0, 1, 1, 2002, 'com.example.browser');
+      INSERT INTO visit_source (id, source) VALUES (2, 2);
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+/** @param {string} root */
+function makeGroundTruthSource(root) {
+  const source = join(root, "source");
+  mkdirSync(source, { recursive: true });
+  writeFileSync(join(source, "Local State"), "{}\n");
+  seedGroundTruthHistory(join(source, "Default", "History"));
+  return source;
+}
+
+/** A History file with a valid SQLite header but a corrupt body. */
+function makeBrokenSource(root) {
+  const source = join(root, "broken-source");
+  mkdirSync(join(source, "Default"), { recursive: true });
+  writeFileSync(join(source, "Local State"), "{}\n");
+  // Valid SQLite magic header then garbage: opens but fails integrity/reads.
+  const header = Buffer.from("SQLite format 3\u0000", "binary");
+  const garbage = Buffer.alloc(4096 - header.length, 0x7a);
+  writeFileSync(
+    join(source, "Default", "History"),
+    Buffer.concat([header, garbage]),
+  );
+  return source;
+}
+
+// --- Report accumulator -----------------------------------------------------
+
+const capabilities = [];
+const invariants = [];
+const fixtures = [];
+const failures = [];
+
+/** @param {string} scope @param {string} name @param {string} message */
+function fail(scope, name, message) {
+  failures.push({ scope, name, message });
+}
+
+/**
+ * Record a supported capability that was actually exercised.
+ * @param {string} name @param {boolean} exercised @param {string} [detail]
+ */
+function capabilityPass(name, exercised, detail) {
+  if (exercised) {
+    capabilities.push({ name, status: "PASS", detail: detail ?? null });
+  } else {
+    capabilities.push({ name, status: "PASS", detail: detail ?? null });
+    fail("capability", name, "expected PASS but capability was not exercised");
+  }
+}
+
+/**
+ * Record an unsupported capability. It is UNCOVERED only if the CLI refused it
+ * with a typed error code and exit status 1. Anything else is a failure.
+ * @param {string} name @param {CliResult} result
+ */
+function capabilityUncovered(name, result) {
+  let code = null;
+  if (result.status === 1) {
+    try {
+      const parsed = parseJson(result.stderr);
+      if (parsed && typeof parsed.code === "string") {
+        code = parsed.code;
+      }
+    } catch {
+      code = null;
+    }
+  }
+  capabilities.push({
+    name,
+    status: "UNCOVERED",
+    refusal: code ? { code } : null,
+  });
+  if (code === null) {
+    fail(
+      "capability",
+      name,
+      `unsupported behavior must fail through a typed refusal (exit 1 + code); got status ${result.status}`,
+    );
+  }
+}
+
+/** @param {string} name @param {boolean} ok @param {string} detail */
+function invariant(name, ok, detail) {
+  invariants.push({ name, status: ok ? "pass" : "fail", detail });
+  if (!ok) {
+    fail("invariant", name, detail);
+  }
+}
+
+// --- Golden Extract handling ------------------------------------------------
+
+const UUID_GLOBAL_RE =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+/**
+ * Redact values that are inherently per-acquisition — random Case/Source/Run
+ * UUIDs (including composite ids such as `<sourceId>:<ordinal>`) and absolute
+ * filesystem paths — while keeping every stable forensic value: field values,
+ * table/rowId Provenance, Commit State, transition semantics, and ordinals.
+ *
+ * The golden is deliberately taken over the Findings/Candidates *records*, not
+ * over physical file digests. A freshly created SQLite file is not guaranteed
+ * byte-reproducible across acquisitions, so the Evidence Set and Working Copy
+ * digests differ per run even for identical logical content. The record-level
+ * fingerprint is the reproducible whole-Extract ground truth.
+ * @param {unknown} value
+ */
+function redactVolatile(value) {
+  if (typeof value === "string") {
+    let out = value.replace(UUID_GLOBAL_RE, "<uuid>");
+    if (out.startsWith("/") || /^[A-Za-z]:[\\/]/.test(out)) {
+      out = "<path>";
+    }
+    return out;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => redactVolatile(item));
+  }
+  if (value !== null && typeof value === "object") {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = redactVolatile(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * A stable digest over the whole Extract's forensic records: every Finding and
+ * Candidate row across both collection files, with volatile identifiers
+ * redacted. Header, manifest, and generation files are excluded because they
+ * carry acquisition-local digests, paths, and instants.
+ * @param {string} directory
+ */
+function normalizedExtractDigest(directory) {
+  const files = readExtract(directory);
+  const normalized = {};
+  for (const name of Object.keys(files).sort()) {
+    if (!name.endsWith(".jsonl")) {
+      continue;
+    }
+    normalized[name] = files[name]
+      .toString("utf8")
+      .split("\n")
+      .filter((line) => line.length > 0)
+      .map((line) => redactVolatile(JSON.parse(line)));
+  }
+  return sha256(Buffer.from(JSON.stringify(normalized), "utf8"));
+}
+
+/** @param {string} fixtureName @param {string} derivedDigest */
+function checkGolden(fixtureName, derivedDigest) {
+  const goldenPath = join(GOLDEN_DIR, `${fixtureName}.json`);
+  if (updateGolden) {
+    if (inCi) {
+      fail(
+        "golden",
+        fixtureName,
+        "golden updates are disabled in CI (FORENSIX_UPDATE_GOLDEN with CI set)",
+      );
+      return { status: "update_refused" };
+    }
+    mkdirSync(GOLDEN_DIR, { recursive: true });
+    writeFileSync(
+      goldenPath,
+      `${JSON.stringify({ fixture: fixtureName, derivedDigest }, null, 2)}\n`,
+    );
+    return { status: "updated" };
+  }
+  let golden;
+  try {
+    golden = parseJson(readFileSync(goldenPath, "utf8"));
+  } catch {
+    fail("golden", fixtureName, `golden missing: ${goldenPath}`);
+    return { status: "missing" };
+  }
+  if (golden.derivedDigest !== derivedDigest) {
+    fail(
+      "golden",
+      fixtureName,
+      `golden Extract digest mismatch: expected ${golden.derivedDigest}, got ${derivedDigest}`,
+    );
+    return { status: "mismatch" };
+  }
+  return { status: "match" };
+}
+
+// --- Fixture: Chrome ground truth + core invariants -------------------------
+
+/** @param {string} root */
+function runGroundTruthFixture(root) {
+  const checks = [];
+  const source = makeGroundTruthSource(root);
+  const sourceHistory = join(source, "Default", "History");
+  const sourceDigestBefore = sha256(readFileSync(sourceHistory));
+  const caseDirectory = join(root, "CASE");
+
+  const ingest = runCli(["ingest", source, "--case", caseDirectory, "--json"]);
+  capabilityPass("ingest.profile-dir", ingest.status === 0);
+  checks.push({ name: "ingest", ok: ingest.status === 0 });
+  if (ingest.status !== 0) {
+    fixtures.push({ name: "chrome-ground-truth", status: "fail", checks });
+    return;
+  }
+
+  const analyse = runCli([
+    "analyse",
+    "--case",
+    caseDirectory,
+    "--timezone",
+    "America/New_York",
+    "--json",
+  ]);
+  const analyseOk = analyse.status === 0;
+  capabilityPass("analyse.history", analyseOk);
+  checks.push({ name: "analyse", ok: analyseOk });
+  if (analyseOk) {
+    const summary = parseJson(analyse.stdout);
+    const rowsOk =
+      summary.history?.committedVisitCount === 2 &&
+      summary.history?.recoveredVisitCount === 0 &&
+      summary.history?.profileCount === 1;
+    invariant(
+      "row-counts.ground-truth",
+      rowsOk,
+      `expected 2 committed / 0 recovered / 1 profile, got ${JSON.stringify(summary.history)}`,
+    );
+    checks.push({ name: "exact-row-counts", ok: rowsOk });
+  }
+
+  // Seeded field ground truth via the history view.
+  const historyPage = runCli([
+    "history",
+    "--case",
+    caseDirectory,
+    "--view",
+    "visits",
+    "--sort",
+    "visit-time",
+    "--direction",
+    "asc",
+    "--limit",
+    "10",
+    "--json",
+  ]);
+  let fieldsOk = false;
+  if (historyPage.status === 0) {
+    const page = parseJson(historyPage.stdout);
+    const first = page.items?.[0];
+    fieldsOk =
+      first?.fields?.url?.value === "https://alpha.example/start" &&
+      first?.fields?.visitTime?.value?.utc === "2024-01-02T03:04:05.123456Z" &&
+      first?.fields?.transitionCore?.value === "typed";
+  }
+  capabilityPass("history.query.keyset", historyPage.status === 0);
+  invariant(
+    "seeded-fields.ground-truth",
+    fieldsOk,
+    "first visit must decode seeded url/timestamp/transition exactly",
+  );
+  checks.push({ name: "seeded-fields", ok: fieldsOk });
+
+  // Export -> whole golden Extract + deterministic rerun.
+  const extractOne = join(root, "extract-1");
+  const extractTwo = join(root, "extract-2");
+  const exportOne = runCli([
+    "export",
+    "--case",
+    caseDirectory,
+    "--out",
+    extractOne,
+    "--json",
+  ]);
+  const exportTwo = runCli([
+    "export",
+    "--case",
+    caseDirectory,
+    "--out",
+    extractTwo,
+    "--json",
+  ]);
+  const exportOk = exportOne.status === 0 && exportTwo.status === 0;
+  capabilityPass("export.findings", exportOk);
+  capabilityPass(
+    "export.candidates",
+    exportOk && parseJson(exportOne.stdout).candidateCount === 0,
+    "candidates collection produced (count 0)",
+  );
+  checks.push({ name: "export", ok: exportOk });
+
+  if (exportOk) {
+    const summaryOne = parseJson(exportOne.stdout);
+    const summaryTwo = parseJson(exportTwo.stdout);
+    invariant(
+      "deterministic-rerun.extract-digest",
+      summaryOne.derivedDigest === summaryTwo.derivedDigest,
+      "two exports of the same Case must share one derived Extract digest",
+    );
+    checks.push({
+      name: "deterministic-rerun",
+      ok: summaryOne.derivedDigest === summaryTwo.derivedDigest,
+    });
+
+    // Whole golden Extract: every non-generation file byte-stable, and the
+    // reproducible manifest digest pinned to golden.
+    const filesOne = readExtract(extractOne);
+    const filesTwo = readExtract(extractTwo);
+    let byteStable = true;
+    for (const name of Object.keys(filesOne)) {
+      if (name === "export_generation.json") {
+        continue;
+      }
+      if (!filesTwo[name] || !filesOne[name].equals(filesTwo[name])) {
+        byteStable = false;
+      }
+    }
+    invariant(
+      "golden-extract.byte-stable",
+      byteStable,
+      "non-generation Extract files must be byte-identical across reruns",
+    );
+    checks.push({ name: "whole-extract-byte-stable", ok: byteStable });
+    const normalizedDigest = normalizedExtractDigest(extractOne);
+    const golden = checkGolden("chrome-ground-truth", normalizedDigest);
+    checks.push({
+      name: "golden-extract-digest",
+      ok: golden.status === "match" || golden.status === "updated",
+    });
+  }
+
+  // Immutable Source: the recorded Source bytes never change.
+  const sourceDigestAfter = sha256(readFileSync(sourceHistory));
+  invariant(
+    "immutable-source.bytes",
+    sourceDigestBefore === sourceDigestAfter,
+    "the recorded Source must be byte-identical after the full pipeline",
+  );
+  checks.push({
+    name: "immutable-source",
+    ok: sourceDigestBefore === sourceDigestAfter,
+  });
+
+  // Supersede: a second analysis run supersedes the first; exactly one active
+  // History artifact result remains and two runs are recorded.
+  const reanalyse = runCli([
+    "analyse",
+    "--case",
+    caseDirectory,
+    "--timezone",
+    "America/New_York",
+    "--json",
+  ]);
+  let supersedeOk = false;
+  if (reanalyse.status === 0) {
+    const database = new DatabaseSync(join(caseDirectory, "case.fxdb"), {
+      readBigInts: true,
+    });
+    try {
+      const runs = database
+        .prepare("SELECT count(*) AS c FROM analysis_runs")
+        .get();
+      const active = database
+        .prepare(
+          "SELECT count(*) AS c FROM history_artifact_results WHERE active = 1",
+        )
+        .get();
+      supersedeOk = runs.c === 2n && active.c === 1n;
+    } finally {
+      database.close();
+    }
+  }
+  invariant(
+    "supersede.single-active-artifact",
+    supersedeOk,
+    "re-analysis must record a new run and leave exactly one active History artifact",
+  );
+  checks.push({ name: "supersede", ok: supersedeOk });
+
+  const allOk = checks.every((c) => c.ok);
+  fixtures.push({
+    name: "chrome-ground-truth",
+    status: allOk ? "pass" : "fail",
+    checks,
+  });
+}
+
+/** @param {string} directory @returns {Record<string, Buffer>} */
+function readExtract(directory) {
+  const files = {};
+  for (const name of readdirSync(directory)) {
+    files[name] = readFileSync(join(directory, name));
+  }
+  return files;
+}
+
+// --- Fixture: broken input + scripted negative controls ---------------------
+
+/** @param {string} root */
+function runBrokenInputFixture(root) {
+  const checks = [];
+  const source = makeBrokenSource(root);
+  const caseDirectory = join(root, "CASE-BROKEN");
+  const ingest = runCli(["ingest", source, "--case", caseDirectory, "--json"]);
+  // Ingest only copies + hashes, so a corrupt-but-present History is recorded.
+  // Analyse must then refuse to fabricate: it exits with a nonzero typed exit
+  // state and reports the History artifact as unavailable (not complete),
+  // rather than crashing or inventing rows.
+  let refused = false;
+  let outcome = { status: ingest.status, stderr: ingest.stderr };
+  if (ingest.status === 0) {
+    const analyse = runCli(["analyse", "--case", caseDirectory, "--json"]);
+    outcome = { status: analyse.status, stdout: analyse.stdout.slice(0, 200) };
+    // Exit states: 2 = partial, 3 = failed. Either is an honest nonzero exit.
+    const honestExit = analyse.status === 2 || analyse.status === 3;
+    let honestReport = false;
+    try {
+      const s = parseJson(analyse.stdout);
+      honestReport =
+        s.history?.status !== "complete" &&
+        s.history?.unavailableProfileCount >= 1 &&
+        s.history?.committedVisitCount === 0 &&
+        s.history?.recoveredVisitCount === 0;
+    } catch {
+      honestReport = false;
+    }
+    refused = honestExit && honestReport;
+  } else {
+    try {
+      refused = typeof parseJson(ingest.stderr).code === "string";
+    } catch {
+      refused = false;
+    }
+  }
+  invariant(
+    "broken-input.honest-unavailable",
+    refused,
+    `corrupt History must yield an honest nonzero exit with an unavailable artifact (no fabricated rows), got ${JSON.stringify(outcome)}`,
+  );
+  checks.push({ name: "broken-input", ok: refused });
+  fixtures.push({
+    name: "broken-input",
+    status: refused ? "pass" : "fail",
+    checks,
+  });
+}
+
+// --- Capability table: UNCOVERED behaviors via typed refusals ---------------
+
+/** @param {string} root */
+function runUncoveredCapabilities(root) {
+  const source = makeGroundTruthSource(join(root, "cap"));
+  const caseDirectory = join(root, "CASE-CAP");
+  runCli(["ingest", source, "--case", caseDirectory, "--json"]);
+  runCli([
+    "analyse",
+    "--case",
+    caseDirectory,
+    "--timezone",
+    "America/New_York",
+    "--json",
+  ]);
+
+  // Unsupported Extract collection: refused with INVALID_ARGUMENT.
+  capabilityUncovered(
+    "export.collection.telemetry",
+    runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      join(root, "cap-out"),
+      "--collection",
+      "telemetry",
+      "--json",
+    ]),
+  );
+
+  // Unsupported timezone-less range bound: refused with INVALID_ARGUMENT.
+  capabilityUncovered(
+    "history.range.timezone-less",
+    runCli([
+      "history",
+      "--case",
+      caseDirectory,
+      "--from",
+      "2024-01-02T03:04:05",
+      "--limit",
+      "10",
+      "--json",
+    ]),
+  );
+
+  // Unknown command: refused, not crashed.
+  capabilityUncovered("command.unknown", runCli(["frobnicate", "--json"]));
+}
+
+// --- Negative control: empty / non-Chrome Source ----------------------------
+
+/** @param {string} root */
+function runNegativeControl(root) {
+  // A Source path that does not exist must be refused with a typed error and
+  // exit 1, never a stack trace or a silently empty Case.
+  const missing = join(root, "does-not-exist");
+  const caseDirectory = join(root, "CASE-MISSING");
+  const ingest = runCli(["ingest", missing, "--case", caseDirectory, "--json"]);
+  let code = null;
+  if (ingest.status === 1) {
+    try {
+      const parsed = parseJson(ingest.stdout || ingest.stderr);
+      code = typeof parsed.code === "string" ? parsed.code : null;
+    } catch {
+      code = null;
+    }
+  }
+  const refused = code !== null;
+  invariant(
+    "negative-control.missing-source",
+    refused,
+    `a missing Source path must be refused with a typed error (exit 1 + code), got status ${ingest.status}`,
+  );
+  fixtures.push({
+    name: "negative-control",
+    status: refused ? "pass" : "fail",
+    checks: [{ name: "missing-source-refused", ok: refused, code }],
+  });
+}
+
+// --- Main -------------------------------------------------------------------
+
+function main() {
+  const root = mkdtempSync(join(tmpdir(), "forensix-offline-verify-"));
+  try {
+    runGroundTruthFixture(root);
+    runBrokenInputFixture(root);
+    runUncoveredCapabilities(root);
+    runNegativeControl(root);
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+
+  const ok = failures.length === 0;
+  const report = {
+    schema: REPORT_SCHEMA,
+    tool: { version: readToolVersion(), gitSha: gitSha() },
+    startedAt: new Date().toISOString(),
+    goldenMode: updateGolden ? (inCi ? "refused-in-ci" : "update") : "verify",
+    capabilities,
+    invariants,
+    fixtures,
+    failures,
+    ok,
+  };
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+
+  const passCount = capabilities.filter((c) => c.status === "PASS").length;
+  const uncoveredCount = capabilities.filter(
+    (c) => c.status === "UNCOVERED",
+  ).length;
+  process.stderr.write(
+    `offline-verification: ${ok ? "OK" : "FAILED"} — ` +
+      `${passCount} PASS, ${uncoveredCount} UNCOVERED, ` +
+      `${invariants.length} invariants, ${fixtures.length} fixtures, ` +
+      `${failures.length} failures\n`,
+  );
+  for (const failure of failures) {
+    process.stderr.write(
+      `  ✗ [${failure.scope}] ${failure.name}: ${failure.message}\n`,
+    );
+  }
+  process.exit(ok ? 0 : 1);
+}
+
+function readToolVersion() {
+  const result = runCli(["--version"]);
+  return result.status === 0 ? result.stdout.trim() : "unknown";
+}
+
+main();

--- a/scripts/offline-verification.mjs
+++ b/scripts/offline-verification.mjs
@@ -34,6 +34,11 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DatabaseSync } from "node:sqlite";
 
+import {
+  createHistoryDatabase,
+  writeLocalState,
+} from "./lib/chrome-history-schema.mjs";
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
 const COMPILED_CLI = resolve(REPO_ROOT, "cli/dist/cli.js");
@@ -89,35 +94,8 @@ function gitSha() {
 
 /** @param {string} path */
 function seedGroundTruthHistory(path) {
-  mkdirSync(dirname(path), { recursive: true });
-  const database = new DatabaseSync(path);
-  try {
+  createHistoryDatabase(path, (database) => {
     database.exec(`
-      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
-      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
-      CREATE TABLE urls (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        url LONGVARCHAR, title LONGVARCHAR,
-        visit_count INTEGER DEFAULT 0 NOT NULL,
-        typed_count INTEGER DEFAULT 0 NOT NULL,
-        last_visit_time INTEGER NOT NULL,
-        hidden INTEGER DEFAULT 0 NOT NULL
-      );
-      CREATE TABLE visits (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
-        from_visit INTEGER, external_referrer_url TEXT,
-        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
-        visit_duration INTEGER DEFAULT 0 NOT NULL,
-        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
-        opener_visit INTEGER, originator_cache_guid TEXT,
-        originator_visit_id INTEGER, originator_from_visit INTEGER,
-        originator_opener_visit INTEGER,
-        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
-        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
-        visited_link_id INTEGER, app_id TEXT
-      );
-      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
       INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
       VALUES
         (10, 'https://alpha.example/start', 'Alpha start', 1, 1, 13348638245123456, 0),
@@ -133,16 +111,14 @@ function seedGroundTruthHistory(path) {
         (2, 11, 13348638305456000, 1, '', 1610612736, 0, 5000000, 1, 0, 'origin-cache-guid', 1002, 0, 0, 1, 1, 2002, 'com.example.browser');
       INSERT INTO visit_source (id, source) VALUES (2, 2);
     `);
-  } finally {
-    database.close();
-  }
+  });
 }
 
 /** @param {string} root */
 function makeGroundTruthSource(root) {
   const source = join(root, "source");
   mkdirSync(source, { recursive: true });
-  writeFileSync(join(source, "Local State"), "{}\n");
+  writeLocalState(source);
   seedGroundTruthHistory(join(source, "Default", "History"));
   return source;
 }
@@ -151,7 +127,7 @@ function makeGroundTruthSource(root) {
 function makeBrokenSource(root) {
   const source = join(root, "broken-source");
   mkdirSync(join(source, "Default"), { recursive: true });
-  writeFileSync(join(source, "Local State"), "{}\n");
+  writeLocalState(source);
   // Valid SQLite magic header then garbage: opens but fails integrity/reads.
   const header = Buffer.from("SQLite format 3\u0000", "binary");
   const garbage = Buffer.alloc(4096 - header.length, 0x7a);
@@ -175,14 +151,17 @@ function fail(scope, name, message) {
 }
 
 /**
- * Record a supported capability that was actually exercised.
+ * Record a supported capability. It is PASS only when actually exercised; an
+ * unexercised capability is a FAIL, never a PASS row that lies in the table.
  * @param {string} name @param {boolean} exercised @param {string} [detail]
  */
 function capabilityPass(name, exercised, detail) {
-  if (exercised) {
-    capabilities.push({ name, status: "PASS", detail: detail ?? null });
-  } else {
-    capabilities.push({ name, status: "PASS", detail: detail ?? null });
+  capabilities.push({
+    name,
+    status: exercised ? "PASS" : "FAIL",
+    detail: detail ?? null,
+  });
+  if (!exercised) {
     fail("capability", name, "expected PASS but capability was not exercised");
   }
 }
@@ -228,29 +207,36 @@ function invariant(name, ok, detail) {
 
 // --- Golden Extract handling ------------------------------------------------
 
-const UUID_GLOBAL_RE =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+// Provenance identity keys that are randomly assigned per acquisition (Case,
+// Source, and Run UUIDs, plus the composite `<sourceId>:<ordinal>` entry id).
+// Redaction is scoped to these keys only — never by value shape — so a
+// path-shaped or UUID-shaped *forensic field value* stays in the fingerprint
+// and a regression there still moves the golden digest.
+const VOLATILE_KEYS = new Set([
+  "caseId",
+  "manifestId",
+  "manifestEntryId",
+  "sourceId",
+  "source_id",
+  "runId",
+  "run_id",
+]);
 
 /**
- * Redact values that are inherently per-acquisition — random Case/Source/Run
- * UUIDs (including composite ids such as `<sourceId>:<ordinal>`) and absolute
- * filesystem paths — while keeping every stable forensic value: field values,
- * table/rowId Provenance, Commit State, transition semantics, and ordinals.
+ * Redact only the known per-acquisition identity keys, keeping every stable
+ * forensic value: field values, table/rowId Provenance, Commit State,
+ * transition semantics, and ordinals.
  *
  * The golden is deliberately taken over the Findings/Candidates *records*, not
  * over physical file digests. A freshly created SQLite file is not guaranteed
  * byte-reproducible across acquisitions, so the Evidence Set and Working Copy
  * digests differ per run even for identical logical content. The record-level
  * fingerprint is the reproducible whole-Extract ground truth.
- * @param {unknown} value
+ * @param {unknown} value @param {string} [key]
  */
-function redactVolatile(value) {
-  if (typeof value === "string") {
-    let out = value.replace(UUID_GLOBAL_RE, "<uuid>");
-    if (out.startsWith("/") || /^[A-Za-z]:[\\/]/.test(out)) {
-      out = "<path>";
-    }
-    return out;
+function redactVolatile(value, key) {
+  if (key !== undefined && VOLATILE_KEYS.has(key)) {
+    return "<volatile>";
   }
   if (Array.isArray(value)) {
     return value.map((item) => redactVolatile(item));
@@ -258,7 +244,7 @@ function redactVolatile(value) {
   if (value !== null && typeof value === "object") {
     const out = {};
     for (const [k, v] of Object.entries(value)) {
-      out[k] = redactVolatile(v);
+      out[k] = redactVolatile(v, k);
     }
     return out;
   }

--- a/scripts/offline-verification.mjs
+++ b/scripts/offline-verification.mjs
@@ -36,12 +36,12 @@ import { DatabaseSync } from "node:sqlite";
 
 import {
   createHistoryDatabase,
+  runCompiledCli,
   writeLocalState,
 } from "./lib/chrome-history-schema.mjs";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(HERE, "..");
-const COMPILED_CLI = resolve(REPO_ROOT, "cli/dist/cli.js");
 const GOLDEN_DIR = resolve(
   REPO_ROOT,
   "e2e/fixtures/offline-verification/golden",
@@ -53,21 +53,35 @@ const inCi = process.env.CI !== undefined && process.env.CI !== "";
 
 /** @typedef {{ status: number | null, stdout: string, stderr: string }} CliResult */
 
-/** @param {readonly string[]} argv @returns {CliResult} */
-function runCli(argv) {
-  const result = spawnSync(process.execPath, [COMPILED_CLI, ...argv], {
-    encoding: "utf8",
-  });
-  return {
-    status: result.status,
-    stdout: result.stdout ?? "",
-    stderr: result.stderr ?? "",
-  };
-}
+const runCli = runCompiledCli;
 
 /** @param {string} value */
 function parseJson(value) {
   return JSON.parse(value.trim());
+}
+
+/**
+ * Extract a typed ForensixError code from a CLI result, or null if the result
+ * carries no structured refusal. Typed errors are emitted on stderr, but some
+ * commands also mirror them to stdout, so both streams are checked. The caller
+ * decides whether the accompanying exit status is acceptable.
+ * @param {CliResult} result @returns {string | null}
+ */
+function typedRefusalCode(result) {
+  for (const stream of [result.stderr, result.stdout]) {
+    if (!stream) {
+      continue;
+    }
+    try {
+      const parsed = parseJson(stream);
+      if (parsed && typeof parsed.code === "string") {
+        return parsed.code;
+      }
+    } catch {
+      // Not JSON on this stream; try the next.
+    }
+  }
+  return null;
 }
 
 /** @param {Buffer} data */
@@ -172,17 +186,7 @@ function capabilityPass(name, exercised, detail) {
  * @param {string} name @param {CliResult} result
  */
 function capabilityUncovered(name, result) {
-  let code = null;
-  if (result.status === 1) {
-    try {
-      const parsed = parseJson(result.stderr);
-      if (parsed && typeof parsed.code === "string") {
-        code = parsed.code;
-      }
-    } catch {
-      code = null;
-    }
-  }
+  const code = result.status === 1 ? typedRefusalCode(result) : null;
   capabilities.push({
     name,
     status: "UNCOVERED",
@@ -551,11 +555,7 @@ function runBrokenInputFixture(root) {
     }
     refused = honestExit && honestReport;
   } else {
-    try {
-      refused = typeof parseJson(ingest.stderr).code === "string";
-    } catch {
-      refused = false;
-    }
+    refused = typedRefusalCode(ingest) !== null;
   }
   invariant(
     "broken-input.honest-unavailable",
@@ -629,15 +629,7 @@ function runNegativeControl(root) {
   const missing = join(root, "does-not-exist");
   const caseDirectory = join(root, "CASE-MISSING");
   const ingest = runCli(["ingest", missing, "--case", caseDirectory, "--json"]);
-  let code = null;
-  if (ingest.status === 1) {
-    try {
-      const parsed = parseJson(ingest.stdout || ingest.stderr);
-      code = typeof parsed.code === "string" ? parsed.code : null;
-    } catch {
-      code = null;
-    }
-  }
+  const code = ingest.status === 1 ? typedRefusalCode(ingest) : null;
   const refused = code !== null;
   invariant(
     "negative-control.missing-source",

--- a/scripts/scale-gate.mjs
+++ b/scripts/scale-gate.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// ForensiX scale gate (issue #188, AC4).
+//
+// Drives the compiled analyzer CLI through ingest -> analyse -> export over a
+// seeded History of N visits and asserts the pipeline completes within a finite
+// wall-clock budget while returning the exact expected row count. The default
+// size is a bounded CI gate; the million-row case is invoked manually before a
+// release with a larger budget:
+//
+//   node scripts/scale-gate.mjs 25000    180000   # CI gate (default)
+//   node scripts/scale-gate.mjs 1000000  1800000  # manual pre-release
+//
+// Exit 0 only when the counts are exact and the run stayed within budget.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const rowCount = Number.parseInt(process.argv[2] ?? "25000", 10);
+const budgetMs = Number.parseInt(process.argv[3] ?? "180000", 10);
+const COMPILED_CLI = resolve("cli/dist/cli.js");
+
+if (!Number.isInteger(rowCount) || rowCount < 1) {
+  process.stderr.write(`invalid row count: ${process.argv[2]}\n`);
+  process.exit(2);
+}
+
+/** @param {readonly string[]} argv */
+function runCli(argv) {
+  return spawnSync(process.execPath, [COMPILED_CLI, ...argv], {
+    encoding: "utf8",
+    maxBuffer: 256 * 1024 * 1024,
+  });
+}
+
+/** @param {string} path @param {number} count */
+function seedHistory(path, count) {
+  mkdirSync(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
+        from_visit INTEGER, external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER, originator_cache_guid TEXT,
+        originator_visit_id INTEGER, originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER, app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+    `);
+    const insertUrl = database.prepare(
+      `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+       VALUES (?, ?, ?, 1, 0, ?, 0)`,
+    );
+    const insertVisit = database.prepare(
+      `INSERT INTO visits
+         (id, url, visit_time, from_visit, external_referrer_url, transition,
+          segment_id, visit_duration, incremented_omnibox_typed_score,
+          opener_visit, originator_cache_guid, originator_visit_id,
+          originator_from_visit, originator_opener_visit, is_known_to_sync,
+          consider_for_ntp_most_visited, visited_link_id, app_id)
+       VALUES (?, ?, ?, 0, '', 1, 0, ?, 1, 0, '', 0, 0, 0, 0, 1, 0, NULL)`,
+    );
+    const base = 13_348_638_245_123_456n;
+    database.exec("BEGIN");
+    for (let i = 1; i <= count; i += 1) {
+      const id = BigInt(i);
+      const visitTime = base + id;
+      insertUrl.run(id, `https://scale.example/${i}`, `Visit ${i}`, visitTime);
+      insertVisit.run(id, id, visitTime, id);
+    }
+    database.exec("COMMIT");
+  } finally {
+    database.close();
+  }
+}
+
+function main() {
+  const root = mkdtempSync(join(tmpdir(), "forensix-scale-"));
+  const started = Date.now();
+  try {
+    const source = join(root, "source");
+    mkdirSync(source, { recursive: true });
+    writeFileSync(join(source, "Local State"), "{}\n");
+    const seedStart = Date.now();
+    seedHistory(join(source, "Default", "History"), rowCount);
+    const seedMs = Date.now() - seedStart;
+
+    const caseDirectory = join(root, "CASE");
+    const pipelineStart = Date.now();
+    const ingest = runCli([
+      "ingest",
+      source,
+      "--case",
+      caseDirectory,
+      "--json",
+    ]);
+    if (ingest.status !== 0) {
+      throw new Error(`ingest failed (${ingest.status}): ${ingest.stderr}`);
+    }
+    const analyse = runCli([
+      "analyse",
+      "--case",
+      caseDirectory,
+      "--timezone",
+      "UTC",
+      "--json",
+    ]);
+    if (analyse.status !== 0) {
+      throw new Error(`analyse failed (${analyse.status}): ${analyse.stderr}`);
+    }
+    const summary = JSON.parse(analyse.stdout);
+    const committed = summary.history?.committedVisitCount;
+    if (committed !== rowCount) {
+      throw new Error(
+        `expected ${rowCount} committed visits, got ${committed}`,
+      );
+    }
+    const exportOut = join(root, "extract");
+    const exported = runCli([
+      "export",
+      "--case",
+      caseDirectory,
+      "--out",
+      exportOut,
+      "--json",
+    ]);
+    if (exported.status !== 0) {
+      throw new Error(`export failed (${exported.status}): ${exported.stderr}`);
+    }
+    const pipelineMs = Date.now() - pipelineStart;
+    const totalMs = Date.now() - started;
+
+    const report = {
+      schema: "forensix/scale-gate/1",
+      rowCount,
+      budgetMs,
+      seedMs,
+      pipelineMs,
+      totalMs,
+      withinBudget: pipelineMs <= budgetMs,
+      committedVisitCount: committed,
+    };
+    process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+    if (!report.withinBudget) {
+      process.stderr.write(
+        `scale-gate: FAILED — pipeline ${pipelineMs}ms exceeded budget ${budgetMs}ms\n`,
+      );
+      process.exit(1);
+    }
+    process.stderr.write(
+      `scale-gate: OK — ${rowCount} visits in ${pipelineMs}ms (budget ${budgetMs}ms)\n`,
+    );
+  } finally {
+    rmSync(root, { force: true, recursive: true });
+  }
+}
+
+main();

--- a/scripts/scale-gate.mjs
+++ b/scripts/scale-gate.mjs
@@ -13,10 +13,14 @@
 // Exit 0 only when the counts are exact and the run stayed within budget.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
-import { DatabaseSync } from "node:sqlite";
+import { join, resolve } from "node:path";
+
+import {
+  createHistoryDatabase,
+  writeLocalState,
+} from "./lib/chrome-history-schema.mjs";
 
 const rowCount = Number.parseInt(process.argv[2] ?? "25000", 10);
 const budgetMs = Number.parseInt(process.argv[3] ?? "180000", 10);
@@ -37,36 +41,7 @@ function runCli(argv) {
 
 /** @param {string} path @param {number} count */
 function seedHistory(path, count) {
-  mkdirSync(dirname(path), { recursive: true });
-  const database = new DatabaseSync(path);
-  try {
-    database.exec(`
-      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
-      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
-      CREATE TABLE urls (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        url LONGVARCHAR, title LONGVARCHAR,
-        visit_count INTEGER DEFAULT 0 NOT NULL,
-        typed_count INTEGER DEFAULT 0 NOT NULL,
-        last_visit_time INTEGER NOT NULL,
-        hidden INTEGER DEFAULT 0 NOT NULL
-      );
-      CREATE TABLE visits (
-        id INTEGER PRIMARY KEY AUTOINCREMENT,
-        url INTEGER NOT NULL, visit_time INTEGER NOT NULL,
-        from_visit INTEGER, external_referrer_url TEXT,
-        transition INTEGER DEFAULT 0 NOT NULL, segment_id INTEGER,
-        visit_duration INTEGER DEFAULT 0 NOT NULL,
-        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
-        opener_visit INTEGER, originator_cache_guid TEXT,
-        originator_visit_id INTEGER, originator_from_visit INTEGER,
-        originator_opener_visit INTEGER,
-        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
-        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
-        visited_link_id INTEGER, app_id TEXT
-      );
-      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
-    `);
+  createHistoryDatabase(path, (database) => {
     const insertUrl = database.prepare(
       `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
        VALUES (?, ?, ?, 1, 0, ?, 0)`,
@@ -89,9 +64,7 @@ function seedHistory(path, count) {
       insertVisit.run(id, id, visitTime, id);
     }
     database.exec("COMMIT");
-  } finally {
-    database.close();
-  }
+  });
 }
 
 function main() {
@@ -100,7 +73,7 @@ function main() {
   try {
     const source = join(root, "source");
     mkdirSync(source, { recursive: true });
-    writeFileSync(join(source, "Local State"), "{}\n");
+    writeLocalState(source);
     const seedStart = Date.now();
     seedHistory(join(source, "Default", "History"), rowCount);
     const seedMs = Date.now() - seedStart;

--- a/scripts/scale-gate.mjs
+++ b/scripts/scale-gate.mjs
@@ -12,32 +12,25 @@
 //
 // Exit 0 only when the counts are exact and the run stayed within budget.
 
-import { spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 
 import {
   createHistoryDatabase,
+  runCompiledCli,
   writeLocalState,
 } from "./lib/chrome-history-schema.mjs";
 
 const rowCount = Number.parseInt(process.argv[2] ?? "25000", 10);
 const budgetMs = Number.parseInt(process.argv[3] ?? "180000", 10);
-const COMPILED_CLI = resolve("cli/dist/cli.js");
 
 if (!Number.isInteger(rowCount) || rowCount < 1) {
   process.stderr.write(`invalid row count: ${process.argv[2]}\n`);
   process.exit(2);
 }
 
-/** @param {readonly string[]} argv */
-function runCli(argv) {
-  return spawnSync(process.execPath, [COMPILED_CLI, ...argv], {
-    encoding: "utf8",
-    maxBuffer: 256 * 1024 * 1024,
-  });
-}
+const runCli = runCompiledCli;
 
 /** @param {string} path @param {number} count */
 function seedHistory(path, count) {


### PR DESCRIPTION
Closes #188.

One offline command drives the **compiled** analyzer CLI from a recorded Source through ingest → analyse → export and returns a structured capability, invariant, fixture, and failure report.

## Acceptance criteria mapping

- **AC1 — one offline verification command.** `scripts/offline-verification.mjs` (wired as `pnpm verify:offline` / part of `pnpm verify:full`) spawns the compiled `cli/dist/cli.js` through the full pipeline and emits a single structured JSON report (`schema forensix/offline-verification/1`) with capability, invariant, fixture, and failure details. Covered by `e2e/offline-verification.test.ts`.
- **AC2 — fixture matrix + goldens.** Chrome ground truth (exact row counts + seeded field values), broken input (honest nonzero exit, no fabricated rows), immutable-Source byte check, deterministic reruns, supersede (one active History artifact after re-analysis), and a scripted negative control (missing Source → typed refusal). Whole golden Extract pinned as a normalized record-level digest under `e2e/fixtures/offline-verification/golden/`. **Golden updates are refused when `CI` is set.**
- **AC3 — capability table PASS/UNCOVERED only.** Every UNCOVERED capability (unsupported Extract collection, timezone-less range bound, unknown command) is proven to fail through a **tested typed refusal** (exit 1 + `ForensixError` code), never a crash.
- **AC4 — required checks within settled budgets.** `analyzer.yml` now runs three-platform `verify:full` plus dedicated `static`, `supply-chain`, and bounded `scale` (25k visits / 180s) gates. The million-row case is a **manual** `workflow_dispatch` job (`scale-million.yml`). Collector keeps its three-platform + race + six-target cross-build gate.
- **AC5 — independent SemVer + releases.** `release-analyzer.yml` (tag `analyzer-v*`, npm tarball) and `release-collector.yml` (tag `collector-v*`, six raw static Go binaries) publish on independent lines via GitHub Releases.
- **AC6 — checksums, provenance, injected version + SHA, cross-impl bundle digest.** Both releases emit `SHA256SUMS`, attach `actions/attest-build-provenance` attestations, and inject version + git SHA (analyzer `cli/dist/build-info.json` read offline by `--version`; Collector via `-ldflags`). A shared Acquisition Bundle Digest golden (`contracts/acquisition-bundle/`) is pinned identically by the analyzer (`acquisitionBundleFilesDigest`, `core/test/acquisition-bundle-conformance.test.ts`) and the Collector (`bundle_conformance_test.go`).

## Windows flake hardening (part of AC4)

`e2e/history-cli.test.ts` intermittently timed out on Windows with "unable to open database file". Root cause: the read-write recovery pass rolled back a hot journal / checkpointed a WAL on the **same** temp snapshot whose immutable committed handle had just closed — and on Windows a handle close does not synchronously release the OS lock. Fix (semantics unchanged on success, only the transient path changes):

- The recovery pass now opens its **own isolated snapshot copy** in a separate directory, so its read-write open never contends with the committed handle.
- The recovery open uses a **finite, Windows-generous** retry budget (`maxAttempts 12`, `maxTotalMs 15s`, `busyTimeout 10s`) — comfortably under the 60s test ceiling, so a genuine deadlock still fails instead of hanging.

No tests disabled, no assertions or forensic semantics weakened.

## Validation

- `pnpm verify:full` green (format, lint, typecheck, 160 tests, offline harness) on Node 24.15.0.
- Offline harness deterministic across repeated fresh runs; CI golden-update refusal verified.
- Collector `go test ./...` + `go vet ./...` green; cross-build with injected `version+commit` verified (`forensix-collect 9.9.9+deadbeef`).
- Cross-implementation Acquisition Bundle Digest golden matches on both sides.