### PR TITLE
docs: correct facts and simplify Markdown with Simplified Technical English

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,9 @@ Working rules for agents and contributors in this repository.
 ## Toolchain
 
 - **Node 24.15.0** (see `engines` in `package.json`).
-- pnpm workspace monorepo (`core/`, `cli/`, `server/`, `client/`, `contracts/`,
-  `collector/`, `e2e/`).
+- pnpm workspace with four members: `core/`, `cli/`, `server/`, `client/`.
+- `contracts/`, `collector/`, `e2e/`, and `scripts/` are in the repository but
+  are not pnpm workspace members. The Collector is a separate Go program.
 - Run the full gate before pushing:
 
   ```bash
@@ -56,6 +57,6 @@ When you rename a PR, keep the title conventional so the squash commit is valid.
 
 - The Analyzer and Collector are **separate, offline** programs. Do not couple
   them.
-- Do not change Analyzer behavior or output. Hardening (e.g. the bounded SQLite
+- Do not change Analyzer behavior or output. Hardening (for example, the bounded SQLite
   open retry in `core/src/sqlite-open.ts`) must leave successful results
-  byte-for-byte identical; it only affects the transient-failure path.
+  byte-for-byte identical. It only affects the transient-failure path.

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ The metadata is available independently of secret decryption.
 An encrypted secret without authorized key material is `unavailable` with a typed reason, never absent or blank.
 
 The analyzer also parses `Local State` and each Profile's `Preferences` JSON into metadata Findings.
-Browser-level metadata (Chrome version, variations country, OSCrypt key presence) is scoped to the Source; Profile-level metadata (account data, demographics, screen resolution, and avatars) is scoped to its Profile.
+Browser-level metadata (Chrome version, variations country, OSCrypt key presence) is scoped to the Source. Profile-level metadata (account data, demographics, screen resolution, and avatars) is scoped to its Profile.
 Avatar and demographic values that live in the browser-level `profile.info_cache` slice are attributed to the owning Profile through a supporting Provenance row.
-Every value is verified against the current schema and carries a Field State: a removed or inapplicable key is `absent`, while a malformed or unreadable input is `unavailable` with a typed reason.
+Every value is verified against the current schema and carries a Field State.
+A removed or inapplicable key is `absent`.
+A malformed or unreadable input is `unavailable` with a typed reason.
 
 After the Findings are written, the analyzer derives ranked identity and behavior **Candidates** from them (Web Data autofill, Preferences/Local State metadata, and History visits).
 A Candidate is nominal: it is a ranked hypothesis with a supporting count and resolvable row-level Provenance.
@@ -59,7 +61,7 @@ pnpm build
 ```
 
 The workspace members are `core`, `cli`, `server`, and `client`.
-The Collector and the tools under `tools/` are not workspace members.
+The Collector is a separate Go program, not a workspace member.
 
 ## Ingest a Source
 
@@ -90,7 +92,7 @@ The Analyzer does not boot images, write to them, or parse opaque E01 files dire
 
 An Acquisition Bundle preserves every supplied acquisition-time Manifest in the Case.
 Verification reports `match`, `mismatch`, `missing_on_disk`, and `missing_in_manifest` per file.
-Divergent files do not enter the Working Copy; unaffected evidence remains available.
+Divergent files do not enter the Working Copy. Unaffected evidence remains available.
 
 Tier 2 content is off by default for direct, filesystem, and image ingestion.
 Add `--include-tier-2` to copy Tier 2 paths from Selection Policy `chrome-userdata/1`.
@@ -136,7 +138,7 @@ The `analyse` command reports the run exit state through the process exit code:
 | Code | Exit state | Meaning                                                        |
 | ---- | ---------- | -------------------------------------------------------------- |
 | 0    | clean      | Every artifact produced defensible results.                    |
-| 2    | partial    | Some artifacts were unavailable; other results stay queryable. |
+| 2    | partial    | Some artifacts were unavailable. Other results stay queryable.  |
 | 3    | failed     | The analysis produced no defensible artifact result.           |
 | 1    | error      | Usage error, missing Case, or Working Copy integrity refusal.  |
 
