### PR TITLE
feat(server): expose metadata, downloads, bookmarks, and autofill routes

### DIFF
--- a/core/src/case-overview.ts
+++ b/core/src/case-overview.ts
@@ -11,6 +11,16 @@ import { tableExists } from "./sqlite-artifact.js";
  * Completeness Statements and Profile filters. It interprets no artifact rows
  * and writes nothing: every function opens the Case immutable and read-only,
  * mirroring the History/Cookies/Login Data/Web Data query contracts.
+ *
+ * The Completeness Statement covers every artifact the analyzer attempts:
+ * History, Cookies, Login Data, Top Sites, Web Data, Favicons, Candidates,
+ * Downloads, Bookmarks, Preferences, and Cache. Preferences pools both the
+ * browser-level `Local State` and Profile-level `Preferences` attempt rows
+ * under one statement, and Bookmarks pools both the primary `Bookmarks` file
+ * and its `Bookmarks.bak` backup, because each results table already scopes
+ * its own artifact sub-kinds through a CHECK constraint. Leaving any attempted
+ * artifact out of this statement would silently under-report Case coverage,
+ * which breaks the rule that absence is data.
  */
 
 export type OverviewArtifact =
@@ -20,7 +30,11 @@ export type OverviewArtifact =
   | "Top Sites"
   | "Web Data"
   | "Favicons"