@@ -188,7 +190,7 @@ node cli/dist/cli.js cookies \
 
 Each Cookie Finding records host, name, path, flags, and the exact SameSite,
 priority, source scheme, source type, and port. Cookie timestamps use the
-1601 Epoch Family; a legacy schema needs `--origin-os` before the analyzer
+1601 Epoch Family. A legacy schema needs `--origin-os` before the analyzer
 asserts the UTC instant. An encrypted cookie value stays `unavailable` with the
 typed reason `encrypted_secret_without_key_material`, and the Finding still
 reports the encryption scheme (`v10`, `v11`, `v20`) and the ciphertext byte
@@ -199,7 +201,7 @@ as the next `--after` value.
 ## Query Credential Metadata
 
 The `credentials` command returns Login Data Findings with the same bounded, multi-Profile query surface as History.
-Each query returns 50 rows by default; set `--limit` from 1 through 100 and use `nextCursor` as the next `--after` value.
+Each query returns 50 rows by default. Set `--limit` from 1 through 100, and use `nextCursor` as the next `--after` value.
 
 ```sh
 node cli/dist/cli.js credentials \
@@ -223,7 +225,7 @@ The secret itself stays `unavailable` with the reason `encrypted_secret_without_
 
 The `candidates` command returns ranked identity and behavior Candidates with the same bounded, multi-Profile query surface as the Finding lists.
 TYPE (the `candidateKind`) is the first column, and each query returns a Completeness Statement before any row.
-Each query returns 50 rows by default; set `--limit` from 1 through 100 and use `nextCursor` as the next `--after` value.
+Each query returns 50 rows by default. Set `--limit` from 1 through 100, and use `nextCursor` as the next `--after` value.
 
 ```sh
 node cli/dist/cli.js candidates \
@@ -240,7 +242,7 @@ node cli/dist/cli.js candidates \
 
 The sorts are `rank`, `kind`, `supporting-count`, `value`, and `profile`.
 Filter by `--category identity|behavior` and by an exact `--kind`, and repeat `--profile` to query at most 100 Profiles.
-Every row carries its `rank`, `supportingCount`, and resolvable Provenance; aggregated evidence is carried as supporting Provenance rows.
+Every row carries its `rank`, `supportingCount`, and resolvable Provenance. Aggregated evidence is carried as supporting Provenance rows.
 A Candidate never carries a Commit State and is never a Finding.
 See [`docs/candidates.md`](docs/candidates.md) for the heuristics and the deterministic behavior for ties, no evidence, conflicting evidence, and unavailable inputs.
 
@@ -263,8 +265,16 @@ Key material is either operator-`supplied` (`forensix/supplied-key-material/1`) 
 A captured bundle seals each derived OSCrypt row key to an X25519 recipient key, so `--recipient-key` unseals it offline (see `collector/contracts/key-material`).
 Each row is dispatched independently by its own `v10`, `v11`, or `v20` prefix, so a mixed-version database is handled correctly.
 Supported routes are Linux basic, GNOME Keyring, KWallet, macOS Keychain, the Windows `v10` key, and legacy Windows DPAPI, each only within its evidenced bounds.
-A decrypted secret becomes a `value`; it is a Redaction State secret and stays withheld in an Extract unless `--include-secrets` is set.
-Everything else stays `unavailable` with a distinct typed reason and is never a guessed unwrap: `unsupported_app_bound_v20` (Windows `v20` App-Bound), `unsupported_encryption_route`, `no_authorized_key_material`, `decryption_wrong_key`, `decryption_malformed_ciphertext`, `decryption_missing_context`, and `decryption_authentication_failed`.
+A decrypted secret becomes a `value`. It is a Redaction State secret and stays withheld in an Extract unless `--include-secrets` is set.
+Everything else stays `unavailable` with a distinct typed reason and is never a guessed unwrap:
+
+- `unsupported_app_bound_v20` (Windows `v20` App-Bound)
+- `unsupported_encryption_route`
+- `no_authorized_key_material`
+- `decryption_wrong_key`
+- `decryption_malformed_ciphertext`
+- `decryption_missing_context`
+- `decryption_authentication_failed`
 
 ## Export a canonical Extract
 
@@ -292,7 +302,7 @@ The command writes these files:
 Each row keeps its Provenance, Field State, Commit State, and timestamp semantics.
 The Completeness Statement records attempted, produced, absent, and unavailable artifacts before any result row is interpreted.
 
-Plaintext secrets are redacted by default; each withheld value keeps a hash so it stays citable.
+Plaintext secrets are redacted by default. Each withheld value keeps a hash so it stays citable.
 Add `--include-secrets` to disclose them.
 Binary payloads are separately hashed files, never base64 cells.
 
@@ -312,13 +322,17 @@ node cli/dist/cli.js report \
   --json
 ```
 
-The output is one self-contained HTML file with no runtime network dependency: every style is inlined and no external script, stylesheet, font, or image is loaded when the Report is opened.
-The `report` command accepts no `--case` option; its only forensic input is the Extract.
+The output is one self-contained HTML file with no runtime network dependency.
+Every style is inlined.
+When the Report is opened, it loads no external script, stylesheet, font, or image.
+The `report` command accepts no `--case` option. Its only forensic input is the Extract.
 
 The Report preserves the Extract scope, Redaction State, Completeness Statement, Finding vs Candidate type, Field State, Commit State, Provenance, and timestamp semantics.
 Committed and sidecar (WAL / rollback-journal) rows stay in separate groups.
 An empty string, an absent field, and an unavailable value render with three distinct words, never by color alone.
-The Report recomputes the Export Manifest derived digest from the Extract bytes and marks the integrity as `verified` or `altered`, so an Extract edited after export is reported as altered rather than passed off as authentic.
+The Report recomputes the Export Manifest derived digest from the Extract bytes.
+It marks the integrity as `verified` or `altered`.
+An Extract edited after export is reported as altered, never passed off as authentic.
 
 ## Verify the implementation
 

--- a/collector/CONFORMANCE.md
+++ b/collector/CONFORMANCE.md
@@ -15,14 +15,19 @@ The canonical files are:
 
 Collector tests read these files directly.
 There is no private Collector copy of the fixtures.
-The tests compare Manifest bytes and both digests exactly, run every language-neutral Selection Policy case, compare the compiled policy with the machine-readable policy, and reject unknown policy fields.
+The tests do these checks:
+
+- compare Manifest bytes and both digests exactly
+- run every language-neutral Selection Policy case
+- compare the compiled policy with the machine-readable policy
+- reject unknown policy fields
 
 ## Boundary decisions
 
 1. Manifest entries and headers contain only canonical fields in canonical order.
 2. Acquisition-only values, such as the absolute Source path and Go `time.Time`, do not enter Manifest JSON.
 3. Chrome-running and Liveness Evidence remain Acquisition Bundle metadata. They are not added to the canonical Manifest header.
-4. Tier 2 opt-in is recorded by `tier_2_included`; `selection_policy_diff` remains empty.
+4. Tier 2 opt-in is recorded by `tier_2_included`. `selection_policy_diff` remains empty.
 5. Paths outside a User Data Dir, including a platform scanner's external cache path, are not folded into that User Data Dir Manifest. The shared contract must define a second Source boundary before the Collector can represent those paths without a policy diff.
 6. Unsupported filesystem Node Types fail collection explicitly instead of being mislabeled as sockets.
 

--- a/contracts/acquisition-bundle/README.md
+++ b/contracts/acquisition-bundle/README.md
@@ -2,8 +2,8 @@
 
 The Acquisition Bundle Digest is the single cross-implementation digest for a
 whole Acquisition Bundle. The Collector writes it as `bundle_digest` in
-`bundle_manifest.json`; the analyzer recomputes it independently while
-inspecting a Bundle and refuses a Bundle whose recomputed digest differs.
+`bundle_manifest.json`. The analyzer recomputes it independently when it
+inspects a Bundle, and refuses a Bundle whose recomputed digest differs.
 
 ## Construction
 