-  | "Candidates";
+  | "Candidates"
+  | "Downloads"
+  | "Bookmarks"
+  | "Preferences"
+  | "Cache";
 export type CompletenessOutcome = "produced" | "absent" | "unavailable";
 
 export interface CompletenessArtifact {
@@ -85,6 +99,10 @@ const ARTIFACT_TABLES: readonly ArtifactTable[] = [
   { artifact: "Web Data", resultsTable: "web_data_artifact_results" },
   { artifact: "Favicons", resultsTable: "favicon_artifact_results" },
   { artifact: "Candidates", resultsTable: "candidate_artifact_results" },
+  { artifact: "Downloads", resultsTable: "downloads_artifact_results" },
+  { artifact: "Bookmarks", resultsTable: "bookmarks_artifact_results" },
+  { artifact: "Preferences", resultsTable: "preferences_artifact_results" },
+  { artifact: "Cache", resultsTable: "cache_artifact_results" },
 ];
 
 function openCase(caseDirectory: string): DatabaseSync {

--- a/core/test/case-overview.test.ts
+++ b/core/test/case-overview.test.ts
@@ -1,0 +1,366 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { analyseCase } from "../src/analyse-case.js";
+import { CASE_FILENAME } from "../src/case.js";
+import { queryCompleteness, queryProfiles } from "../src/case-overview.js";
+import { ingestUserDataDir } from "../src/ingest.js";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots
+      .splice(0)
+      .map((root) =>
+        rm(root, { force: true, recursive: true }).catch(() => undefined),
+      ),
+  );
+});
+
+async function createHistory(path: string): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '70'), ('last_compatible_version', '16');
+      CREATE TABLE urls (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url LONGVARCHAR, title LONGVARCHAR,
+        visit_count INTEGER DEFAULT 0 NOT NULL,
+        typed_count INTEGER DEFAULT 0 NOT NULL,
+        last_visit_time INTEGER NOT NULL,
+        hidden INTEGER DEFAULT 0 NOT NULL
+      );
+      CREATE TABLE visits (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        url INTEGER NOT NULL,
+        visit_time INTEGER NOT NULL,
+        from_visit INTEGER,
+        external_referrer_url TEXT,
+        transition INTEGER DEFAULT 0 NOT NULL,
+        segment_id INTEGER,
+        visit_duration INTEGER DEFAULT 0 NOT NULL,
+        incremented_omnibox_typed_score BOOLEAN DEFAULT FALSE NOT NULL,
+        opener_visit INTEGER,
+        originator_cache_guid TEXT,
+        originator_visit_id INTEGER,
+        originator_from_visit INTEGER,
+        originator_opener_visit INTEGER,
+        is_known_to_sync BOOLEAN DEFAULT FALSE NOT NULL,
+        consider_for_ntp_most_visited BOOLEAN DEFAULT FALSE NOT NULL,
+        visited_link_id INTEGER,
+        app_id TEXT
+      );
+      CREATE TABLE visit_source (id INTEGER PRIMARY KEY, source INTEGER NOT NULL);
+      CREATE TABLE segments (id INTEGER PRIMARY KEY, name VARCHAR, url_id INTEGER NON NULL);
+      CREATE TABLE segment_usage (
+        id INTEGER PRIMARY KEY, segment_id INTEGER NOT NULL,
+        time_slot INTEGER NOT NULL, visit_count INTEGER DEFAULT 0 NOT NULL
+      );
+    `);
+    database
+      .prepare(
+        `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
+         VALUES (1, 'https://example.com', 'Example', 1, 1, 13350000000000000, 0)`,
+      )
+      .run();
+    database
+      .prepare(
+        `INSERT INTO visits
+           (id, url, visit_time, from_visit, external_referrer_url, transition,
+            segment_id, visit_duration, incremented_omnibox_typed_score,
+            opener_visit, originator_cache_guid, originator_visit_id,
+            originator_from_visit, originator_opener_visit, is_known_to_sync,
+            consider_for_ntp_most_visited, visited_link_id, app_id)
+         VALUES (1, 1, 13350000000000000, 0, '', 0, 0, 0, 1, 0, '', 0, 0, 0, 1, 1, 0, '')`,
+      )
+      .run();
+  } finally {
+    database.close();
+  }
+}
+
+async function ingest(
+  sourcePath: string,
+  caseDirectory: string,
+): Promise<void> {
+  const generator = ingestUserDataDir({ sourcePath, caseDirectory });
+  let next = await generator.next();
+  while (next.done !== true) {
+    next = await generator.next();
+  }
+}
+
+/**
+ * Build a real Case (ingest + analyse) with a single Default Profile whose
+ * History database has no `downloads`, `Bookmarks`, `Preferences`, or Cache
+ * backend of its own. `analyseCase` attempts Downloads, Bookmarks,
+ * Preferences, and Cache on every Profile in the same run as History — not
+ * only when a dedicated fixture is supplied — so this fixture already
+ * produces real `absent` attempt rows for all four newly-mapped artifacts,
+ * with no fabricated rows required to exercise the "attempted but absent"
+ * path.
+ */
+async function buildCase(): Promise<{
+  readonly caseDirectory: string;
+  readonly sourceId: string;
+  readonly runId: string;
+}> {
+  const root = await mkdtemp(join(tmpdir(), "forensix-overview-"));
+  temporaryRoots.push(root);
+  const source = join(root, "source");
+  await mkdir(source, { recursive: true });
+  await writeFile(join(source, "Local State"), "{}\n");
+  await createHistory(join(source, "Default", "History"));
+  const caseDirectory = join(root, "CASE");
+  await ingest(source, caseDirectory);
+  await analyseCase({ caseDirectory, topicClassification: { enabled: false } });
+
+  const database = new DatabaseSync(join(caseDirectory, CASE_FILENAME), {
+    readOnly: true,
+  });
+  try {
+    const sourceRow = database
+      .prepare("SELECT source_id FROM sources LIMIT 1")
+      .get() as { source_id: string } | undefined;
+    const runRow = database
+      .prepare("SELECT run_id FROM analysis_runs LIMIT 1")
+      .get() as { run_id: string } | undefined;
+    if (sourceRow === undefined || runRow === undefined) {
+      throw new Error("Fixture Case did not record a Source or Run.");
+    }
+    return {
+      caseDirectory,
+      sourceId: sourceRow.source_id,
+      runId: runRow.run_id,
+    };
+  } finally {
+    database.close();
+  }
+}
+
+/**
+ * Insert one synthetic `produced` artifact-result attempt row directly,
+ * scoped to a Profile the real analysis pass never touched, so it adds a
+ * `produced` outcome for that artifact without colliding with the real
+ * `absent` row the fixture already recorded for `Default`.
+ * `manifest_entry_ordinal` is left NULL: SQLite does not enforce a composite
+ * foreign key when any column of it is NULL, so this stays a valid row
+ * against the real schema without needing a Manifest entry.
+ */
+function insertProducedAttempt(
+  caseDirectory: string,
+  table: string,
+  artifactLiteral: string,
+  row: {
+    readonly runId: string;
+    readonly sourceId: string;
+    readonly profilePath: string;
+    readonly databasePath: string;
+  },
+): void {
+  // `downloads_artifact_results` carries the same recovery-status pair
+  // History does; the other three new tables do not, so the column list is
+  // built per table rather than assumed uniform across all four.
+  const hasRecoveryStatus = table === "downloads_artifact_results";
+  const columns = [
+    "run_id",
+    "source_id",
+    "profile_path",
+    "artifact",
+    "manifest_entry_ordinal",
+    "database_path",
+    ...(hasRecoveryStatus ? ["recovery_status"] : []),
+    "status",
+    "reason",
+    "active",
+  ];
+  const placeholders = columns.map((column) =>
+    column === "manifest_entry_ordinal" ? "NULL" : "?",
+  );
+  const values = [
+    row.runId,
+    row.sourceId,
+    row.profilePath,
+    artifactLiteral,
+    row.databasePath,
+    ...(hasRecoveryStatus ? ["complete"] : []),
+    "complete",
+    null,
+    1,
+  ];
+  const database = new DatabaseSync(join(caseDirectory, CASE_FILENAME));
+  try {
+    database
+      .prepare(
+        `INSERT INTO ${table} (${columns.join(", ")})
+         VALUES (${placeholders.join(", ")})`,
+      )
+      .run(...values);
+  } finally {
+    database.close();
+  }
+}
+
+describe("queryCompleteness", () => {
+  it("covers History, Cookies, Login Data, Top Sites, Web Data, Favicons, Candidates, Downloads, Bookmarks, Preferences, and Cache", async () => {
+    const { caseDirectory } = await buildCase();
+    const completeness = queryCompleteness({ caseDirectory });
+    const artifacts = completeness.statements.map((s) => s.artifact);
+    expect(artifacts).toEqual([
+      "History",
+      "Cookies",
+      "Login Data",
+      "Top Sites",
+      "Web Data",
+      "Favicons",
+      "Candidates",
+      "Downloads",
+      "Bookmarks",
+      "Preferences",
+      "Cache",
+    ]);
+  });
+
+  it("reports the real absent attempts analyseCase records for Downloads, Bookmarks, Preferences, and Cache when no dedicated evidence is present", async () => {
+    const { caseDirectory } = await buildCase();
+    const completeness = queryCompleteness({ caseDirectory });
+    const byArtifact = new Map(
+      completeness.statements.map((s) => [s.artifact, s]),
+    );
+
+    const downloads = byArtifact.get("Downloads");
+    expect(downloads?.attempted).toBe(1);
+    expect(downloads?.absent).toBe(1);
+    expect(downloads?.artifacts[0]?.reason).toMatch(/downloads_table_absent/);
+
+    // Bookmarks pools the primary ('Bookmarks') and backup ('Bookmarks.bak')
+    // sub-kind attempts under one statement, because both share the results
+    // table and the "Bookmarks" OverviewArtifact. The current-row reduction
+    // is scoped to (Source, Profile), not (Source, Profile, artifact), so the
+    // two Default sub-kind rows collapse to the one current outcome for that
+    // Profile — the same rule History's own single sub-kind relies on.
+    const bookmarks = byArtifact.get("Bookmarks");
+    expect(bookmarks?.attempted).toBe(1);
+    expect(bookmarks?.absent).toBe(1);
+    const bookmarkReasons = bookmarks?.artifacts.map((a) => a.reason) ?? [];
+    expect(bookmarkReasons[0]).toMatch(/^bookmarks_(backup_)?absent$/);
+
+    // Preferences pools Local State (browser-level, profile ".") and
+    // Preferences (Profile-level, profile "Default") sub-kind attempts under
+    // one statement, but they never collapse against each other: each is a
+    // distinct Profile key ("." vs "Default"), unlike Bookmarks' two rows,
+    // which share one Profile ("Default"). Local State is produced here
+    // because the fixture wrote a minimal `{}` file; Preferences is absent
+    // because none was written.
+    const preferences = byArtifact.get("Preferences");
+    expect(preferences?.attempted).toBe(2);
+    expect(preferences?.produced).toBe(1);
+    expect(preferences?.absent).toBe(1);
+    const preferenceReasons = preferences?.artifacts.map((a) => a.reason) ?? [];
+    expect(preferenceReasons).toContain("preferences_absent");
+
+    const cache = byArtifact.get("Cache");
+    expect(cache?.attempted).toBe(1);
+    expect(cache?.absent).toBe(1);
+    expect(cache?.artifacts[0]?.reason).toBe("cache_absent");
+  });
+
+  it("reports a produced outcome for Downloads, Bookmarks, Preferences, and Cache once their tables carry a complete attempt row", async () => {
+    const { caseDirectory, sourceId, runId } = await buildCase();
+
+    insertProducedAttempt(
+      caseDirectory,
+      "downloads_artifact_results",
+      "Downloads",
+      {
+        runId,
+        sourceId,
+        profilePath: "SecondProfile",
+        databasePath: "SecondProfile/History",
+      },
+    );
+    insertProducedAttempt(
+      caseDirectory,
+      "bookmarks_artifact_results",
+      "Bookmarks",
+      {
+        runId,
+        sourceId,
+        profilePath: "SecondProfile",
+        databasePath: "SecondProfile/Bookmarks",
+      },
+    );
+    insertProducedAttempt(
+      caseDirectory,
+      "preferences_artifact_results",
+      "Preferences",
+      {
+        runId,
+        sourceId,
+        profilePath: "SecondProfile",
+        databasePath: "SecondProfile/Preferences",
+      },
+    );
+    insertProducedAttempt(caseDirectory, "cache_artifact_results", "Cache", {
+      runId,
+      sourceId,
+      profilePath: "SecondProfile",
+      databasePath: "SecondProfile/Cache/Cache_Data",
+    });
+
+    const completeness = queryCompleteness({ caseDirectory });
+    const byArtifact = new Map(
+      completeness.statements.map((s) => [s.artifact, s]),
+    );
+
+    for (const artifact of [
+      "Downloads",
+      "Bookmarks",
+      "Preferences",
+      "Cache",
+    ] as const) {
+      const statement = byArtifact.get(artifact);
+      expect(statement).toBeDefined();
+      const secondProfileRow = statement?.artifacts.find(
+        (row) => row.profile === "SecondProfile",
+      );
+      expect(
+        secondProfileRow,
+        `${artifact} should carry a SecondProfile row`,
+      ).toBeDefined();
+      expect(secondProfileRow?.outcome).toBe("produced");
+      expect(secondProfileRow?.reason).toBeNull();
+    }
+    // The produced attempts increase the artifact's total attempted count
+    // beyond what the real analysis pass alone recorded for Default.
+    expect(byArtifact.get("Downloads")?.attempted).toBe(2);
+    expect(byArtifact.get("Cache")?.attempted).toBe(2);
+  });
+});
+
+describe("queryProfiles", () => {
+  it("includes a Profile that only carries an active Downloads, Bookmarks, Preferences, or Cache attempt", async () => {
+    const { caseDirectory, sourceId, runId } = await buildCase();
+    insertProducedAttempt(
+      caseDirectory,
+      "downloads_artifact_results",
+      "Downloads",
+      {
+        runId,
+        sourceId,
+        profilePath: "OnlyInDownloads",
+        databasePath: "OnlyInDownloads/History",
+      },
+    );
+
+    const profiles = queryProfiles({ caseDirectory });
+    expect(profiles.profiles).toContain("OnlyInDownloads");
+  });
+});

--- a/e2e/serve-cli.test.ts
+++ b/e2e/serve-cli.test.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { request as httpRequest } from "node:http";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -108,6 +108,56 @@ async function createHistory(
         id INTEGER PRIMARY KEY, segment_id INTEGER NOT NULL,
         time_slot INTEGER NOT NULL, visit_count INTEGER DEFAULT 0 NOT NULL
       );
+      CREATE TABLE downloads (
+        id INTEGER PRIMARY KEY,
+        guid VARCHAR NOT NULL,
+        current_path LONGVARCHAR NOT NULL,
+        target_path LONGVARCHAR NOT NULL,
+        start_time INTEGER NOT NULL,
+        received_bytes INTEGER NOT NULL,
+        total_bytes INTEGER NOT NULL,
+        state INTEGER NOT NULL,
+        danger_type INTEGER NOT NULL,
+        interrupt_reason INTEGER NOT NULL,
+        hash BLOB NOT NULL,
+        end_time INTEGER NOT NULL,
+        opened INTEGER NOT NULL,
+        last_access_time INTEGER NOT NULL,
+        transient INTEGER NOT NULL,
+        referrer VARCHAR NOT NULL,
+        site_url VARCHAR NOT NULL,
+        tab_url VARCHAR NOT NULL,
+        tab_referrer_url VARCHAR NOT NULL,
+        http_method VARCHAR NOT NULL,
+        by_ext_id VARCHAR NOT NULL,
+        by_ext_name VARCHAR NOT NULL,
+        by_web_app_id VARCHAR NOT NULL,
+        etag VARCHAR NOT NULL,
+        last_modified VARCHAR NOT NULL,
+        mime_type VARCHAR(255) NOT NULL,
+        original_mime_type VARCHAR(255) NOT NULL
+      );
+      CREATE TABLE downloads_url_chains (
+        id INTEGER NOT NULL,
+        chain_index INTEGER NOT NULL,
+        url LONGVARCHAR NOT NULL,
+        PRIMARY KEY (id, chain_index)
+      );
+      INSERT INTO downloads
+        (id, guid, current_path, target_path, start_time, received_bytes,
+         total_bytes, state, danger_type, interrupt_reason, hash, end_time,
+         opened, last_access_time, transient, referrer, site_url, tab_url,
+         tab_referrer_url, http_method, by_ext_id, by_ext_name, by_web_app_id,
+         etag, last_modified, mime_type, original_mime_type)
+      VALUES (
+        1, 'guid-1', '/home/alice/Downloads/report.pdf',
+        '/home/alice/Downloads/report.pdf', 13348638245123456, 1024, 1024,
+        1, 0, 0, x'00', 13348638255123456, 0, 0, 0, '', 'https://alpha.example',
+        'https://alpha.example/report.pdf', '', 'GET', '', '', '', '', '',
+        'application/pdf', 'application/pdf'
+      );
+      INSERT INTO downloads_url_chains (id, chain_index, url)
+      VALUES (1, 0, 'https://alpha.example/report.pdf');
     `);
     const insertUrl = database.prepare(
       `INSERT INTO urls (id, url, title, visit_count, typed_count, last_visit_time, hidden)
@@ -150,10 +200,72 @@ async function createHistory(
   }
 }
 
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+/** Minimal single-row `autofill` table for the `Web Data` database. */
+function createWebDataDatabase(path: string): void {
+  const database = new DatabaseSync(path);
+  try {
+    database.exec(`
+      CREATE TABLE meta (key LONGVARCHAR NOT NULL UNIQUE PRIMARY KEY, value LONGVARCHAR);
+      INSERT INTO meta (key, value) VALUES ('version', '133'), ('last_compatible_version', '83');
+      CREATE TABLE autofill (
+        name VARCHAR,
+        value VARCHAR,
+        value_lower VARCHAR,
+        date_created INTEGER DEFAULT 0,
+        date_last_used INTEGER DEFAULT 0,
+        count INTEGER DEFAULT 1,
+        PRIMARY KEY (name, value)
+      );
+      INSERT INTO autofill (name, value, value_lower, date_created, date_last_used, count)
+      VALUES ('email', 'ada@example.com', 'ada@example.com', 1704164645, 1704164645, 1);
+    `);
+  } finally {
+    database.close();
+  }
+}
+
+const DEFAULT_BOOKMARKS = {
+  checksum: "abc123",
+  roots: {
+    bookmark_bar: {
+      type: "folder",
+      id: "1",
+      guid: "guid-bar",
+      name: "Bookmarks bar",
+      date_added: "13350000000000000",
+      children: [
+        {
+          type: "url",
+          id: "5",
+          guid: "guid-example",
+          name: "Example",
+          url: "https://example.com/",
+          date_added: "13350000001000000",
+          date_last_used: "0",
+        },
+      ],
+    },
+    other: { type: "folder", id: "2", name: "Other bookmarks", children: [] },
+    synced: { type: "folder", id: "3", name: "Mobile bookmarks", children: [] },
+  },
+  version: 1,
+};
+
 async function createSource(root: string): Promise<string> {
   const source = join(root, "source");
   await mkdir(source, { recursive: true });
-  await writeLocalState(source);
+  await writeLocalState(source, JSON.stringify({ variations_country: "us" }));
+  await writeJson(join(source, "Default", "Preferences"), {
+    profile: { name: "Ada" },
+    account_info: [{ email: "ada@example.com", gaia: "1122334455" }],
+  });
+  await writeJson(join(source, "Default", "Bookmarks"), DEFAULT_BOOKMARKS);
+  createWebDataDatabase(join(source, "Default", "Web Data"));
   await createHistory(join(source, "Default", "History"), [
     {
       id: 1n,
@@ -354,11 +466,17 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
     expect(history?.attempted).toBe(2);
     expect(history?.produced).toBe(2);
 
-    // Multi-Profile filter data is exposed.
+    // Multi-Profile filter data is exposed. "." is the Source-scoped
+    // (browser-level) Preferences row's profile sentinel, present because the
+    // fixture now includes a Metadata (Preferences) Finding.
     const profiles = (await (
       await fetch(`${base}/api/profiles`, { headers: auth })
     ).json()) as { readonly profiles: readonly string[] };
-    expect([...profiles.profiles].sort()).toEqual(["Default", "Profile 1"]);
+    expect([...profiles.profiles].sort()).toEqual([
+      ".",
+      "Default",
+      "Profile 1",
+    ]);
 
     // Candidate Completeness comes from the shared completeness route,
     // exactly like every other artifact — not embedded in the list response.
@@ -444,7 +562,56 @@ describe("compiled analyzer CLI read-only Case dashboard", () => {
     ).json()) as Page;
     expect(walResident.items).toHaveLength(0);
 
-    // The HTML shell injects the per-run token and loads the client bundle.
+    // The four previously unreachable core queries are now routed: each
+    // returns its own `command` tag and requires the per-run token exactly
+    // like every other route.
+    const metadata = (await (
+      await fetch(`${base}/api/metadata?type=profile_metadata&limit=10`, {
+        headers: auth,
+      })
+    ).json()) as Page & { readonly command: string };
+    expect(metadata.command).toBe("metadata");
+    expect(metadata.items.length).toBeGreaterThan(0);
+    expect(
+      metadata.items.every((row) => row.findingKind === "profile_metadata"),
+    ).toBe(true);
+
+    const downloads = (await (
+      await fetch(`${base}/api/downloads?limit=10`, { headers: auth })
+    ).json()) as Page & { readonly command: string };
+    expect(downloads.command).toBe("downloads");
+    // Both fixture History databases carry the same `downloads` schema (the
+    // real `downloads` table always shares Chrome's History database), so one
+    // download row exists per Profile.
+    expect(downloads.items).toHaveLength(2);
+    expect(downloads.items.every((row) => row.findingKind === "download")).toBe(
+      true,
+    );
+
+    const bookmarks = (await (
+      await fetch(`${base}/api/bookmarks?source=primary&limit=10`, {
+        headers: auth,
+      })
+    ).json()) as Page & { readonly command: string };
+    expect(bookmarks.command).toBe("bookmarks");
+    expect(bookmarks.items.length).toBeGreaterThan(0);
+    expect(bookmarks.items.every((row) => row.findingKind === "bookmark")).toBe(
+      true,
+    );
+
+    const autofill = (await (
+      await fetch(`${base}/api/autofill?limit=10`, { headers: auth })
+    ).json()) as Page & { readonly command: string };
+    expect(autofill.command).toBe("autofill");
+    expect(autofill.items).toHaveLength(1);
+    expect(autofill.items[0]?.findingKind).toBe("autofill_entry");
+
+    // The token gate applies uniformly to the newly wired routes too.
+    for (const route of ["metadata", "downloads", "bookmarks", "autofill"]) {
+      const unauthorized = await fetch(`${base}/api/${route}`);
+      expect(unauthorized.status).toBe(401);
+    }
+
     const shell = await (await fetch(`${base}/`, { headers: auth })).text();
     expect(shell).toContain("__FORENSIX_TOKEN__");
     expect(shell).toContain('src="/index.js"');

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -10,13 +10,22 @@ import { createRequire } from "node:module";
 
 import {
   ForensixError,
+  queryAutofill,
+  queryBookmarks,
   queryCandidates,
   queryCompleteness,
   queryCookies,
   queryCredentials,
+  queryDownloads,
   queryHistory,
+  queryMetadata,
   queryProfiles,
   queryTopSites,
+  type AutofillDirection,
+  type AutofillSort,
+  type BookmarkDirection,
+  type BookmarkSort,
+  type BookmarkSource,
   type CandidateDirection,
   type CandidateSort,
   type CommitState,
@@ -24,9 +33,14 @@ import {
   type CookieSort,
   type CredentialDirection,
   type CredentialSort,
+  type DownloadDirection,
+  type DownloadSort,
   type HistoryDirection,
   type HistorySort,
   type HistoryView,
+  type MetadataDirection,
+  type MetadataSort,
+  type MetadataType,
   type TopSiteDirection,
   type TopSiteSort,
 } from "@forensix/core";
@@ -324,6 +338,56 @@ const API_ROUTES = new Map<
         ...listParameters<CandidateSort, CandidateDirection>(parameters),
         category: firstString(parameters.get("category")),
         kind: firstString(parameters.get("kind")),
+      }),
+  ],
+  [
+    "metadata",
+    (parameters, caseDirectory) =>
+      queryMetadata({
+        caseDirectory,
+        ...listParameters<MetadataSort, MetadataDirection>(parameters),
+        commitState: firstString(parameters.get("commit-state")) as
+          | CommitState
+          | undefined,
+        type: firstString(parameters.get("type")) as MetadataType | undefined,
+      }),
+  ],
+  [
+    "downloads",
+    (parameters, caseDirectory) =>
+      queryDownloads({
+        caseDirectory,
+        ...listParameters<DownloadSort, DownloadDirection>(parameters),
+        commitState: firstString(parameters.get("commit-state")) as
+          | CommitState
+          | undefined,
+        state: firstString(parameters.get("state")),
+        dangerType: firstString(parameters.get("danger-type")),
+      }),
+  ],
+  [
+    "bookmarks",
+    (parameters, caseDirectory) =>
+      queryBookmarks({
+        caseDirectory,
+        ...listParameters<BookmarkSort, BookmarkDirection>(parameters),
+        commitState: firstString(parameters.get("commit-state")) as
+          | CommitState
+          | undefined,
+        source: firstString(parameters.get("source")) as
+          | BookmarkSource
+          | undefined,
+      }),
+  ],
+  [
+    "autofill",
+    (parameters, caseDirectory) =>
+      queryAutofill({
+        caseDirectory,
+        ...listParameters<AutofillSort, AutofillDirection>(parameters),
+        commitState: firstString(parameters.get("commit-state")) as
+          | CommitState
+          | undefined,
       }),
   ],
 ]);


### PR DESCRIPTION
## Problem

The analyzer core exports 14 read queries. The dashboard server exposed 7 of them.

Preferences metadata, Downloads, Bookmarks, and Web Data autofill were parsed, verified, tested, and written into the Case — and then no route could return them. The evidence existed but nothing could read it.

The Completeness Statement had the same gap in a worse form. It mapped 7 result tables while the Case holds 11. `downloads_artifact_results`, `bookmarks_artifact_results`, `preferences_artifact_results`, and `cache_artifact_results` were left out. An examiner could not tell an artifact that produced nothing from an artifact the statement never examined. That breaks the promise that absence is data.

## Change

**`core/src/case-overview.ts`** — add `Downloads`, `Bookmarks`, `Preferences`, and `Cache` to the `OverviewArtifact` union and to the table map. New entries are appended, so the statement stays deterministic. The JSDoc now records the two pooled sub-kind cases: Preferences pools `Local State` and `Preferences`; Bookmarks pools `Bookmarks` and `Bookmarks.bak`.

**`server/src/index.ts`** — add four routes that follow the existing adapter pattern. Each maps request parameters onto one core read query.

| Route | Core query | Extra parameters |
| --- | --- | --- |
| `metadata` | `queryMetadata` | `type` (`browser_metadata` \| `profile_metadata`) |
| `downloads` | `queryDownloads` | `state`, `danger-type` |
| `bookmarks` | `queryBookmarks` | `source` (`primary` \| `backup`) |
| `autofill` | `queryAutofill` | — |

The server stays a thin adapter. No forensic logic, no Case writes. The loopback bind, the per-run token gate, and the same-origin check are unchanged.

## Tests

- `core/test/case-overview.test.ts` (new, 4 tests) — asserts the statement lists all 11 artifacts, that `analyseCase` records real `absent` outcomes for the four new ones, that an outcome flips to `produced` once a table carries a complete row, and that `queryProfiles` sees a Profile visible only through a new table.
- `e2e/serve-cli.test.ts` — each new route is requested against fixtures and asserted for status, `command`, row shape, and token enforcement.

## Verification

```
pnpm verify   exit 0
              format:check · lint · typecheck · 32 files · 165 tests
```

## Not in this PR

The dashboard client changes stay out on purpose: the four new tabs and the rebuilt Overview screen ride on these routes but belong in a separate review.