--- a/contracts/manifest/README.md
+++ b/contracts/manifest/README.md
@@ -81,7 +81,7 @@ Keep the line order and the final LF bytes.
 This command reproduces the digest on a POSIX system:
 
 ```sh
-LC_ALL=C grep '"copied":true' manifest.jsonl | sort | sha256sum
+LC_ALL=C grep '"copied":true' manifest.jsonl | LC_ALL=C sort | sha256sum
 ```
 
 Use `shasum -a 256` instead of `sha256sum` on macOS.

--- a/docs/candidates.md
+++ b/docs/candidates.md
@@ -1,17 +1,17 @@
 # Identity and behavior Candidates
 
-The analyzer derives ranked **Candidates** from the Findings it has already
-written for an Analysis Run. Candidates answer questions like "whose profile is
+The analyzer derives ranked **Candidates** from the Findings it already wrote for an
+Analysis Run. Candidates answer questions like "whose profile is
 this?" and "what does this person do?" without ever asserting an answer.
 
 ## What a Candidate is
 
 A Candidate is a **nominal, ranked hypothesis**. Every Candidate carries:
 
-- a `candidateKind` (the TYPE, always the first column);
-- a `category`, either `identity` or `behavior`;
-- a `rank` (a positive integer, dense within its kind and Profile);
-- a `supportingCount` (how many source rows support it);
+- a `candidateKind` (the TYPE, always the first column)
+- a `category`, either `identity` or `behavior`
+- a `rank` (a positive integer, dense within its kind and Profile)
+- a `supportingCount` (how many source rows support it)
 - resolvable, row-level **Provenance**. When more than one source row supports a
   Candidate, the extra rows are carried as `provenance.supportingRows`.
 
@@ -24,8 +24,8 @@ A Candidate is **never** a Finding and **never** a factual summary tile:
   only here — ranked and hedged — never in a Finding field or a summary tile.
 
 Candidate generation **reads** Findings. It never mutates, hides, re-scores, or
-re-orders any Preferences, Web Data, History, or other source row. Removing the
-Candidate pass leaves every other artifact byte-for-byte identical.
+re-orders any Preferences, Web Data, History, or other source row. If you remove
+the Candidate pass, every other artifact stays byte-for-byte identical.
 
 ## Inputs and heuristics
 
@@ -33,17 +33,17 @@ Each heuristic consumes committed Findings from earlier parsers in the same run.
 
 | Kind                      | Category | Evidence                                                                   |
 | ------------------------- | -------- | -------------------------------------------------------------------------- |
-| `identity_name`           | identity | Web Data autofill name-like fields; Preferences `full_name` / `given_name` |
-| `identity_email`          | identity | Web Data autofill email-like fields or values; Preferences account `email` |
+| `identity_name`           | identity | Web Data autofill name-like fields. Preferences `full_name` / `given_name` |
+| `identity_email`          | identity | Web Data autofill email-like fields or values. Preferences account `email` |
 | `identity_phone`          | identity | Web Data autofill phone/tel/mobile fields                                  |
 | `identity_postal_address` | identity | Web Data autofill address/street/city/state/zip fields                     |
-| `identity_country`        | identity | Web Data autofill country fields; Local State `variations_country`         |
+| `identity_country`        | identity | Web Data autofill country fields. Local State `variations_country`         |
 | `behavior_frequent_host`  | behavior | Host of each committed History visit URL                                   |
 | `behavior_search_query`   | behavior | Query term parsed from known search-engine History URLs                    |
 
 **Linked-device Candidates are deferred.** The parent intent names "linked
 devices" as a future Candidate class, but no linked-device heuristic is supported
-yet; none is emitted, so no linked-device value is ever asserted.
+yet. None is emitted, so no linked-device value is ever asserted.
 
 Only committed evidence is used. Sidecar (WAL / rollback-journal) rows never
 feed Candidate generation, so a recovered row can never inflate a rank.
@@ -53,9 +53,9 @@ feed Candidate generation, so a recovered row can never inflate a rank.
 Within one `candidateKind` and Profile, evidence is grouped by a normalized key
 (trimmed, whitespace-collapsed, lower-cased). Each group becomes one Candidate:
 
-- `supportingCount` is the number of distinct source rows in the group;
+- `supportingCount` is the number of distinct source rows in the group
 - the displayed value is the most frequent raw form, with ties broken by the
-  smallest value in code-unit order;
+  smallest value in code-unit order
 - groups are ordered by `supportingCount` descending, then by normalized value
   ascending, and assigned dense ranks `1..N` in that order.
 
@@ -65,9 +65,9 @@ supporting).
 
 The `supportingCount` is the **full** tally of distinct source rows behind a
 Candidate, even when that exceeds 200. The carried Provenance is a bounded
-sample: `supportingCount` may therefore be larger than the number of resolvable
-Provenance rows. This keeps the rank faithful to all the evidence while keeping
-the stored row list bounded; the count is never silently truncated to match the
+sample: `supportingCount` can therefore be larger than the number of resolvable
+Provenance rows. This keeps the rank faithful to all the evidence and keeps the
+stored row list bounded. The count is never silently truncated to match the
 sample.
 
 ## Deterministic behavior for the awkward cases
@@ -77,9 +77,9 @@ sample.
   ranks. Identical inputs always produce identical output.
 - **No evidence.** A heuristic that finds nothing emits no Candidate. When every
   heuristic is empty but at least one input was produced, the Candidate artifact
-  is `complete` with zero rows — the pass ran and nominated nothing.
+  is `complete` with zero rows. The pass ran and nominated nothing.
 - **Conflicting evidence.** Distinct values under one kind each become their own
-  ranked Candidate. Conflicts are surfaced as a ranked list; they are never
+  ranked Candidate. Conflicts are surfaced as a ranked list. They are never
   merged and never resolved into a single fact.
 - **Unavailable inputs.** An `absent` or `unavailable` input contributes no
   evidence and is named in the artifact `reason` (for example
@@ -95,6 +95,6 @@ contract as every Finding list: TYPE first, and `--search`, `--category`,
 `--kind`, `--profile` (multi-Profile), `--sort`, `--direction`, and keyset
 `--limit` / `--after` pagination. The sorts are `rank`, `kind`,
 `supporting-count`, `value`, and `profile`. Like every other artifact list, the
-Candidate list returns rows only; the Completeness Statement for `Candidates` is
+Candidate list returns rows only. The Completeness Statement for `Candidates` is
 read from the shared `completeness` route (and the dashboard renders it before
 any row).


### PR DESCRIPTION
## What

Review pass over every Markdown file for correctness, consistency, and clarity, then rewrite to ASD-STE100 Simplified Technical English.

## Factual / consistency fixes

1. **`README.md`** — removed a reference to a `tools/` directory that does not exist. The Collector is a separate Go program, not a workspace member.
2. **`AGENTS.md`** — it listed `contracts/`, `collector/`, `e2e/` as pnpm workspace members. `pnpm-workspace.yaml` has only `core`, `cli`, `server`, `client`. Now names the four real members and marks the rest as repo directories.
3. **`contracts/manifest/README.md`** — the Working Copy Digest command had `LC_ALL=C` on `grep` instead of `sort`, so the byte-order sort could break in a non-C locale. Moved it onto `sort` (now matches `collector/README.md`).

## Simplified Technical English (ASD-STE100)

- Split descriptive sentences over the 25-word limit (Rule 6.3).
- Removed semicolons (Rule 8.1) and banned modals `may`/`might`/`could` → `can` (Rule 3.4).
- `e.g.` → `for example` (GR-6); removed present-perfect and `-ing` verbs (Rules 3.4/3.5).
- Converted two dense inline lists to vertical lists (Rule 4.3): the decryption error reasons in `README.md` and the conformance checks in `collector/CONFORMANCE.md`.

## Scope / safety

- Docs only. No change to Analyzer behavior, output, commands, flags, or code strings.
- Verified: 0 true prose sentences over 25 words, 0 semicolons/banned modals/`e.g.` outside code, and Prettier passes on the CI-checked contract docs.

Files: `AGENTS.md`, `README.md`, `collector/CONFORMANCE.md`, `contracts/acquisition-bundle/README.md`, `contracts/manifest/README.md`, `docs/candidates.md`.